### PR TITLE
Allow bundles to be analyzed with Webpack-specific tools

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -30,6 +30,7 @@
     "babel-loader": "8.0.0-beta.0",
     "babel-plugin-named-asset-import": "^0.1.0",
     "babel-preset-react-app": "^3.1.1",
+    "bfj": "5.2.0",
     "case-sensitive-paths-webpack-plugin": "2.1.2",
     "chalk": "2.4.1",
     "css-loader": "0.28.11",

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -2048,6 +2048,14 @@ will affect your users' experience.
 
 ## Analyzing the Bundle Size
 
+When your app grows in size, it's easy for bundles to become bloated. The first step to solving large bundles is understanding what's in them!
+
+There are many different tools available to analyze bundles, but they typically rely on either **sourcemaps** or **webpack-specific JSON stats**.
+
+### Using Sourcemaps
+
+When building for production, sourcemaps are automatically created adjacent to the JS files in `build/static/js`.
+
 [Source map explorer](https://www.npmjs.com/package/source-map-explorer) analyzes
 JavaScript bundles using the source maps. This helps you understand where code
 bloat is coming from.
@@ -2081,6 +2089,46 @@ script.
 npm run build
 npm run analyze
 ```
+
+### Using Webpack Stats JSON
+
+> Note: this feature is available with react-scripts@2.0 and higher.
+
+Webpack can produce a JSON manifest that details the bundles, and several tools can use that file to do analysis.
+
+Unlike with sourcemaps, the JSON file isn't created automatically on build. You must pass a `--stats` flag:
+
+```sh
+npm run build -- --stats
+```
+
+Once the build is complete, you should have a JSON file located at `build/bundle-stats.json`.
+
+The quickest way to get insight into your bundle is to drag and drop that JSON file into [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/).
+
+Another very popular tool is [`webpack-bundle-analyzer`](https://www.npmjs.com/package/webpack-bundle-analyzer).
+
+To use `webpack-bundle-analyzer`, start by installing it from NPM:
+
+```sh
+npm install --save webpack-bundle-analyzer
+# or, with Yarn:
+yarn add webpack-bundle-analyzer
+```
+
+
+In `package.json`, add the following line to `scripts`:
+
+```diff
+   "scripts": {
++    "analyze": "npm run build -- --stats && webpack-bundle-analyzer build/bundle-stats.json",
+     "start": "react-scripts start",
+     "build": "react-scripts build",
+     "build:with-stats": "react-scripts build",
+     "test": "react-scripts test --env=jsdom",
+```
+
+When you run `npm run analyze`, a new build will be created, and a browser tab should open automatically, displaying the sizes of the modules within your bundle.
 
 ## Deployment
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -2106,7 +2106,7 @@ Once the build is complete, you should have a JSON file located at `build/bundle
 
 The quickest way to get insight into your bundle is to drag and drop that JSON file into [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/).
 
-Another very popular tool is [`webpack-bundle-analyzer`](https://www.npmjs.com/package/webpack-bundle-analyzer).
+Another very popular tool is [`webpack-bundle-analyzer`](https://github.com/webpack-contrib/webpack-bundle-analyzer).
 
 To use `webpack-bundle-analyzer`, start by installing it from NPM:
 
@@ -2124,7 +2124,6 @@ In `package.json`, add the following line to `scripts`:
 +    "analyze": "npm run build -- --stats && webpack-bundle-analyzer build/bundle-stats.json",
      "start": "react-scripts start",
      "build": "react-scripts build",
-     "build:with-stats": "react-scripts build",
      "test": "react-scripts test --env=jsdom",
 ```
 


### PR DESCRIPTION
Associated issue: #1858

To analyze Webpack bundles, a "stats" JSON is required.

This PR allows that file to be created and saved to the `build`
directory, so that users can use it with Webpack-specific insight
tools like `webpack-bundle-analyzer` without ejecting their
application.

Updated the README to include details for how to do this.

### Test plan

**1. check that the stats flag works**

I ran `yarn build --stats` in the root directory of the project. Once it completed, I verified that build/bundle-stats.json existed. I dragged it into Webpack Visualizer to check that the file is correct:

<img width="450" alt="screen shot 2018-01-31 at 8 46 57 am" src="https://user-images.githubusercontent.com/6692932/35626319-5f4af9f4-0663-11e8-9b83-4362683da608.png">


**2. check that it works in a created project**

I ran `yarn create-react-app test` to generate a new app.

After `cd`-ing into the directory and installing its dependencies, I followed the steps I added to the the README for using `webpack-bundle-analyzer`. Specifically I ran:

```sh
$ npm install --save webpack-bundle-analyzer
```

Then, I opened the project's `package.json` and added a script:

```
"analyze": "npm run build -- --stats && webpack-bundle-analyzer build/bundle-stats.json",
```
Finally, I ran the new script:

```sh
$ npm run analyze
```

The project built, and a new browser window automatically opened, with the bundle stats:
![screen shot 2018-01-31 at 8 42 14 am](https://user-images.githubusercontent.com/6692932/35626432-bb87ee02-0663-11e8-98c1-abcd2d4bb46b.png)
