### PR TITLE
Support custom env file

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -24,6 +24,7 @@ if (!NODE_ENV) {
 
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 var dotenvFiles = [
+    process.env.CUSTOM_ENV_FILE && `${process.env.CUSTOM_ENV_FILE}`, // support custom env file. Will be useful for CI
   `${paths.dotenv}.${NODE_ENV}.local`,
   `${paths.dotenv}.${NODE_ENV}`,
   // Don't include `.env.local` for `test` environment


### PR DESCRIPTION
At the current project, we need to have a lot of .env properties based on sub-domain: 
```
master. 
develop. 
a. 
b.
```

So I think it can be useful for other developers.

Usage example

`
"start": "CUSTOM_ENV_FILE=.custom.env react-scripts start"
`