### PR TITLE
Upgrade dotenv-expand to 4.2.0 (#3961)

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -34,7 +34,7 @@
     "chalk": "2.3.0",
     "css-loader": "0.28.9",
     "dotenv": "4.0.0",
-    "dotenv-expand": "4.0.1",
+    "dotenv-expand": "4.2.0",
     "eslint": "4.15.0",
     "eslint-config-react-app": "^2.1.0",
     "eslint-loader": "1.9.0",


### PR DESCRIPTION
Update `dotenv-expand` to fix bug with environment variables that contain a `$`.

Closes #3961 