### PR TITLE
add support for react-native-svg-web

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -104,6 +104,7 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      'react-native-svg': 'react-native-svg-web',
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -110,6 +110,7 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      'react-native-svg': 'react-native-svg-web',
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -42,6 +42,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$'],
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
+      '^react-native-svg$': 'react-native-svg-web',
     },
     moduleFileExtensions: [
       'web.js',


### PR DESCRIPTION
I'd like to use [react-native-svg-web](https://www.npmjs.com/package/react-native-svg-web) similar to issue https://github.com/facebook/create-react-app/issues/316 and PR https://github.com/facebook/create-react-app/pull/407

I tested these changes locally in an app I'm building by editing the react-scripts webpack config files directly in the node_modules folder. Before doing so, I get the following error:

<img width="1042" alt="screen shot 2018-02-19 at 4 35 17 pm" src="https://user-images.githubusercontent.com/689046/36402526-12676588-1594-11e8-9749-1b8c22d86ebf.png">

But everything works fine once I add in these lines to the config.