### PR TITLE
Check for files in mayProxy

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -287,7 +287,11 @@ function prepareProxy(proxy, appPublicFolder) {
   // Otherwise, if proxy is specified, we will let it handle any request except for files in the public folder.
   function mayProxy(pathname) {
     const maybePublicPath = path.resolve(appPublicFolder, pathname.slice(1));
-    return !fs.existsSync(maybePublicPath);
+    try {
+      return !fs.statSync(maybePublicPath).isFile();
+    } catch (ex) {
+      return true;
+    }
   }
 
   // Support proxy as a string for those who are using the simple proxy option


### PR DESCRIPTION
The existing code made it impossible to proxy the root of the application `/` because mayProxy would see that as being the public *folder*, since we only actually want to serve files, we should check for files.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
