### PR TITLE
Issue 1394 adding no bin links option

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -186,9 +186,8 @@ function createApp(name, verbose, version, useNpm, binLinks, template) {
     path.join(root, 'package.json'),
     JSON.stringify(packageJson, null, 2) + os.EOL
   );
-  console.log(`what are we using?: ${useNpm}`);
-  const useYarn = false;
-  //const useYarn = useNpm ? false : shouldUseYarn(root);
+
+  const useYarn = useNpm ? false : shouldUseYarn(root);
   const originalDirectory = process.cwd();
   process.chdir(root);
   if (!useYarn && !checkThatNpmCanReadCwd()) {
@@ -288,7 +287,6 @@ function install(root, useYarn, dependencies, verbose, binLinks, isOnline) {
     }
 
     if (binLinks === false) {
-      console.log(`ya got links?: ${binLinks}`);
       args.push('--no-bin-links');
     }
 


### PR DESCRIPTION
Sorry about so many commit's.  I forgot to set autocrlf to false (I'm working in Windows) so went back and set that which looks like it changed the whole file to fix the line endings.  I'll just note below what lines I actually added code to for your review:

Line 79 - added option for --no-bin-links
Line 163 - passed program.binLinks to createApp()
Line 167 - added binLinks as arg to createApp()
Line 228 - passed binLinks to run()
Line 249 - added binLinks as arg to install()
Lines 289-291 - if statement to push --no-bin-links to npm args
Line 311 - added binLinks as arg to run()
Line 342 - passed binLinks to install()

I added a few console.log's when testing to make sure argument was only being passed when it was called.  Running `create-react-app my-app` should have no changes.  You would need to run `create-react-app my-app --use-npm --no-bin-links` which should then pass the --no-bin-links command to npm.  When I tested those flags, the process completed without any errors.

Please let me know if there are any further changes you would like me to make or if I did not do something correctly.  Thank you!

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
