### PR TITLE
[docs] Clarify proxy feature within package.json and environment variables.

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1077,7 +1077,9 @@ If the `proxy` option is **not** flexible enough for you, alternatively you can:
 
 * [Configure the proxy yourself](#configuring-the-proxy-manually)
 * Enable CORS on your server ([here’s how to do it for Express](http://enable-cors.org/server_expressjs.html)).
-* Use [environment variables](#adding-custom-environment-variables) to inject the right server host and port into your app.
+* Use [environment variables](#adding-custom-environment-variables) to inject the right server host and port directly into your application code for each request (i.e. completely bypassing the the CRA proxy feature.)
+
+Note: Currently the only way to use the creat-react-app proxy feature is by setting the proxy key within `package.json`. In other words, CRA itself does not look for this information in any environment variables.
 
 ### "Invalid Host Header" Errors After Configuring Proxy
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1077,7 +1077,7 @@ If the `proxy` option is **not** flexible enough for you, alternatively you can:
 
 * [Configure the proxy yourself](#configuring-the-proxy-manually)
 * Enable CORS on your server ([here’s how to do it for Express](http://enable-cors.org/server_expressjs.html)).
-* Use [environment variables](#adding-custom-environment-variables) to inject the right server host and port directly into your application code for each request (i.e. completely bypassing the the CRA proxy feature.)
+* Use [environment variables](#adding-custom-environment-variables) to inject the right server host and port directly into your application code for each request (i.e. completely bypassing the CRA proxy feature.)
 
 Note: Currently the only way to use the creat-react-app proxy feature is by setting the proxy key within `package.json`. In other words, CRA itself does not look for this information in any environment variables.
 


### PR DESCRIPTION
This PR modifies the following sentence "Use environment variables to inject the right server host and port into your app"

I originally misunderstood this sentence to mean that it was possible to specify the proxy setting for CRA using environment variable(s). For example, it made me think something like `PROXY_PORT` and `PROXY_HOST` might exist and be understood by CRA.

In hindsight, I understand what the sentence was trying to convey, but perhaps a clarification would be helpful. This PR attempts to clarify that environment variables have no effect on the CRA proxy setting itself.

I don't think I'm the only one that has misunderstood this sentence.

See, for example, https://stackoverflow.com/questions/46686434/how-to-inject-port-and-host-using-env-variable-in-create-react-app-proxy-setting/48248492#48248492

Thank you!