### PR TITLE
WatchMissingNodeModulesPlugin now handles webpack@4 data

### DIFF
--- a/packages/react-dev-utils/WatchMissingNodeModulesPlugin.js
+++ b/packages/react-dev-utils/WatchMissingNodeModulesPlugin.js
@@ -18,13 +18,18 @@ class WatchMissingNodeModulesPlugin {
 
   apply(compiler) {
     compiler.plugin('emit', (compilation, callback) => {
-      var missingDeps = compilation.missingDependencies;
+      var missingDeps = Array.from(compilation.missingDependencies);
       var nodeModulesPath = this.nodeModulesPath;
+      var isWebpack4 = compilation.contextDependencies.add;
 
       // If any missing files are expected to appear in node_modules...
       if (missingDeps.some(file => file.indexOf(nodeModulesPath) !== -1)) {
         // ...tell webpack to watch node_modules recursively until they appear.
-        compilation.contextDependencies.push(nodeModulesPath);
+        if (isWebpack4) {
+          compilation.contextDependencies.add(nodeModulesPath);
+        } else {
+          compilation.contextDependencies.push(nodeModulesPath);
+        }
       }
 
       callback();


### PR DESCRIPTION
webpack now uses Sets to track:
- [missingDependencies](https://github.com/webpack/webpack/blob/51b0df77e4f366163730ee465f01458bfad81f34/lib/Compilation.js#L1597)
- [contextDependencies](https://github.com/webpack/webpack/blob/51b0df77e4f366163730ee465f01458bfad81f34/lib/NormalModule.js#L229)

`Set#some` does not exist, so this fix just converts webpack's data to an array.
`Set#push` does not exist, so watch logic now uses `add` if it's available

-----

### To verify
Check out [this example repo](https://github.com/GoodForOneFare/watch-missing-modules-webpack4-example) that runs a webpack@4 build with `WatchMissingNodeModules` as a plugin.

| Before | After |
| ----- | ----- |
| <img width="1778" alt="watch-modules-broken" src="https://user-images.githubusercontent.com/673655/37934747-30c16a3e-311d-11e8-8460-11f5588c87ff.png">  | <img width="1778" alt="watch-modules-fixed" src="https://user-images.githubusercontent.com/673655/37934749-3423a9bc-311d-11e8-820c-603bb1289573.png"> |


#### Verify that `react-dev-utils@next` fails with a confusing error
```sh
git clone git@github.com:GoodForOneFare/watch-missing-modules-webpack4-example.git
cd watch-missing-modules-webpack4-example
git checkout master
yarn install
yarn run build # This will output errors about missingDeps.some not being a function
```

#### Verify that this fork gives useful feedback + watch behaviour
```
git clone git@github.com:GoodForOneFare/watch-missing-modules-webpack4-example.git
cd watch-missing-modules-webpack4-example
git checkout fixed
yarn install
yarn run build --watch # This will allow the plugin to report a missing dependency (the build still fails, though!)

# To verify that contextDependencies watching still works, use this:
#  `touch node_modules/missing`
# Once that folder exists, the build should pass.
```
