### PR TITLE
Update instructions for continuous delivery with Netlify

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -2264,7 +2264,8 @@ With this setup Netlify will build and deploy when you push to git or open a pul
 
 1. [Start a new netlify project](https://app.netlify.com/signup)
 2. Pick your Git hosting service and select your repository
-3. Click `Build your site`
+3. Set `yarn build` as the build command and `build` as the publish directory
+4. Click `Deploy site`
 
 **Support for client-side routing:**
 


### PR DESCRIPTION
This adds instructions needed when configuring Netlify for continuous delivery of a GitHub repository.

This is what [the form](https://app.netlify.com/start) currently looks like:

![image](https://user-images.githubusercontent.com/14294/35779169-aebce62c-09c0-11e8-8381-6c991d83cc17.png)
