### PR TITLE
Update eslint no-unused-vars args options from 'all' to 'after-used'

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -131,7 +131,7 @@ module.exports = {
     'no-unused-vars': [
       'warn',
       {
-        args: 'none',
+        args: 'after-used',
         ignoreRestSiblings: true,
       },
     ],


### PR DESCRIPTION
Should warn that "baz" is defined but never used:
```javascript
(function(foo, bar, baz) {
    return bar;
})();
```

Should be correct:
```javascript
(function(foo, bar, baz) {
    return baz;
})();
```

