### PR TITLE
Allow to configure some behaviour for react-scripts start script

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -106,7 +106,7 @@ checkBrowsers(paths.appPath)
       if (err) {
         return console.log(err);
       }
-      if (isInteractive) {
+      if (isInteractive && !process.env.NO_CLEAR_CONSOLE) {
         clearConsole();
       }
       console.log(chalk.cyan('Starting the development server...\n'));


### PR DESCRIPTION
This PR adds 2 new environment variables for configuring some behaviour in the `react-scripts start` script: `NO_CLEAR_CONSOLE` and `NO_OPEN_BROWSER `.

The motivation behind these changes is to improve the experience executing `create-react-app` in environments where there's not a browser installed, like in a docker container.

Also, clearing the console might prevent to see the output generated by other containers.
