### PR TITLE
Multicompilation of indexXX.js files to indexXX.html outputs

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -68,7 +68,7 @@ module.exports = function(proxy, allowedHost) {
     hot: true,
     // It is important to tell WebpackDevServer to use the same "root" path
     // as we specified in the config. In development, we always serve from /.
-    publicPath: config.output.publicPath,
+    publicPath: (config[0] || config).output.publicPath,
     // WebpackDevServer is noisy by default so we emit custom message instead
     // by listening to the compiler events with `compiler.plugin` calls above.
     quiet: true,

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -76,12 +76,16 @@ measureFileSizesBeforeBuild(paths.appBuild)
       }
 
       console.log('File sizes after gzip:\n');
-      printFileSizesAfterBuild(stats, previousFileSizes, paths.appBuild);
+      // Webpack multicompilation produces an array of stats
+      (stats.stats || [stats]).forEach(stats => {
+        console.log(`  ${stats.compilation.name}:`);
+        printFileSizesAfterBuild(stats, previousFileSizes, paths.appBuild);
+      });
       console.log();
 
       const appPackage = require(paths.appPackageJson);
       const publicUrl = paths.publicUrl;
-      const publicPath = config.output.publicPath;
+      const publicPath = (config[0] || config).output.publicPath;
       const buildFolder = path.relative(process.cwd(), paths.appBuild);
       printHostingInstructions(
         appPackage,


### PR DESCRIPTION
<!--
Thank you for sending the PR!
If you changed any code, there are just two more things to do:

* Provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Hi, consider this as a WIP / discussion opener / proof-of-concept of sorts related to #1084.
With this, it is quite easy to add multiple .html outputs when needed:
* `src/index.js` results in `index.html` and accompanied bundles in `build/`
* `src/indexXX.js` results in `indexXX.html` and accompanied bundles in `build/`

Verified by copying `packages/react-scripts/template/src/index.js` to `index2.js` with modifications and seeing that both `yarn start` and `yarn build` succeeded and both `http://localhost:3000/` and `http://localhost:3000/index2.html` work and hot-reload ok, but there may well be edge cases (such as advanced configuration and router usage) so please don't merge until polished by a knowledgeable create-react-app person.

It might be better to output pages (such as `src/pages/indexname/index.js` or `src/pages/indexname.js`) to separate subdirectories (such as `build/indexname/index.html`), but that may necessitate larger changes in build scripts than this minimal diff.