### PR TITLE
(feature) Custom webpack dev server endpoint

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -43,12 +43,21 @@ if (module.hot && typeof module.hot.dispose === 'function') {
   });
 }
 
+var urlParts;
+if(typeof __resourceQuery === "string" && __resourceQuery) {
+  // If this bundle is inlined, use the resource query to get the correct url.
+  urlParts = url.parse(__resourceQuery.substr(1));
+} else {
+  // Else, get the url from current window
+  urlParts = url.parse(window.location.origin);
+}
+
 // Connect to WebpackDevServer via a socket.
 var connection = new SockJS(
   url.format({
-    protocol: window.location.protocol,
-    hostname: window.location.hostname,
-    port: window.location.port,
+    protocol: urlParts.protocol,
+    hostname: urlParts.hostname,
+    port: urlParts.port,
     // Hardcoded in WebpackDevServer
     pathname: '/sockjs-node',
   })

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -43,6 +43,7 @@ if (module.hot && typeof module.hot.dispose === 'function') {
   });
 }
 
+/* globals __resourceQuery */
 var urlParts;
 if(typeof __resourceQuery === "string" && __resourceQuery) {
   // If this bundle is inlined, use the resource query to get the correct url.


### PR DESCRIPTION
* Lets you specify your webpack dev server endpoint in your webpack configuration
* Ex: require.resolve('react-dev-utils/webpackHotDevClient') + '?' + config.get('app.host')

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
