### PR TITLE
Enable jest cacheDirectory configuration

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -69,6 +69,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'resetModules',
     'snapshotSerializers',
     'watchPathIgnorePatterns',
+    'cacheDirectory',
   ];
   if (overrides) {
     supportedKeys.forEach(key => {

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1564,8 +1564,8 @@ Example package.json:
       }
     },
     "coverageReporters": ["text"],
-	"snapshotSerializers": ["my-serializer-module"],
-	"cacheDirectory": ".tmp/cache/jest"
+    "snapshotSerializers": ["my-serializer-module"],
+    "cacheDirectory": ".tmp/cache/jest"
   }
 }
 ```
@@ -1646,7 +1646,7 @@ To speed up tests, Jest uses a cache. Unfortunately it saves the cache in hard-t
 
 ```json
   "jest": {
-	  "cacheDirectory": ".tmp/cache/jest"
+    "cacheDirectory": ".tmp/cache/jest"
   }
 ```
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1539,6 +1539,10 @@ Supported overrides:
  - [`coverageReporters`](https://facebook.github.io/jest/docs/en/configuration.html#coveragereporters-array-string)
  - [`coverageThreshold`](https://facebook.github.io/jest/docs/en/configuration.html#coveragethreshold-object)
  - [`snapshotSerializers`](https://facebook.github.io/jest/docs/en/configuration.html#snapshotserializers-array-string)
+ - [`resetMocks`](https://facebook.github.io/jest/docs/en/configuration.html#resetmocks-boolean)
+ - [`resetModules`](https://facebook.github.io/jest/docs/en/configuration.html#resetmodules-boolean)
+ - [`watchPathIgnorePatterns`](https://facebook.github.io/jest/docs/en/configuration.html#watchpathignorepatterns-array-string)
+ - [`cacheDirectory`](https://facebook.github.io/jest/docs/en/configuration.html#watchpathignorepatterns-array-string)
 
 Example package.json:
 
@@ -1560,7 +1564,8 @@ Example package.json:
       }
     },
     "coverageReporters": ["text"],
-    "snapshotSerializers": ["my-serializer-module"]
+	"snapshotSerializers": ["my-serializer-module"],
+	"cacheDirectory": ".tmp/cache/jest"
   }
 }
 ```

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1640,6 +1640,18 @@ The test command will force Jest to run tests once instead of launching the watc
 
 The build command will check for linter warnings and fail if any are found.
 
+### Speeding up CI tests with jest cache
+
+To speed up tests, Jest uses a cache. Unfortunately it saves the cache in hard-to-predict directory by default, making it difficult to save this cache in between builds on the CI environment. To counter this and make your tests run up to 2 times faster, you can specify which directory Jest should save it's cache to, by setting it in the `package.json`:
+
+```json
+  "jest": {
+	  "cacheDirectory": ".tmp/cache/jest"
+  }
+```
+
+And then configuring your CI to cache that directory. See guides for [Travis CI](https://docs.travis-ci.com/user/caching/#Arbitrary-directories) and [CircleCI](https://circleci.com/docs/2.0/caching/) on how to configure cache directories.
+
 ### Disabling jsdom
 
 By default, the `package.json` of the generated project looks like this:


### PR DESCRIPTION
Fixes #2687 .

Enables the user to override Jest's [`cacheDirectory`]( https://facebook.github.io/jest/docs/en/configuration.html#cachedirectory-string) configuration, mainly to make it easier for users to speed up their builds on CI, by caching jest's cache in between builds.

## How I tested

- [x] Test that it breaks without modification
  - Don't modify anything.
  - Add `"jest": { "cacheDirectory": "tmp/jest-cache" }` to `/packages/react-scripts/package.json`
  - Run `yarn test`
  - See that it complaints about overriding `cacheDirectory`
- [x] Test that it works with modified code
  - Add modification to code
  - Repeat above
  - See that it doesn't complain
  - See that a new folder `tmp/jest-cache` is created in `/packages/react-scripts/template/`
  - Re-run tests
  - See that it still works
- [x] Test that it works in generated app
  - run `yarn create-react-app a-test-app`
  - Repeat above steps in the newly generated app
  - See that it still works

## Documentation

I've added `cacheDirectory` to the list of supported overrides in the template README.md. I've also added `resetMocks`, `resetModules` and `watchPathIgnorePattern` as they weirdly wasn't on the list, even though the are supported. If they are omitted on purpose, I'm sorry, I'll remove them again.
I've also added a short section about using the `cacheDirectory` option to speed up tests on CI.

## Future work

Should this be accepted, I'll gladly looking into speeding up this repos tests using the `cacheDirectory`  pattern. However I'm inexperienced with TravisCI so I might come up short. Please let me know in the comments if I should pursue this or not.