### PR TITLE
Add env option to babel-preset-react-app

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -38,101 +38,107 @@ const plugins = [
   ],
 ];
 
-// This is similar to how `env` works in Babel:
-// https://babeljs.io/docs/usage/babelrc/#env-option
-// We are not using `env` because it’s ignored in versions > babel-core@6.10.4:
-// https://github.com/babel/babel/issues/4539
-// https://github.com/facebookincubator/create-react-app/issues/720
-// It’s also nice that we can enforce `NODE_ENV` being specified.
-var env = process.env.BABEL_ENV || process.env.NODE_ENV;
-if (env !== 'development' && env !== 'test' && env !== 'production') {
-  throw new Error(
-    'Using `babel-preset-react-app` requires that you specify `NODE_ENV` or ' +
-      '`BABEL_ENV` environment variables. Valid values are "development", ' +
-      '"test", and "production". Instead, received: ' +
-      JSON.stringify(env) +
-      '.'
-  );
-}
-
-if (env === 'development' || env === 'test') {
-  // The following two plugins are currently necessary to make React warnings
-  // include more valuable information. They are included here because they are
-  // currently not enabled in babel-preset-react. See the below threads for more info:
-  // https://github.com/babel/babel/issues/4702
-  // https://github.com/babel/babel/pull/3540#issuecomment-228673661
-  // https://github.com/facebookincubator/create-react-app/issues/989
-  plugins.push.apply(plugins, [
-    // Adds component stack to warning messages
-    require.resolve('babel-plugin-transform-react-jsx-source'),
-    // Adds __self attribute to JSX which React will use for some warnings
-    require.resolve('babel-plugin-transform-react-jsx-self'),
-  ]);
-}
-
-if (env === 'test') {
-  module.exports = {
-    presets: [
-      // ES features necessary for user's Node version
-      [
-        require('babel-preset-env').default,
-        {
-          targets: {
-            node: 'current',
-          },
-        },
-      ],
-      // JSX, Flow
-      require.resolve('babel-preset-react'),
-    ],
-    plugins: plugins.concat([
-      // Compiles import() to a deferred require()
-      require.resolve('babel-plugin-dynamic-import-node'),
-    ]),
-  };
-} else {
-  module.exports = {
-    presets: [
-      // Latest stable ECMAScript features
-      [
-        require.resolve('babel-preset-env'),
-        {
-          targets: {
-            // React parses on ie 9, so we should too
-            ie: 9,
-            // We currently minify with uglify
-            // Remove after https://github.com/mishoo/UglifyJS2/issues/448
-            uglify: true,
-          },
-          // Disable polyfill transforms
-          useBuiltIns: false,
-          // Do not transform modules to CJS
-          modules: false,
-        },
-      ],
-      // JSX, Flow
-      require.resolve('babel-preset-react'),
-    ],
-    plugins: plugins.concat([
-      // function* () { yield 42; yield 43; }
-      [
-        require.resolve('babel-plugin-transform-regenerator'),
-        {
-          // Async functions are converted to generators by babel-preset-env
-          async: false,
-        },
-      ],
-      // Adds syntax support for import()
-      require.resolve('babel-plugin-syntax-dynamic-import'),
-    ]),
-  };
-
-  if (env === 'production') {
-    // Optimization: hoist JSX that never changes out of render()
-    // Disabled because of issues: https://github.com/facebookincubator/create-react-app/issues/553
-    // TODO: Enable again when these issues are resolved.
-    // plugins.push.apply(plugins, [
-    //   require.resolve('babel-plugin-transform-react-constant-elements')
-    // ]);
+module.exports = (context, opts = {}) => {
+  // This is similar to how `env` works in Babel:
+  // https://babeljs.io/docs/usage/babelrc/#env-option
+  // We are not using `env` because it’s ignored in versions > babel-core@6.10.4:
+  // https://github.com/babel/babel/issues/4539
+  // https://github.com/facebookincubator/create-react-app/issues/720
+  // It’s also nice that we can enforce `NODE_ENV` being specified.
+  var env =
+    opts.environment ||
+    opts.env ||
+    process.env.BABEL_ENV ||
+    process.env.NODE_ENV;
+  if (env !== 'development' && env !== 'test' && env !== 'production') {
+    throw new Error(
+      'Using `babel-preset-react-app` requires that you specify `NODE_ENV` or ' +
+        '`BABEL_ENV` environment variables. Valid values are "development", ' +
+        '"test", and "production". Instead, received: ' +
+        JSON.stringify(env) +
+        '.'
+    );
   }
-}
+
+  if (env === 'development' || env === 'test') {
+    // The following two plugins are currently necessary to make React warnings
+    // include more valuable information. They are included here because they are
+    // currently not enabled in babel-preset-react. See the below threads for more info:
+    // https://github.com/babel/babel/issues/4702
+    // https://github.com/babel/babel/pull/3540#issuecomment-228673661
+    // https://github.com/facebookincubator/create-react-app/issues/989
+    plugins.push.apply(plugins, [
+      // Adds component stack to warning messages
+      require.resolve('babel-plugin-transform-react-jsx-source'),
+      // Adds __self attribute to JSX which React will use for some warnings
+      require.resolve('babel-plugin-transform-react-jsx-self'),
+    ]);
+  }
+
+  if (env === 'test') {
+    return {
+      presets: [
+        // ES features necessary for user's Node version
+        [
+          require('babel-preset-env').default,
+          {
+            targets: {
+              node: 'current',
+            },
+          },
+        ],
+        // JSX, Flow
+        require.resolve('babel-preset-react'),
+      ],
+      plugins: plugins.concat([
+        // Compiles import() to a deferred require()
+        require.resolve('babel-plugin-dynamic-import-node'),
+      ]),
+    };
+  } else {
+    return {
+      presets: [
+        // Latest stable ECMAScript features
+        [
+          require.resolve('babel-preset-env'),
+          {
+            targets: {
+              // React parses on ie 9, so we should too
+              ie: 9,
+              // We currently minify with uglify
+              // Remove after https://github.com/mishoo/UglifyJS2/issues/448
+              uglify: true,
+            },
+            // Disable polyfill transforms
+            useBuiltIns: false,
+            // Do not transform modules to CJS
+            modules: false,
+          },
+        ],
+        // JSX, Flow
+        require.resolve('babel-preset-react'),
+      ],
+      plugins: plugins.concat([
+        // function* () { yield 42; yield 43; }
+        [
+          require.resolve('babel-plugin-transform-regenerator'),
+          {
+            // Async functions are converted to generators by babel-preset-env
+            async: false,
+          },
+        ],
+        // Adds syntax support for import()
+        require.resolve('babel-plugin-syntax-dynamic-import'),
+      ]),
+    };
+
+    if (env === 'production') {
+      // Optimization: hoist JSX that never changes out of render()
+      // Disabled because of issues: https://github.com/facebookincubator/create-react-app/issues/553
+      // TODO: Enable again when these issues are resolved.
+      // plugins.push.apply(plugins, [
+      //   require.resolve('babel-plugin-transform-react-constant-elements')
+      // ]);
+    }
+  }
+};

--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -96,6 +96,15 @@ module.exports = (context, opts = {}) => {
       ]),
     };
   } else {
+    if (env === 'production') {
+      // Optimization: hoist JSX that never changes out of render()
+      // Disabled because of issues: https://github.com/facebookincubator/create-react-app/issues/553
+      // TODO: Enable again when these issues are resolved.
+      // plugins.push.apply(plugins, [
+      //   require.resolve('babel-plugin-transform-react-constant-elements')
+      // ]);
+    }
+
     return {
       presets: [
         // Latest stable ECMAScript features
@@ -131,14 +140,5 @@ module.exports = (context, opts = {}) => {
         require.resolve('babel-plugin-syntax-dynamic-import'),
       ]),
     };
-
-    if (env === 'production') {
-      // Optimization: hoist JSX that never changes out of render()
-      // Disabled because of issues: https://github.com/facebookincubator/create-react-app/issues/553
-      // TODO: Enable again when these issues are resolved.
-      // plugins.push.apply(plugins, [
-      //   require.resolve('babel-plugin-transform-react-constant-elements')
-      // ]);
-    }
   }
 };


### PR DESCRIPTION
Addresses: #2592 

#### Summary

Adds possibility to specify env/environment option directly to babel-preset-react-app

#### Examples

```
"babel": {
    "presets": [
      [ "react-app", { "env": "development" } ]
    ]
  }
```

```
"babel": {
    "presets": [
      [ "react-app", { "environment": "production" } ]
    ]
  },
```

#### Changes

Code changes are simple, wrap the current preset in a function to allow opts to be specified, plugins are now returned from the function instead of being exported directly