### PR TITLE
Initialize SW registration when document is already loaded

### DIFF
--- a/packages/react-scripts/template/src/registerServiceWorker.js
+++ b/packages/react-scripts/template/src/registerServiceWorker.js
@@ -29,26 +29,34 @@ export default function register() {
       return;
     }
 
-    window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+    // Init check
+    if (document.readyState === 'complete') {
+      checkOrRegisterSW();
+    // Register check when document finishes loadingInitialize in case document is ready
+    } else {
+      window.addEventListener('load', checkOrRegisterSW);
+    }
+  }
+}
 
-      if (isLocalhost) {
-        // This is running on localhost. Lets check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl);
+function checkOrRegisterSW() {
+  const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
 
-        // Add some additional logging to localhost, pointing developers to the
-        // service worker/PWA documentation.
-        navigator.serviceWorker.ready.then(() => {
-          console.log(
-            'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit https://goo.gl/SC7cgQ'
-          );
-        });
-      } else {
-        // Is not local host. Just register service worker
-        registerValidSW(swUrl);
-      }
+  if (isLocalhost) {
+    // This is running on localhost. Lets check if a service worker still exists or not.
+    checkValidServiceWorker(swUrl);
+
+    // Add some additional logging to localhost, pointing developers to the
+    // service worker/PWA documentation.
+    navigator.serviceWorker.ready.then(() => {
+      console.log(
+        'This web app is being served cache-first by a service ' +
+          'worker. To learn more, visit https://goo.gl/SC7cgQ'
+      );
     });
+  } else {
+    // Is not local host. Just register service worker
+    registerValidSW(swUrl);
   }
 }
 


### PR DESCRIPTION
At this moment, service worker registers a callback to the windows' `load` event.
In some cases (like when there are no images on page), this happens after `load` event has been fired previously and so callback isn't invoked.

This PR adds a check to see if the document is already loaded (`document.readyState === 'complete'`) and if so, invokes callback manually.