### PR TITLE
Add support for react-native-svg via svgs

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -104,6 +104,7 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      'react-native-svg': 'svgs',
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -110,6 +110,7 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      'react-native-svg': 'svgs',
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).


### PR DESCRIPTION
This PR is in line with https://github.com/facebook/create-react-app/issues/316 which adds support for `react-native-web` via a webpack alias. It's similar to https://github.com/facebook/create-react-app/pull/4044 but uses [svgs](https://github.com/godaddy/svgs) which seems to be [more actively maintained ](https://github.com/godaddy/svgs/graphs/contributors). It follows the instructions from the svgs [README](https://github.com/godaddy/svgs#webpack). Thanks for considering my PR. We're using create-react-app to build a react-native app with cross platform components and your tooling has made my life much easier.