### PR TITLE
Strip comments from the production build

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -92,8 +92,17 @@ module.exports = {
     new webpack.DefinePlugin({ 'process.env.NODE_ENV': '"production"' }),
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.optimize.UglifyJsPlugin({
-      compressor: { warnings: false },
-      output: { comments: false }
+      compressor: {
+        screw_ie8: true,
+        warnings: false
+      },
+      mangle: {
+        screw_ie8: true
+      },
+      output: {
+        comments: false,
+        screw_ie8: true
+      }
     })
   ]
 };


### PR DESCRIPTION
Do we also want to use Uglify's [`screw-ie8` option](https://github.com/mishoo/UglifyJS2#usage)?

It will default to `true` as of `2.7.0`,  but Webpack is still on `~2.6.0`.

If so, I can add to this PR - there are [3 different pieces of the uglification process it can be configured for](https://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin) - `compress`, `mangle` and `output`.
