### PR TITLE
Detail docs about building for relative path

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -2173,6 +2173,12 @@ To override this, specify the `homepage` in your `package.json`, for example:
   "homepage": "http://mywebsite.com/relativepath",
 ```
 
+Or, specify environment variable named `PUBLIC_URL`, for example:
+
+```sh
+  export PUBLIC_URL=http://mywebsite.com/relativepath
+```
+
 This will let Create React App correctly infer the root path to use in the generated HTML file.
 
 **Note**: If you are using `react-router@^4`, you can root `<Link>`s using the `basename` prop on any `<Router>`.<br>


### PR DESCRIPTION
Added docs is verified at [here](https://github.com/facebook/create-react-app/blob/b43ad04b880f460ed23dbb7968bae634bf7dbc91/packages/react-scripts/config/paths.js#L35).

Hope it will help guys wanna change root path of built app without changing `package.json`.
