### PR TITLE
Fix eject on Windows

### DIFF
--- a/scripts/eject.js
+++ b/scripts/eject.js
@@ -11,7 +11,7 @@ var fs = require('fs');
 var path = require('path');
 var rl = require('readline');
 var rimrafSync = require('rimraf').sync;
-var spawnSync = require('child_process').spawnSync;
+var spawnSync = require('cross-spawn').sync;
 
 var prompt = function(question, cb) {
   var rlInterface = rl.createInterface({


### PR DESCRIPTION
Similar to #6, this should fix `eject` on Windows.
(issue reported in https://github.com/facebookincubator/create-react-app/issues/7#issuecomment-234156200)
