### PR TITLE
Update issue template to include the --info flag

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -79,17 +79,11 @@
   To help identify if a problem is specific to a platform, browser, or module version, information about your environment is required.
   This enables the maintainers quickly reproduce the issue and give feedback.
 
-  Run the command specific to your operating system in your react app's folder
+  Run the following command in your react app's folder in terminal.
+  Note: The result is copied to your clipboard directly.
   
-  Windows: `create-react-app --info | clip`
-  macOS: `create-react-app --info | pbcopy`
-  Linux: `create-react-app --info`
+  npx -p create-react-app -p clipboard-cli -c 'create-react-app --info | clipboard'  
   
-  If you get an error, you can use `npx` or `yarn` by running one of the commands below in terminal.
-  
-  npx create-react-app --info
-  yarn create react-app --info
-
   Paste the output of the command in the section below.
 -->
 (paste the output of the command here)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -82,7 +82,7 @@
   Run the following command in your react app's folder in terminal.
   Note: The result is copied to your clipboard directly.
   
-  npx -p create-react-app -p clipboard-cli -c 'create-react-app --info | clipboard'  
+  npx -p create-react-app -p clipboard-cli -c "create-react-app --info | clipboard"
   
   Paste the output of the command in the section below.
 -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -76,18 +76,26 @@
 ### Environment
 
 <!--
-  Please fill in all the relevant fields by running these commands in terminal.
--->
+  To help identify if a problem is specific to a platform, browser, or module version, information about your environment is required.
+  This enables the maintainers quickly reproduce the issue and give feedback.
 
-1. `node -v`: 
-2. `npm -v`:
-3. `yarn --version` (if you use Yarn):
-4. `npm ls react-scripts` (if you haven’t ejected): 
+  Run the command specific to your operating system in your react app's folder
+  
+  Windows: `create-react-app --info | clip`
+  macOS: `create-react-app --info | pbcopy`
+  Linux: `create-react-app --info`
+  
+  If you get an error, you can use `npx` or `yarn` by running one of the commands below in terminal.
+  
+  npx create-react-app --info
+  yarn create react-app --info
+
+  Paste the output of the command in the section below.
+-->
+(paste the output of the command here)
 
 Then, specify:
-
-1. Operating system:
-2. Browser and version (if relevant):
+1. Browser and version (if relevant)
 
 
 ### Steps to Reproduce


### PR DESCRIPTION
Document using the `--info` flag exposed by #3408 when reporting issues in CRA.

For platforms that have a built in command to pipe from terminal to clipboard (OSX and Windows), the suggested command copies the result to the clipboard automatically. Although, it also never prints the result to terminal for the user to see first, which might be a bummer, suggestions welcome.

For Linux users, there are different ways to pipe the result of a command to terminal, I'll leave it up to the user to use one.