### PR TITLE
Recursively copy the template folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "bundle-deps": "^1.0.0",
+    "fs-extra": "^0.30.0",
     "react": "^15.2.1",
     "react-dom": "^15.2.1"
   },

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 var spawn = require('cross-spawn');
 
@@ -35,39 +35,7 @@ module.exports = function(hostPath, appName, verbose) {
   );
 
   // Copy the files for the user
-  function copyFileSync(src, dest) {
-      var target = dest;
-      if (fs.existsSync(dest)) {
-          if (fs.lstatSync(dest).isDirectory()) {
-              target = path.join(dest, path.basename(src));
-          }
-      }
-      fs.writeFileSync(target, fs.readFileSync(src));
-  }
-
-  function copyFolderSync(src, dest) {
-      var files = [];
-      var targetFolder = path.join(dest, path.basename(src)).replace('/template', '');
-      if (!fs.existsSync(targetFolder)) {
-          fs.mkdirSync(targetFolder);
-      }
-      if (fs.lstatSync(src).isDirectory()) {
-          files = fs.readdirSync(src);
-          files.forEach(function (file) {
-              var currentSrc = path.join(src, file);
-              if (fs.lstatSync(currentSrc).isDirectory()) {
-                  copyFolderSync(currentSrc, targetFolder);
-              } else {
-                  copyFileSync(currentSrc, targetFolder);
-              }
-          } );
-      }
-  }
-
-  copyFolderSync(
-    path.join(selfPath, 'template'),
-    hostPath
-  )
+  fs.copySync(path.join(selfPath, 'template'), hostPath);
 
   // Run another npm install for react and react-dom
   console.log('Installing react and react-dom from npm...');


### PR DESCRIPTION
I noticed my work on #33 would only copy first in the template directory, and explicitly had to check the src folder and copy it.

This instead just recursively copies the template folder into the root of the app. 

Should work with deep nested paths like `./template/tests/components/myComponentTest.js`

Though we don't necessarily need it now, if someone wants to add something to the template in the future, this is probably a better way to handle copying.
