### PR TITLE
improvements: set react and react-dom alias in webpack

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -104,6 +104,12 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      'react': path.dirname(
+        require.resolve('react')
+      ),
+      'react-dom': path.dirname(
+        require.resolve('react-dom')
+      ),
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).


### PR DESCRIPTION
set react and react-dom alias in webpack to avoid loading twice react during developing. This issue has been discussed, see here https://github.com/facebookincubator/create-react-app/issues/675.  I have tested with my app locally. The duplicated react issue is gone after set up alias.
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
