### PR TITLE
Enable Access-Control-Allow-Origin on webpack-dev-server

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -81,6 +81,9 @@ module.exports = function(proxy, allowedHost) {
     // Enable HTTPS if the HTTPS environment variable is set to 'true'
     https: protocol === 'https',
     host: host,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+    },
     overlay: false,
     historyApiFallback: {
       // Paths with dots should still use the history fallback.


### PR DESCRIPTION
When a page is loaded in a sandboxed iframe without `allow-same-origin` (referer: `'null'`), external fonts are blocked by Chrome and Firefox, except if they are served with the `Access-Control-Allow-Origin` header set to `*`.