### PR TITLE
Fix cli bin path

### DIFF
--- a/global-cli/package.json
+++ b/global-cli/package.json
@@ -5,7 +5,7 @@
     "index.js"
   ],
   "bin": {
-    "create-react-app": "index.js"
+    "create-react-app": "./index.js"
   },
   "dependencies": {
     "chalk": "^1.1.1",


### PR DESCRIPTION
~~The current setup doesn't work with `nvm`: the `create-react-app` file doesn't get added to npm's global `.bin` folder. Adding a `./` prefix fixed this.~~

https://docs.npmjs.com/files/package.json#bin
