### PR TITLE
Support async generator functions and for-await statements

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -93,6 +93,9 @@ module.exports = function(api, opts) {
       require('@babel/plugin-transform-destructuring').default,
       // class { handleClick = () => { } }
       require('@babel/plugin-proposal-class-properties').default,
+      // Support async generator functions and for-await
+      // async function* agf() { await 1; yield 2; }
+      require('@babel/plugin-proposal-async-generator-functions').default,
       // The following two plugins use Object.assign directly, instead of Babel's
       // extends helper. Note that this assumes `Object.assign` is available.
       // { ...todo, completed: true }

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -13,6 +13,7 @@
   ],
   "dependencies": {
     "@babel/core": "7.0.0-beta.42",
+    "@babel/plugin-proposal-async-generator-functions": "^7.0.0-beta.42",
     "@babel/plugin-proposal-class-properties": "7.0.0-beta.42",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.42",
     "@babel/plugin-syntax-dynamic-import": "7.0.0-beta.42",


### PR DESCRIPTION
Aim to resolve #4206

Add [`@babel/plugin-proposal-async-generator-functions`](https://github.com/babel/babel/tree/master/packages/babel-plugin-proposal-async-generator-functions) in babel config to support async generator functions and for-await statements

```js
async function* agf() {
  await 1;
  yield 2;
}
```

**Test steps**

- `yarn create-react-app my-agf-app`
- `cd my-agf-app`
- Add `async function* agf() { }` to `index.js`
- `yarn start`
- App starts and works