### PR TITLE
feat: react-scripts lint command #1217

### DIFF
--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -19,7 +19,12 @@ const spawn = require('react-dev-utils/crossSpawn');
 const args = process.argv.slice(2);
 
 const scriptIndex = args.findIndex(
-  x => x === 'build' || x === 'eject' || x === 'start' || x === 'test'
+  x =>
+    x === 'build' ||
+    x === 'eject' ||
+    x === 'start' ||
+    x === 'test' ||
+    x === 'lint'
 );
 const script = scriptIndex === -1 ? args[0] : args[scriptIndex];
 const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : [];
@@ -28,7 +33,8 @@ switch (script) {
   case 'build':
   case 'eject':
   case 'start':
-  case 'test': {
+  case 'test':
+  case 'lint': {
     const result = spawn.sync(
       'node',
       nodeArgs

--- a/packages/react-scripts/scripts/lint.js
+++ b/packages/react-scripts/scripts/lint.js
@@ -1,0 +1,28 @@
+// @remove-on-eject-begin
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @remove-on-eject-end
+'use strict';
+
+const CLIEngine = require('eslint').CLIEngine;
+
+const cli = new CLIEngine({
+  // @remove-on-eject-begin
+  configFile: require.resolve('eslint-config-react-app'),
+  // @remove-on-eject-end
+  fix: process.argv.slice(2).indexOf('--fix') >= 0,
+});
+const report = cli.executeOnFiles(['src/**/*.{js,jsx,mjs}']);
+const formatter = cli.getFormatter();
+
+// persist changed files when using --fix option
+CLIEngine.outputFixes(report);
+console.log(formatter(report.results));
+
+if (report.errorCount > 0) {
+  process.exit(1);
+}

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -243,6 +243,9 @@ exists build/static/css/*.css
 exists build/static/media/*.svg
 exists build/favicon.ico
 
+# Test linter
+./node_modules/.bin/react-scripts lint
+
 # Run tests with CI flag
 CI=true yarn test
 # Uncomment when snapshot testing is enabled by default:
@@ -272,6 +275,9 @@ exists build/static/js/*.js
 exists build/static/css/*.css
 exists build/static/media/*.svg
 exists build/favicon.ico
+
+# Test linter
+node scripts/lint.js
 
 # Run tests, overring the watch option to disable it.
 # `CI=true yarn test` won't work here because `yarn test` becomes just `jest`.


### PR DESCRIPTION
Adds lint command to react-scripts.

Typical use will be to:
1. add to package.json scripts:
```
  "scripts": {
    ...,
    "lint": "react-scripts lint"
  }
```
EDIT: PR provides a default configuration for ESlinter, so these are no longer needed:
~2. `yarn lint --init`~
~3. `yarn` to install new dependencies~
~4. `yarn lint` to use~

Script passes all options to eslint, so this will work `yarn lint --fix`. Files checked are: .js, .jsx and .mjs in src folder. This includes test files too.