### PR TITLE
Configurable build output directory

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -47,11 +47,14 @@ function getServedPath(appPackageJson) {
   return ensureSlash(servedUrl, true);
 }
 
+// The location where the final bundle will be put, defaults to 'build' folder in the app root.
+const buildDirectory = process.env.BUILD_DIR || 'build';
+
 // config after eject: we're in ./config/
 module.exports = {
   dotenv: resolveApp('.env'),
   appPath: resolveApp('.'),
-  appBuild: resolveApp('build'),
+  appBuild: resolveApp(buildDirectory),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),
   appIndexJs: resolveApp('src/index.js'),
@@ -72,7 +75,7 @@ const resolveOwn = relativePath => path.resolve(__dirname, '..', relativePath);
 module.exports = {
   dotenv: resolveApp('.env'),
   appPath: resolveApp('.'),
-  appBuild: resolveApp('build'),
+  appBuild: resolveApp(buildDirectory),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),
   appIndexJs: resolveApp('src/index.js'),
@@ -97,7 +100,7 @@ if (useTemplate) {
   module.exports = {
     dotenv: resolveOwn('template/.env'),
     appPath: resolveApp('.'),
-    appBuild: resolveOwn('../../build'),
+    appBuild: resolveOwn('../../' + buildDirectory),
     appPublic: resolveOwn('template/public'),
     appHtml: resolveOwn('template/public/index.html'),
     appIndexJs: resolveOwn('template/src/index.js'),

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -2493,6 +2493,7 @@ REACT_EDITOR | :white_check_mark: | :x: | When an app crashes in development, yo
 CHOKIDAR_USEPOLLING | :white_check_mark: | :x: | When set to `true`, the watcher runs in polling mode, as necessary inside a VM. Use this option if `npm start` isn't detecting changes.
 GENERATE_SOURCEMAP | :x: | :white_check_mark: | When set to `false`, source maps are not generated for a production build. This solves OOM issues on some smaller machines.
 NODE_PATH | :white_check_mark: |  :white_check_mark: | Same as [`NODE_PATH` in Node.js](https://nodejs.org/api/modules.html#modules_loading_from_the_global_folders), but only relative folders are allowed. Can be handy for emulating a monorepo setup by setting `NODE_PATH=src`.
+BUILD_DIR | :x: | :white_check_mark: | Create React App assumes that your `build` folder holds the production bundle. Output directory can be also configured by setting `BUILD_DIR` variable.
 
 ## Troubleshooting
 


### PR DESCRIPTION
This pull request enables build output directory to be configured via special environment variable.
I think this change will come handy in some special environments where `build` folder can't be deployed directly.

Default output:
```
$ yarn build
yarn run v1.3.2
$ cd packages/react-scripts && node bin/react-scripts.js build
Creating an optimized production build...
Compiled successfully.

File sizes after gzip:

  35.56 KB  build/static/js/main.c76fe2d2.js
  526 B     build/static/css/main.de8ab87f.css

The project was built assuming it is hosted at the server root.
You can control this with the homepage field in your package.json.
For example, add this to build it for GitHub Pages:

  "homepage" : "http://myname.github.io/myapp",

The ../../build folder is ready to be deployed.
```

Output with build directory override:
```
$ BUILD_DIR=target/generated-resources/app yarn build
yarn run v1.3.2
$ cd packages/react-scripts && node bin/react-scripts.js build
Creating an optimized production build...
Compiled successfully.

File sizes after gzip:

  35.56 KB  app/static/js/main.c76fe2d2.js
  526 B     app/static/css/main.de8ab87f.css

The project was built assuming it is hosted at the server root.
You can control this with the homepage field in your package.json.
For example, add this to build it for GitHub Pages:

  "homepage" : "http://myname.github.io/myapp",

The ../../target/generated-resources/app folder is ready to be deployed.
```

Sidenote:
In my case, I'm bundling a React application as part of a larger Java application. For that purpose, bundle resources should be packaged as a `.jar` package and included as a Maven dependency in the parent project.
A precondition for achieving this is to put the bundles in the Maven's `generated-resources` directory. In order to fulfill this precondition, either some additional build steps should be added or the app should be ejected. I want to avoid ejection as the default CRA configuration suits fine.
