### PR TITLE
Order lint warnings by most recently edited file (#2378)

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -139,6 +139,29 @@ function createCompiler(webpack, config, appName, urls, useYarn) {
 
   let isFirstCompile = true;
 
+  compiler.plugin('after-compile', (compilation, callback) => {
+    // Order compilation warnings by most recently modified
+    compilation.warnings = [
+      ...compilation.warnings,
+    ].sort((warning1, warning2) => {
+      if (!warning1._lastModifiedDate) {
+        warning1._lastModifiedDate = fs.statSync(
+          warning1.module.resource
+        ).mtime;
+      }
+
+      if (!warning2._lastModifiedDate) {
+        warning2._lastModifiedDate = fs.statSync(
+          warning2.module.resource
+        ).mtime;
+      }
+
+      return warning1._lastModifiedDate < warning2._lastModifiedDate ? 1 : -1;
+    });
+
+    callback();
+  });
+
   // "done" event fires when Webpack has finished recompiling the bundle.
   // Whether or not you have warnings or errors, you will get this event.
   compiler.plugin('done', stats => {

--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -144,19 +144,14 @@ function createCompiler(webpack, config, appName, urls, useYarn) {
     compilation.warnings = [
       ...compilation.warnings,
     ].sort((warning1, warning2) => {
-      if (!warning1._lastModifiedDate) {
-        warning1._lastModifiedDate = fs.statSync(
-          warning1.module.resource
-        ).mtime;
-      }
+      const warning1Time = compilation.fileTimestamps[
+        warning1.module.resource
+      ] || fs.statSync(warning1.module.resource).mtime.getTime();
+      const warning2Time = compilation.fileTimestamps[
+        warning2.module.resource
+      ] || fs.statSync(warning2.module.resource).mtime.getTime();
 
-      if (!warning2._lastModifiedDate) {
-        warning2._lastModifiedDate = fs.statSync(
-          warning2.module.resource
-        ).mtime;
-      }
-
-      return warning1._lastModifiedDate < warning2._lastModifiedDate ? 1 : -1;
+      return warning1Time < warning2Time ? 1 : -1;
     });
 
     callback();


### PR DESCRIPTION
Hi
I've added sorting to the warning messages by last file modified time. This makes recently edited file pop up at the top of the error list. This affects logs both in the terminal and in the browser console (which seems more intuitive anyway).

I've checked by running `npm-start` in the project and modifying `templates/index.js` and `templates/App.js` alternatively, verifying that the order is coherent (see screenshots).

<img width="447" alt="screen shot 2017-05-29 at 23 42 08" src="https://cloud.githubusercontent.com/assets/1584370/26562661/99435aa0-44c8-11e7-9f23-4cfcac27b0d7.png">

And then after editing the `index.js` file

<img width="447" alt="screen shot 2017-05-29 at 23 42 31" src="https://cloud.githubusercontent.com/assets/1584370/26562667/adcaa456-44c8-11e7-95e1-7166dac77933.png">

I've also checked in the browser console of course. I'm working on a mac.
If this seems like the proper resolution for this bug, I can check on more platforms (like windows) !

Cheers