### PR TITLE
Import scripts in Service Worker

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -48,6 +48,10 @@ function getServedPath(appPackageJson) {
   return ensureSlash(servedUrl, true);
 }
 
+const sWPrecacheImportScript = fs.existsSync(resolveApp('public/service-worker-import.js'))
+  ? 'service-worker-import.js'
+  : undefined;
+
 // config after eject: we're in ./config/
 module.exports = {
   dotenv: resolveApp('.env'),
@@ -62,6 +66,7 @@ module.exports = {
   appNodeModules: resolveApp('node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
+  sWPrecacheImportScript: sWPrecacheImportScript,
 };
 
 // @remove-on-eject-begin
@@ -82,6 +87,7 @@ module.exports = {
   appNodeModules: resolveApp('node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
+  sWPrecacheImportScript: sWPrecacheImportScript,
   // These properties only exist before ejecting:
   ownPath: resolveOwn('.'),
   ownNodeModules: resolveOwn('node_modules'), // This is empty on npm 3

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -322,6 +322,7 @@ module.exports = {
       // about it being stale, and the cache-busting can be skipped.
       dontCacheBustUrlsMatching: /\.\w{8}\./,
       filename: 'service-worker.js',
+      importScripts: paths.sWPrecacheImportScript ? [paths.sWPrecacheImportScript] : undefined,
       logger(message) {
         if (message.indexOf('Total precache size is') === 0) {
           // This message occurs for every build and is a bit too noisy.


### PR DESCRIPTION
This PR adds an ability to use `importScripts` option of `SWPrecacheWebpackPlugin`.

How-to:
1) create a file called `public/service-worker-import.js`
2) run `npm run build`
3) check that file has been loaded (either in console network panel or by placing console.log statement inside and checking for output) by refreshing the page

File is being imported **only on service worker install/ update**.

Downsides:
- It's possible to import only one file and it's name is harcoded
- File is not being passed trough plugins (minification, etc)

Fixes: #2253