### PR TITLE
Check if there is a .babelrc file before ejecting #1066

### DIFF
--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -104,6 +104,9 @@ inquirer
     folders.forEach(verifyAbsent);
     files.forEach(verifyAbsent);
 
+    // Ensure that the app folder doesn't have a .babelrc file
+    verifyAbsent('.babelrc');
+
     // Prepare Jest config early in case it throws
     const jestConfig = createJestConfig(
       filePath => path.posix.join('<rootDir>', filePath),


### PR DESCRIPTION
To verify this change:

1. I ran the tests (`yarn test`).
2. I ran the `react-scripts eject` in a project with `.babelrc` in the root (eject failed with the message).
3. I ran the `react-scripts eject` in a project without `.babelrc` in the root and it was ejected.