### PR TITLE
Toast for Service Worker

### DIFF
--- a/packages/react-dev-utils/ModuleScopePlugin.js
+++ b/packages/react-dev-utils/ModuleScopePlugin.js
@@ -50,8 +50,7 @@ class ModuleScopePlugin {
       // Error if in a parent directory of src/
       const requestRelative = path.relative(appSrc, requestFullPath);
       if (
-        requestRelative.startsWith('../') ||
-        requestRelative.startsWith('..\\')
+        requestRelative.startsWith('../') || requestRelative.startsWith('..\\')
       ) {
         callback(
           new Error(

--- a/packages/react-scripts/template/src/Toast.css
+++ b/packages/react-scripts/template/src/Toast.css
@@ -22,6 +22,7 @@
 	transform: translateY(100%);
 }
 
+.Toast a,
 .Toast-button {
 	padding: 0;
 	background: transparent;
@@ -31,6 +32,7 @@
 	font-size: inherit;
 	line-height: inherit;
 	text-transform: uppercase;
+	text-decoration: none;
 	flex: 0 0 0;
 }
 

--- a/packages/react-scripts/template/src/Toast.css
+++ b/packages/react-scripts/template/src/Toast.css
@@ -3,17 +3,15 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
-	max-width: 100%;
-	width: 240px;
 	padding: 16px;
 	margin: auto;
 	transition: 250ms;
 	background: #222;
 	color: white;
-	text-align: center;
 	line-height: 24px;
 	border-top-left-radius: 2px;
 	border-top-right-radius: 2px;
+	display: flex;
 }
 
 .Toast.active {
@@ -22,4 +20,20 @@
 
 .Toast.inactive {
 	transform: translateY(100%);
+}
+
+.Toast-button {
+	padding: 0;
+	background: transparent;
+	border: 0;
+	display: inline-block;
+	color: #61dafb;
+	font-size: inherit;
+	line-height: inherit;
+	text-transform: uppercase;
+	flex: 0 0 0;
+}
+
+.Toast-text {
+	flex: 1;
 }

--- a/packages/react-scripts/template/src/Toast.css
+++ b/packages/react-scripts/template/src/Toast.css
@@ -1,0 +1,25 @@
+.Toast {
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	max-width: 100%;
+	width: 240px;
+	padding: 16px;
+	margin: auto;
+	transition: 250ms;
+	background: #222;
+	color: white;
+	text-align: center;
+	line-height: 24px;
+	border-top-left-radius: 2px;
+	border-top-right-radius: 2px;
+}
+
+.Toast.active {
+	transform: translateY(0);
+}
+
+.Toast.inactive {
+	transform: translateY(100%);
+}

--- a/packages/react-scripts/template/src/Toast.css
+++ b/packages/react-scripts/template/src/Toast.css
@@ -27,13 +27,11 @@
 	padding: 0;
 	background: transparent;
 	border: 0;
-	display: inline-block;
 	color: #61dafb;
 	font-size: inherit;
 	line-height: inherit;
 	text-transform: uppercase;
 	text-decoration: none;
-	flex: 0 0 0;
 }
 
 .Toast-text {

--- a/packages/react-scripts/template/src/Toast.js
+++ b/packages/react-scripts/template/src/Toast.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import './Toast.css';
+
+export default class Toast extends React.Component {
+  state = {
+    active: true,
+  };
+  componentDidMount() {
+    setTimeout(
+      () => {
+        this.setState({
+          active: false,
+        });
+      },
+      this.props.timeout
+    );
+  }
+  render() {
+    return (
+      <div className={`Toast ${this.state.active ? 'active' : 'inactive'}`}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+Toast.defaultProps = {
+  timeout: 3000,
+};

--- a/packages/react-scripts/template/src/Toast.js
+++ b/packages/react-scripts/template/src/Toast.js
@@ -5,8 +5,15 @@ export default class Toast extends React.Component {
   state = {
     active: true,
   };
+
+  close = () => {
+    clearTimeout(this.timeout);
+    this.setState({
+      active: false,
+    });
+  };
   componentDidMount() {
-    setTimeout(
+    this.timeout = setTimeout(
       () => {
         this.setState({
           active: false,
@@ -15,10 +22,16 @@ export default class Toast extends React.Component {
       this.props.timeout
     );
   }
+  componentWillUnmount() {
+    clearTimeout(this.timeout);
+  }
   render() {
     return (
       <div className={`Toast ${this.state.active ? 'active' : 'inactive'}`}>
-        {this.props.children}
+        <span className="Toast-text">
+          {this.props.children}
+        </span>
+        <button className="Toast-button" onClick={this.close}>Dismiss</button>
       </div>
     );
   }

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -69,7 +69,16 @@ export default function register() {
   }
 
   if (process.env.NODE_ENV !== 'production') {
-    showMessage('Development mode started.');
+    showMessage(
+      <span>
+        Development mode started.{' '}
+        <a
+          href="https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md"
+        >
+          Read Me
+        </a>
+      </span>
+    );
   }
 }
 

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -66,7 +66,9 @@ export default function register() {
         checkValidServiceWorker(swUrl);
       }
     });
-  } else {
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
     showMessage('Development mode started.');
   }
 }

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -11,6 +11,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Toast from './Toast';
 
+const useToast = true;
 const domId = 'create-react-app-toast';
 let dom = document.getElementById(domId);
 
@@ -20,13 +21,17 @@ if (!dom) {
   document.body.appendChild(dom);
 }
 
-function renderToast(message) {
-  ReactDOM.render(
-    <Toast timeout={3000}>
-      {message}
-    </Toast>,
-    dom
-  );
+function showMessage(message) {
+  if (useToast) {
+    ReactDOM.render(
+      <Toast timeout={3000}>
+        {message}
+      </Toast>,
+      dom
+    );
+  } else {
+    console.log(message);
+  }
 }
 
 const isLocalhost = Boolean(
@@ -62,7 +67,7 @@ export default function register() {
       }
     });
   } else {
-    renderToast('Development mode started.');
+    showMessage('Development mode started.');
   }
 }
 
@@ -79,12 +84,12 @@ function registerValidSW(swUrl) {
               // the fresh content will have been added to the cache.
               // It's the perfect time to display a "New content is
               // available; please refresh." message in your web app.
-              renderToast('New content is available; please refresh.');
+              showMessage('New content is available; please refresh.');
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              renderToast('Content is cached for offline use.');
+              showMessage('Content is cached for offline use.');
             }
           }
         };
@@ -116,7 +121,7 @@ function checkValidServiceWorker(swUrl) {
       }
     })
     .catch(() => {
-      renderToast(
+      showMessage(
         'No internet connection found. App is running in offline mode.'
       );
     });

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -24,7 +24,7 @@ if (!dom) {
 function showMessage(message) {
   if (useToast) {
     ReactDOM.render(
-      <Toast timeout={3000}>
+      <Toast>
         {message}
       </Toast>,
       dom

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -7,6 +7,27 @@
 
 // To learn more about the benefits of this model, read https://goo.gl/KwvDNy.
 // This link also includes instructions on opting out of this behavior.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Toast from './Toast';
+
+const domId = 'create-react-app-toast';
+let dom = document.getElementById(domId);
+
+if (!dom) {
+  dom = document.createElement('div');
+  dom.id = domId;
+  document.body.appendChild(dom);
+}
+
+function renderToast(message) {
+  ReactDOM.render(
+    <Toast timeout={3000}>
+      {message}
+    </Toast>,
+    dom
+  );
+}
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
@@ -40,6 +61,8 @@ export default function register() {
         checkValidServiceWorker(swUrl);
       }
     });
+  } else {
+    renderToast('Development mode started.');
   }
 }
 
@@ -56,12 +79,12 @@ function registerValidSW(swUrl) {
               // the fresh content will have been added to the cache.
               // It's the perfect time to display a "New content is
               // available; please refresh." message in your web app.
-              console.log('New content is available; please refresh.');
+              renderToast('New content is available; please refresh.');
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              renderToast('Content is cached for offline use.');
             }
           }
         };
@@ -93,7 +116,7 @@ function checkValidServiceWorker(swUrl) {
       }
     })
     .catch(() => {
-      console.log(
+      renderToast(
         'No internet connection found. App is running in offline mode.'
       );
     });

--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -12,7 +12,7 @@ import ReactDOM from 'react-dom';
 import Toast from './Toast';
 
 const useToast = true;
-const domId = 'create-react-app-toast';
+const domId = 'toast';
 let dom = document.getElementById(domId);
 
 if (!dom) {


### PR DESCRIPTION
Added Toast component for Service Worker, inspired by https://github.com/facebookincubator/create-react-app/issues/2398
It only listens for first registration and update events. I tried to add one to indicate that the content is served from service worker, but it's annoying because it's always shown on every refresh.

![may-31-2017 23-01-41](https://cloud.githubusercontent.com/assets/9636410/26641561/31f4c56c-4655-11e7-911a-e6ac974d4a6a.gif)

<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
