### PR TITLE
[next] Revert to use ecma 5 in uglifyOptions

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -378,7 +378,7 @@ module.exports = {
     // Minify the code.
     new UglifyJsPlugin({
       uglifyOptions: {
-        ecma: 8,
+        ecma: 5,
         compress: {
           warnings: false,
           // Disabled because of an issue with Uglify breaking seemingly valid code:

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -378,7 +378,6 @@ module.exports = {
     // Minify the code.
     new UglifyJsPlugin({
       uglifyOptions: {
-        ecma: 5,
         compress: {
           warnings: false,
           // Disabled because of an issue with Uglify breaking seemingly valid code:

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -378,7 +378,15 @@ module.exports = {
     // Minify the code.
     new UglifyJsPlugin({
       uglifyOptions: {
+        parse: {
+          // we want uglify-js to parse ecma 8 code. However we want it to output
+          // ecma 5 compliant code, to avoid issues with older browsers, this is
+          // whey we put `ecma: 5` to the compress and output section
+          // https://github.com/facebook/create-react-app/pull/4234
+          ecma: 8,
+        },
         compress: {
+          ecma: 5,
           warnings: false,
           // Disabled because of an issue with Uglify breaking seemingly valid code:
           // https://github.com/facebook/create-react-app/issues/2376
@@ -390,6 +398,7 @@ module.exports = {
           safari10: true,
         },
         output: {
+          ecma: 5,
           comments: false,
           // Turned on because emoji and regex is not minified properly using default
           // https://github.com/facebook/create-react-app/issues/2488


### PR DESCRIPTION
Building my app using the [next] version of react-scripts lead to issues when trying to open the minified results on IE11.

It's a combination of using the [commonmark.js](https://github.com/commonmark/commonmark.js) library and using the `{ecma: 8}` in the uglifyOptions. That led to unicode characters in the output that can't be parsed by IE11. Also the Google crawler bot is yelling `Unexpected token ILLEGAL` at the resulting code.

Look here for another discussion about the same issue: https://github.com/rails/webpacker/issues/1235