### PR TITLE
Minor fixes to CI

### DIFF
--- a/packages/react-error-overlay/src/effects/proxyConsole.js
+++ b/packages/react-error-overlay/src/effects/proxyConsole.js
@@ -28,7 +28,7 @@ const registerReactStack = () => {
     // $FlowFixMe
     console.reactStack = frames => reactFrameStack.push(frames);
     // $FlowFixMe
-    console.reactStackEnd = frames => reactFrameStack.pop();
+    console.reactStackEnd = () => reactFrameStack.pop();
   }
 };
 

--- a/packages/react-error-overlay/src/utils/getStackFrames.js
+++ b/packages/react-error-overlay/src/utils/getStackFrames.js
@@ -13,7 +13,7 @@ import { unmap } from './unmapper';
 
 function getStackFrames(
   error: Error,
-  unhandledRejection: boolean = false,
+  unhandledRejection: boolean = false, // eslint-disable-line
   contextSize: number = 3
 ): Promise<StackFrame[] | null> {
   const parsedFrames = parse(error);

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -75,7 +75,6 @@ root_path=$PWD
 if hash npm 2>/dev/null
 then
   npm i -g npm@latest
-  npm cache clean || npm cache verify
 fi
 
 # Bootstrap monorepo

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -68,7 +68,6 @@ root_path=$PWD
 if hash npm 2>/dev/null
 then
   npm i -g npm@latest
-  npm cache clean || npm cache verify
 fi
 
 # Bootstrap monorepo

--- a/tasks/e2e-monorepos.sh
+++ b/tasks/e2e-monorepos.sh
@@ -66,7 +66,6 @@ root_path=$PWD
 if hash npm 2>/dev/null
 then
   npm i -g npm@latest
-  npm cache clean || npm cache verify
 fi
 
 # Bootstrap create-react-app monorepo

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -79,7 +79,6 @@ fi
 if hash npm 2>/dev/null
 then
   npm i -g npm@latest
-  npm cache clean || npm cache verify
 fi
 
 # Bootstrap monorepo


### PR DESCRIPTION
This fixes some CI issue that I encountered, when trying to run CI locally (and on the CI servers).

This does not fix everything, but gets the CI closer to working correctly.

- Remove `cache clean` as it is unneeded in npm@5 and throws an error
- Fix issues with linting that fails CI
