### PR TITLE
Add support for new yarn workspaces config format

### DIFF
--- a/packages/react-dev-utils/workspaceUtils.js
+++ b/packages/react-dev-utils/workspaceUtils.js
@@ -32,7 +32,8 @@ const findPkgs = (rootPath, globPatterns) => {
 const findMonorepo = appDir => {
   const monoPkgPath = findPkg.sync(path.resolve(appDir, '..'));
   const monoPkg = monoPkgPath && require(monoPkgPath);
-  const patterns = monoPkg && monoPkg.workspaces;
+  const workspaces = monoPkg && monoPkg.workspaces;
+  const patterns = (workspaces && workspaces.packages) || workspaces;
   const isYarnWs = Boolean(patterns);
   const allPkgs = patterns && findPkgs(path.dirname(monoPkgPath), patterns);
   const isIncluded = dir => allPkgs && allPkgs.indexOf(dir) !== -1;


### PR DESCRIPTION
With the addition of the [nohoist feature](https://github.com/yarnpkg/yarn/pull/4979), yarn has enabled a new optional format for the `workspaces` key in `package.json`:

```json
"workspaces": {
   "packages": ["packages/*"],
    "nohoist": ["**"]
}
```
This feature is already available in the current [yarn nightly build](https://yarnpkg.com/en/docs/nightly) and I'm successfully using it with the following setup:

`yarn@1.4.1-20180208.2355` (nightly)
`react-scripts@2.0.0-next.47d2d941` (with my patch)
`lerna@2.8.0` (with a similar [patch](https://github.com/lerna/lerna/pull/1254))

With these patches applied, everything worked out-of-the-box*, aside from needing to make use of the `nohoist` option. 
*(obviously, I also needed to configure lerna to use yarn and workspaces)

With the nightly build of yarn installed all enabling `nohoist` required was:
1) Adding the settings shown above to my `package.json`
2) Adding the following to my `.yarnrc`:
```json
--workspaces-experimental true
--workspaces-nohoist-experimental true
```

I could put together a demo lerna repo with my patches applied if needed, but I'm pretty busy with my current project, so if it's not necessary I won't bother.

Similarly, I'd be willing to add a new test to prove it gets the values from `workspaces.packages` when present. But I'm wondering if that's overkill for such a simple change.

Let me know if you have any questions or concerns! :)
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
