### PR TITLE
Update template README - class fields proposal URL

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -192,7 +192,7 @@ In addition to [ES6](https://github.com/lukehoban/es6features) syntax features, 
 * [Async/await](https://github.com/tc39/ecmascript-asyncawait) (ES2017).
 * [Object Rest/Spread Properties](https://github.com/sebmarkbage/ecmascript-rest-spread) (stage 3 proposal).
 * [Dynamic import()](https://github.com/tc39/proposal-dynamic-import) (stage 3 proposal)
-* [Class Fields and Static Properties](https://github.com/tc39/proposal-class-public-fields) (stage 2 proposal).
+* [Public and Private Class Fields](https://github.com/tc39/proposal-class-fields) (stage 2 proposal).
 * [JSX](https://facebook.github.io/react/docs/introducing-jsx.html) and [Flow](https://flowtype.org/) syntax.
 
 Learn more about [different proposal stages](https://babeljs.io/docs/plugins/#presets-stage-x-experimental-presets-).


### PR DESCRIPTION
Public and private fields proposal got merged into one, updating URL.

Just looking through the doc I noticed outdated proposal URL, possibly development/project settings will have to be updated as well. That however is a bigger change and I don't have the capacity to verify that ATM - if that is the case, I can take a further look or close the PR.