### PR TITLE
Update changelog to add noscript when migrating to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1390,6 +1390,14 @@ After the regular update procedure above, add these line to `<head>` in `public/
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
 ```
 
+Add `<noscript>` to `<body>` in `public/index.html`:
+
+```html
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
+```
+
 Then create a file called `public/manifest.json` that looks like this:
 
 ```js


### PR DESCRIPTION
Add ```<noscript>``` to ```<body>``` as part of migration instructions from 0.9.5 to 1.0.0 in order to provide fallback content when JavaScript is not available and improve [Lighthouse ](https://developers.google.com/web/tools/lighthouse/)score.