### PR TITLE
Make target browsers configurable

### DIFF
--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -20,8 +20,7 @@
     "babel-plugin-transform-react-jsx-source": "6.9.0",
     "babel-plugin-transform-regenerator": "6.16.1",
     "babel-plugin-transform-runtime": "6.15.0",
-    "babel-preset-env": "0.0.8",
-    "babel-preset-latest": "6.16.0",
+    "babel-preset-env": "1.0.2",
     "babel-preset-react": "6.16.0",
     "babel-runtime": "6.11.6"
   }

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -83,7 +83,7 @@ if (__dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1) 
     appPublic: resolveOwn('../template/public'),
     appHtml: resolveOwn('../template/public/index.html'),
     appIndexJs: resolveOwn('../template/src/index.js'),
-    appPackageJson: resolveOwn('../package.json'),
+    appPackageJson: resolveOwn('../example.package.json'),
     appSrc: resolveOwn('../template/src'),
     yarnLockFile: resolveOwn('../template/yarn.lock'),
     testsSetup: resolveOwn('../template/src/setupTests.js'),

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -164,7 +164,11 @@ module.exports = {
         query: {
           // @remove-on-eject-begin
           babelrc: false,
-          presets: [require.resolve('babel-preset-react-app')],
+          presets: [
+            [require.resolve('babel-preset-react-app'), {
+              browsers: supportedBrowsers
+            }]
+          ],
           // @remove-on-eject-end
           // This is a feature of `babel-loader` for webpack (not Babel itself).
           // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -10,6 +10,7 @@
 // @remove-on-eject-end
 
 var autoprefixer = require('autoprefixer');
+var chalk = require('chalk');
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
@@ -32,6 +33,21 @@ var publicPath = '/';
 var publicUrl = '';
 // Get environment variables to inject into our app.
 var env = getClientEnvironment(publicUrl);
+
+// TODO: better messages (or make it optional)
+var supportedBrowsers = require(paths.appPackageJson).browsers;
+if (!supportedBrowsers) {
+  console.error(
+    chalk.red('Please specify supported browsers in the "browsers" field in "package.json".')
+  );
+  process.exit(1);
+}
+if (!Array.isArray(supportedBrowsers.development)) {
+  console.error(
+    chalk.red('Please specify the "development" browser array in the "browsers" field in "package.json".')
+  );
+  process.exit(1);
+}
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
@@ -192,12 +208,7 @@ module.exports = {
   postcss: function() {
     return [
       autoprefixer({
-        browsers: [
-          '>1%',
-          'last 4 versions',
-          'Firefox ESR',
-          'not ie < 9', // React doesn't support IE8 anyway
-        ]
+        browsers: supportedBrowsers.development
       }),
     ];
   },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -170,7 +170,11 @@ module.exports = {
         // @remove-on-eject-begin
         query: {
           babelrc: false,
-          presets: [require.resolve('babel-preset-react-app')],
+          presets: [
+            [require.resolve('babel-preset-react-app'), {
+              browsers: supportedBrowsers
+            }]
+          ],
         },
         // @remove-on-eject-end
       },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -10,6 +10,7 @@
 // @remove-on-eject-end
 
 var autoprefixer = require('autoprefixer');
+var chalk = require('chalk');
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
@@ -51,6 +52,21 @@ var publicPath = ensureSlash(homepagePathname, true);
 var publicUrl = ensureSlash(homepagePathname, false);
 // Get environment variables to inject into our app.
 var env = getClientEnvironment(publicUrl);
+
+// TODO: better messages (or make it optional)
+var supportedBrowsers = require(paths.appPackageJson).browsers;
+if (!supportedBrowsers) {
+  console.error(
+    chalk.red('Please specify supported browsers in the "browsers" field in "package.json".')
+  );
+  process.exit(1);
+}
+if (!Array.isArray(supportedBrowsers.production)) {
+  console.error(
+    chalk.red('Please specify the "production" browser array in the "browsers" field in "package.json".')
+  );
+  process.exit(1);
+}
 
 // Assert this just to be safe.
 // Development builds of React are slow and not intended for production.
@@ -204,12 +220,7 @@ module.exports = {
   postcss: function() {
     return [
       autoprefixer({
-        browsers: [
-          '>1%',
-          'last 4 versions',
-          'Firefox ESR',
-          'not ie < 9', // React doesn't support IE8 anyway
-        ]
+        browsers: supportedBrowsers.production
       }),
     ];
   },

--- a/packages/react-scripts/example.package.json
+++ b/packages/react-scripts/example.package.json
@@ -1,0 +1,13 @@
+{
+  "browsers": {
+    "development": [
+      "last 1 chrome version"
+    ],
+    "production": [
+      ">1%",
+      "last 4 versions",
+      "Firefox ESR",
+      "not ie < 9"
+    ]
+  }
+}

--- a/packages/react-scripts/example.package.json
+++ b/packages/react-scripts/example.package.json
@@ -1,4 +1,17 @@
 {
+  "name": "sample-project",
+  "dependencies": {
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1"
+  },
+  "devDependencies": {
+    "react-scripts": "^0.9.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test"
+  },
   "browsers": {
     "development": [
       "last 1 chrome version"


### PR DESCRIPTION
Proof of concept for https://github.com/facebookincubator/create-react-app/issues/892.
Doesn't work with ejecting yet.

Both autoprefixer and Babel are driven by a config like this in `package.json`:

```js
  "browsers": {
    "development": [
      "last 1 chrome version"
    ],
    "production": [
      ">1%",
      "last 4 versions",
      "Firefox ESR",
      "not ie < 9"
    ]
  }
```

Currently I throw if it doesn't exist since I could generate a reasonable config by default (e.g. "last two versions" for development) in new projects and ask old projects to include it during migration. In a way this would be "configuration" but actually sensible one. I don't have a strong opinion here though.