### PR TITLE
Enable CSS source maps in development

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -249,6 +249,7 @@ module.exports = {
               {
                 loader: require.resolve('css-loader'),
                 options: {
+                  sourceMap: true,
                   importLoaders: 1,
                 },
               },
@@ -267,6 +268,7 @@ module.exports = {
               {
                 loader: require.resolve('css-loader'),
                 options: {
+                  sourceMap: true,
                   importLoaders: 1,
                   modules: true,
                   localIdentName: '[path]__[name]___[local]',


### PR DESCRIPTION
Turns on source maps for CSS loader in development webpack config.

Benefit is that styles pane in DevTools can now show the path to the source file with link to surrounding content instead of just `<style>...</style>`. Turning on the sourceMap flag for `postCSSLoaderOptions` as well seemed to mutate the path and remove the "src" directory bit (and also doesn't match the prod config), so avoided that.

## Before
![image](https://user-images.githubusercontent.com/2301202/36046993-a1e9f20a-0d8f-11e8-9587-a20ceb9a7fce.png)


## After
![image](https://user-images.githubusercontent.com/2301202/36046964-86398bb0-0d8f-11e8-9151-4fbfd1536e04.png)
