### PR TITLE
Disable service workers until issues fixed

### DIFF
--- a/packages/react-scripts/template/src/index.js
+++ b/packages/react-scripts/template/src/index.js
@@ -5,4 +5,5 @@ import App from './App';
 import registerServiceWorker from './registerServiceWorker';
 
 ReactDOM.render(<App />, document.getElementById('root'));
-registerServiceWorker();
+// Consider enabling service workers for caching and offline pages by uncommenting the following line
+//registerServiceWorker();

--- a/packages/react-scripts/template/src/index.js
+++ b/packages/react-scripts/template/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
-import registerServiceWorker from './registerServiceWorker';
+//import registerServiceWorker from './registerServiceWorker';
 
 ReactDOM.render(<App />, document.getElementById('root'));
 // Consider enabling service workers for caching and offline pages by uncommenting the following line


### PR DESCRIPTION
See the problems in this thread.

https://github.com/facebookincubator/create-react-app/issues/2398

There are more than 83 comments there to date. Many are confused by service workers and their side effects. We should find the time to fix service workers. Until then, keeping service workers in their current state may deteriorate trust in service workers and create-react-app more than it helps creating progressive web apps.