### PR TITLE
Fix floating caret position incorrect while scrolling overlay

### DIFF
--- a/packages/react-error-overlay/src/components/CodeBlock.js
+++ b/packages/react-error-overlay/src/components/CodeBlock.js
@@ -10,6 +10,7 @@ import React from 'react';
 import { redTransparent, yellowTransparent } from '../styles';
 
 const _preStyle = {
+  position: 'relative',
   display: 'block',
   padding: '0.5em',
   marginTop: '0.5em',


### PR DESCRIPTION
As screenshots, notice the position of "caret" symbol.

### Before

![caret_before](https://user-images.githubusercontent.com/87983/36187035-b359f5e8-117d-11e8-90bb-108715e4597b.gif)

### After

![caret_after](https://user-images.githubusercontent.com/87983/36187030-afb7b86c-117d-11e8-9668-9b9f25c5e5cd.gif)
