### PR TITLE
Add ESLint check for incorrect propTypes usage (#3840)

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -186,6 +186,7 @@ module.exports = {
     'import/no-webpack-loader-syntax': 'error',
 
     // https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules
+    'react/forbid-foreign-prop-types': ['warn', { allowInPropTypes: true }],
     'react/jsx-no-comment-textnodes': 'warn',
     'react/jsx-no-duplicate-props': ['warn', { ignoreCase: true }],
     'react/jsx-no-target-blank': 'warn',

--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -16,7 +16,7 @@
     "eslint-plugin-flowtype": "^2.34.1",
     "eslint-plugin-import": "^2.6.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
-    "eslint-plugin-react": "^7.1.0"
+    "eslint-plugin-react": "^7.7.0"
   },
   "dependencies": {
     "confusing-browser-globals": "^1.0.0"

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-flowtype": "2.41.0",
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-jsx-a11y": "6.0.3",
-    "eslint-plugin-react": "7.5.1",
+    "eslint-plugin-react": "7.7.0",
     "flow-bin": "^0.63.1",
     "html-entities": "1.2.1",
     "jest": "22.1.2",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-flowtype": "2.41.0",
     "eslint-plugin-import": "2.8.0",
     "eslint-plugin-jsx-a11y": "6.0.3",
-    "eslint-plugin-react": "7.5.1",
+    "eslint-plugin-react": "7.7.0",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "1.1.6",
     "fs-extra": "5.0.0",


### PR DESCRIPTION
Update `eslint-plugin-react` to `7.7.0` and add `forbid-foreign-prop-types` check.

Closes #3840 
