### PR TITLE
Add support for parsing absolute paths

### DIFF
--- a/packages/react-error-overlay/src/utils/parseCompileError.js
+++ b/packages/react-error-overlay/src/utils/parseCompileError.js
@@ -7,7 +7,7 @@ export type ErrorLocation = {|
   colNumber?: number,
 |};
 
-const filePathRegex = /^\.(\/[^/\n ]+)+\.[^/\n ]+$/;
+const filePathRegex = /^\.?(\/[^/\n ]+)+\.[^/\n ]+$/;
 
 const lineNumberRegexes = [
   // Babel syntax errors


### PR DESCRIPTION
This fixes a problem in my custom setup where I use the react-error-overlay package.

Previously, when a build error mentioned an absolute path, it would not be openable in the editor. This fixes that.