### PR TITLE
docs: use node_js 8 in example travis.yml

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1611,7 +1611,7 @@ Popular CI servers already set the environment variable `CI` by default but you 
 ```
 language: node_js
 node_js:
-  - 6
+  - 8
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
This is the current node LTS release.