### PR TITLE
Allow ModuleScopePlugin accecpts an array as its appSrc

### DIFF
--- a/packages/react-dev-utils/ModuleScopePlugin.js
+++ b/packages/react-dev-utils/ModuleScopePlugin.js
@@ -12,12 +12,31 @@ const path = require('path');
 
 class ModuleScopePlugin {
   constructor(appSrc, allowedFiles = []) {
-    this.appSrc = appSrc;
+    this.appSrcs = Array.isArray(appSrc) ? appSrc : [appSrc];
     this.allowedFiles = new Set(allowedFiles);
   }
 
+  issuerInAppSrc(appSrc, requestFullPath) {
+    const requestRelative = path.relative(appSrc, requestFullPath);
+    if (
+      requestRelative.startsWith('../') ||
+      requestRelative.startsWith('..\\')
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  issuerIsOurFiles(appSrc, relative) {
+    // If it's not in src/ or a subdirectory, not our request!
+    if (relative.startsWith('../') || relative.startsWith('..\\')) {
+      return false;
+    }
+    return true;
+  }
+
   apply(resolver) {
-    const { appSrc } = this;
+    const { appSrcs } = this;
     resolver.plugin('file', (request, callback) => {
       // Unknown issuer, probably webpack internals
       if (!request.context.issuer) {
@@ -34,10 +53,11 @@ class ModuleScopePlugin {
       }
       // Resolve the issuer from our appSrc and make sure it's one of our files
       // Maybe an indexOf === 0 would be better?
-      const relative = path.relative(appSrc, request.context.issuer);
-      // If it's not in src/ or a subdirectory, not our request!
-      if (relative.startsWith('../') || relative.startsWith('..\\')) {
-        return callback();
+      for (let i = 0; i < appSrcs.length; i++) {
+        const relative = path.relative(appSrcs[i], request.context.issuer);
+        if (relative.startsWith('../') || relative.startsWith('..\\')) {
+          return callback();
+        }
       }
       const requestFullPath = path.resolve(
         path.dirname(request.context.issuer),
@@ -46,34 +66,33 @@ class ModuleScopePlugin {
       if (this.allowedFiles.has(requestFullPath)) {
         return callback();
       }
+
       // Find path from src to the requested file
       // Error if in a parent directory of src/
-      const requestRelative = path.relative(appSrc, requestFullPath);
-      if (
-        requestRelative.startsWith('../') ||
-        requestRelative.startsWith('..\\')
-      ) {
-        callback(
-          new Error(
-            `You attempted to import ${chalk.cyan(
-              request.__innerRequest_request
-            )} which falls outside of the project ${chalk.cyan(
-              'src/'
-            )} directory. ` +
-              `Relative imports outside of ${chalk.cyan(
+      appSrcs.forEach(appSrc => {
+        if (this.issuerInAppSrc(appSrc, requestFullPath)) {
+          callback();
+        } else {
+          callback(
+            new Error(
+              `You attempted to import ${chalk.cyan(
+                request.__innerRequest_request
+              )} which falls outside of the project ${chalk.cyan(
                 'src/'
-              )} are not supported. ` +
-              `You can either move it inside ${chalk.cyan(
-                'src/'
-              )}, or add a symlink to it from project's ${chalk.cyan(
-                'node_modules/'
-              )}.`
-          ),
-          request
-        );
-      } else {
-        callback();
-      }
+              )} directory. ` +
+                `Relative imports outside of ${chalk.cyan(
+                  'src/'
+                )} are not supported. ` +
+                `You can either move it inside ${chalk.cyan(
+                  'src/'
+                )}, or add a symlink to it from project's ${chalk.cyan(
+                  'node_modules/'
+                )}.`
+            ),
+            request
+          );
+        }
+      });
     });
   }
 }

--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -57,7 +57,7 @@ module.exports = {
 ```
 
 
-#### `new ModuleScopePlugin(appSrc: string, allowedFiles?: string[])`
+#### `new ModuleScopePlugin(appSrc: string | string[], allowedFiles?: string[])`
 
 This Webpack plugin ensures that relative imports from app's source directory don't reach outside of it.
 

--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -59,7 +59,7 @@ module.exports = {
 
 #### `new ModuleScopePlugin(appSrc: string | string[], allowedFiles?: string[])`
 
-This Webpack plugin ensures that relative imports from app's source directory don't reach outside of it.
+This Webpack plugin ensures that relative imports from app's source directories don't reach outside of it.
 
 ```js
 var path = require('path');


### PR DESCRIPTION
When ejected, you can now pass in an array as the appSrc for ModuleScopPlugin.
Implement of #4079 

### test plan:
1. `yarn create-react-app test-app`
2. `cd test-app`
3. `yarn run eject`
4. `mkdir docs`
5. In `config/paths.js`, add `docsSrc: resolveApp('docs')`
6. In `config/webpack.config.dev.js`, modify `new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),` to `new ModuleScopePlugin([paths.appSrc, paths.docsSrc], [paths.appPackageJson]),`
7. `yarn start`. You should be able to import stuff from both `src/` and `docs/`.