### PR TITLE
Upgrade dotenv-expand to 4.2.0 in 1.x branch

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -32,7 +32,7 @@
     "chalk": "1.1.3",
     "css-loader": "0.28.7",
     "dotenv": "4.0.0",
-    "dotenv-expand": "4.0.1",
+    "dotenv-expand": "4.2.0",
     "eslint": "4.10.0",
     "eslint-config-react-app": "^2.1.0",
     "eslint-loader": "1.9.0",


### PR DESCRIPTION
Update `dotenv-expand` to fix bug with environment variables that containing a `$`.

Addresses #3961 in the `1.x` branch.