### PR TITLE
Use package.json "prettier" key in the "Formatting Code Automatically" section

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -344,14 +344,19 @@ Next we add a 'lint-staged' field to the `package.json`, for example:
   },
 + "lint-staged": {
 +   "src/**/*.{js,jsx,json,css}": [
-+     "prettier --single-quote --write",
++     "prettier --write",
 +     "git add"
 +   ]
++ },
++ "prettier": {
++   "singleQuote": true
 + },
   "scripts": {
 ```
 
-Now, whenever you make a commit, Prettier will format the changed files automatically. You can also run `./node_modules/.bin/prettier --single-quote --write "src/**/*.{js,jsx}"` to format your entire project for the first time.
+The "prettier" key is optional and allows you to [customize the default configuration](https://prettier.io/docs/en/configuration.html).
+
+Now, whenever you make a commit, Prettier will format the changed files automatically. You can also run `./node_modules/.bin/prettier --write "src/**/*.{js,jsx}"` to format your entire project for the first time.
 
 Next you might want to integrate Prettier in your favorite editor. Read the section on [Editor Integration](https://prettier.io/docs/en/editors.html) on the Prettier GitHub page.
 


### PR DESCRIPTION
Using Prettier in the code editor is very useful and it's even incentivized in the last sentence of the "Formatting Code Automatically" section of the User Guide. Users can also have a custom Prettier configuration in their `package.json`, which is automatically used by code editor extensions and the Prettier CLI.

However, the instructions in this section pass a `--single-quote` option to the CLI which will override the user's custom config (if existent). This means the code automatically formatted by their editors may be different to what will end up being committed.

Ideally, it would be great if we could simplify and remove the custom `--single-quote` config, but I guess this was added to match the styling of the generated files (such as `serviceWorker.js`).

In this PR I moved the configuration to the `"prettier"` key in the `package.json` so that is used by both the CLI and code editor extensions.

I also added a sentence explaining what the key is about so it's harder to miss (because some users may be using a `prettier.config.js` or `.prettierrc` file instead and will want to adjust).

Feel free to close if you disagree! Thank you for creating this project and documenting it so well 👏 

_The reason for this is that I use Prettier in VS Code and have recently blindly copied these instructions, and got confused when I started seeing single quotes instead of double quotes in my committed files, despite having my custom config._ 😄 