### PR TITLE
Unpin and bump fsevents (for 1.x branch)

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -64,6 +64,6 @@
     "react-dom": "^16.0.0"
   },
   "optionalDependencies": {
-    "fsevents": "1.1.2"
+    "fsevents": "^1.1.3"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/facebook/create-react-app/issues/4003.

Unpinning so that it keeps working even as new Node versions come out.
The dependency has been fairly stable and I trust that if it breaks, everyone will notice anyway.