### PR TITLE
Don’t pack dependencies on Travis

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -19,8 +19,18 @@ set -x
 # npm pack the two directories to make sure they are valid npm modules
 initial_path=$PWD
 cd ..
+
+# A hacky way to avoid bundling dependencies.
+# Packing with them enabled takes too much memory, and Travis crashes.
+# End to end script is meant to run on Travis so it's not a big deal.
+# If you run it locally, you'll need to `git checkout -- package.json`.
+perl -i -p0e 's/bundledDependencies.*?]/bundledDependencies": []/s' package.json
+
+# Pack react-scripts
 npm install
 scripts_path=$PWD/`npm pack`
+
+# Pack CLI
 cd global-cli
 npm install
 cli_path=$PWD/`npm pack`


### PR DESCRIPTION
Travis is currently failing because it runs out of memory while packing dependencies.
This disables packing during e2e script.
The downside is you’ll have to `git checkout -- package.json` if you run e2e locally.
