### PR TITLE
Work around Jest environment resolving bug

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -51,6 +51,7 @@
     "promise": "8.0.1",
     "raf": "3.4.0",
     "react-dev-utils": "^5.0.0",
+    "resolve": "1.6.0",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.6.2",

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -24,7 +24,7 @@ process.on('unhandledRejection', err => {
 require('../config/env');
 
 const jest = require('jest');
-const argv = process.argv.slice(2);
+let argv = process.argv.slice(2);
 
 // Watch unless on CI or in coverage mode
 if (!process.env.CI && argv.indexOf('--coverage') < 0) {
@@ -46,5 +46,59 @@ argv.push(
     )
   )
 );
+
+// This is a very dirty workaround for https://github.com/facebook/jest/issues/5913.
+// We're trying to resolve the environment ourselves because Jest does it incorrectly.
+// TODO: remove this (and the `resolve` dependency) as soon as it's fixed in Jest.
+const resolve = require('resolve');
+function resolveJestDefaultEnvironment(name) {
+  const jestDir = path.dirname(
+    resolve.sync('jest', {
+      basedir: __dirname,
+    })
+  );
+  const jestCLIDir = path.dirname(
+    resolve.sync('jest-cli', {
+      basedir: jestDir,
+    })
+  );
+  const jestConfigDir = path.dirname(
+    resolve.sync('jest-config', {
+      basedir: jestCLIDir,
+    })
+  );
+  return resolve.sync(name, {
+    basedir: jestConfigDir,
+  });
+}
+let cleanArgv = [];
+let env = 'node';
+let next;
+do {
+  next = argv.shift();
+  if (next === '--env') {
+    env = argv.shift();
+  } else if (next.indexOf('--env=') === 0) {
+    env = next.substring('--env='.length);
+  } else {
+    cleanArgv.push(next);
+  }
+} while (argv.length > 0);
+argv = cleanArgv;
+let resolvedEnv;
+try {
+  resolvedEnv = resolveJestDefaultEnvironment(`jest-environment-${env}`);
+} catch (e) {
+  // ignore
+}
+if (!resolvedEnv) {
+  try {
+    resolvedEnv = resolveJestDefaultEnvironment(env);
+  } catch (e) {
+    // ignore
+  }
+}
+const testEnvironment = resolvedEnv || env;
+argv.push('--env', testEnvironment);
 // @remove-on-eject-end
 jest.run(argv);


### PR DESCRIPTION
This is a very hacky workaround for https://github.com/facebook/jest/issues/5913. I think we need this because it's actively breaking our users (https://github.com/okonet/lint-staged/issues/414) and is very tricky to debug.

cc @SimenB 