### PR TITLE
Add support for some ES proposals that we use

### DIFF
--- a/config/babel.dev.js
+++ b/config/babel.dev.js
@@ -15,6 +15,8 @@ module.exports = {
     'babel-preset-react'
   ].map(require.resolve),
   plugins: [
+    'babel-plugin-syntax-trailing-function-commas',
+    'babel-plugin-transform-class-properties',
     'babel-plugin-transform-object-rest-spread'
   ].map(require.resolve)
 };

--- a/config/babel.prod.js
+++ b/config/babel.prod.js
@@ -14,6 +14,8 @@ module.exports = {
     'babel-preset-react'
   ].map(require.resolve),
   plugins: [
+    'babel-plugin-syntax-trailing-function-commas',
+    'babel-plugin-transform-class-properties',
     'babel-plugin-transform-object-rest-spread',
     'babel-plugin-transform-react-constant-elements'
   ].map(require.resolve)

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -16,6 +16,8 @@ var ERROR = 2; // rules that prevent common mistakes
 module.exports = {
   root: true,
 
+  parser: 'babel-eslint',
+
   plugins: ['react', 'import'],
 
   env: {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
   "dependencies": {
     "autoprefixer": "^6.3.7",
     "babel-core": "^6.10.4",
+    "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.4",
+    "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
+    "babel-plugin-transform-class-properties": "^6.10.2",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-plugin-transform-react-constant-elements": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
@@ -59,7 +62,10 @@
   "bundledDependencies": [
     "autoprefixer",
     "babel-core",
+    "babel-eslint",
     "babel-loader",
+    "babel-plugin-syntax-trailing-function-commas",
+    "babel-plugin-transform-class-properties",
     "babel-plugin-transform-object-rest-spread",
     "babel-plugin-transform-react-constant-elements",
     "babel-preset-es2015",


### PR DESCRIPTION
This adds support for:
- Flow
- Class properties
- Trailing function commas

Not adding `async` yet because I’ll need to understand its stability better before doing it.
