### PR TITLE
Gracefully shut down server on "end" stdin

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -91,6 +91,12 @@ choosePort(HOST, DEFAULT_PORT)
         process.exit();
       });
     });
+
+    process.stdin.on('end', function() {
+      devServer.close();
+      process.exit();
+    });
+    process.stdin.resume();
   })
   .catch(err => {
     if (err && err.message) {


### PR DESCRIPTION
This is referencing issue https://github.com/facebookincubator/create-react-app/issues/1753 - where `react-scripts start` wasn't closing upon stdin "end". I simply added one more condition on top of https://github.com/facebookincubator/create-react-app/pull/2246 that would handle the "end" case and kill the process.

I am integrating CRA with an elixir-phoenix app and when using `react-scripts start`  from within another process, it wasn't getting closed out when killing the main process. This made it difficult having to `lsof -i $PORT` and `kill <pid>` every time I had to restart the server.

