### PR TITLE
Enable hot reloading for CSS

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -20,6 +20,7 @@ module.exports = {
   devtool: 'eval',
   entry: [
     require.resolve('webpack-dev-server/client') + '?http://localhost:3000',
+    require.resolve('webpack/hot/dev-server'),
     './src/index.js'
   ],
   output: {
@@ -79,6 +80,8 @@ module.exports = {
       inject: true,
       template: path.resolve(__dirname, relative, 'index.html'),
     }),
-    new webpack.DefinePlugin({ 'process.env.NODE_ENV': '"development"' })
+    new webpack.DefinePlugin({ 'process.env.NODE_ENV': '"development"' }),
+    // Note: only CSS is currently hot reloaded
+    new webpack.HotModuleReplacementPlugin()
   ]
 };

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -29,6 +29,7 @@ if (process.argv[2] === '--smoke-test') {
 new WebpackDevServer(webpack(config, handleCompile), {
   publicPath: config.output.publicPath,
   historyApiFallback: true,
+  hot: true, // Note: only CSS is currently hot reloaded
   stats: {
     hash: false,
     version: false,


### PR DESCRIPTION
Now changes to CSS reload instantly.
This is much more stable than hot reloading for components right now.
I think it’s a good idea to get this in.

The only thing I’m not happy about are these logs:

```
[HMR] Waiting for update signal from WDS...
[WDS] Hot Module Replacement enabled.
```

when you start the app.

We could fork WDS and hot server client code (those are tiny files) and remove the logs, or we could send PRs to Webpack to make logging configurable. I think it’s not a big deal and we can do it later.
