### PR TITLE
Enable loose mode for `class-properties`

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -92,8 +92,8 @@ module.exports = function(api, opts) {
       // don't work without it: https://github.com/babel/babel/issues/7215
       require('@babel/plugin-transform-destructuring').default,
       // class { handleClick = () => { } }
-      // Enable loose mode to use assignment instead of defineProperty, as some
-      // libraries add getters and setters to prototypes
+      // Enable loose mode to use assignment instead of defineProperty
+      // See discussion in https://github.com/facebook/create-react-app/issues/4263
       [
         require('@babel/plugin-proposal-class-properties').default,
         {

--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -92,7 +92,14 @@ module.exports = function(api, opts) {
       // don't work without it: https://github.com/babel/babel/issues/7215
       require('@babel/plugin-transform-destructuring').default,
       // class { handleClick = () => { } }
-      require('@babel/plugin-proposal-class-properties').default,
+      // Enable loose mode to use assignment instead of defineProperty, as some
+      // libraries add getters and setters to prototypes
+      [
+        require('@babel/plugin-proposal-class-properties').default,
+        {
+          loose: true,
+        },
+      ],
       // The following two plugins use Object.assign directly, instead of Babel's
       // extends helper. Note that this assumes `Object.assign` is available.
       // { ...todo, completed: true }


### PR DESCRIPTION
**Copying the contents of my MobX issue:**
After trying out the latest create-react-app and mobx 4's `decorate`, I found that my classes were no longer observable. At first glance, it looks like it's Babel 7's class property transform.

Here's a codesandbox: https://codesandbox.io/s/623qwprm8k
I'd expect the updated value of `FooBabel7` to trigger the `autorun`.

Differences in babel output:
Source:
```jsx
class Foo {
  value = 1;
}
```
Babel 6:
```jsx
class Foo {
  constructor() {
    this.value = 1;
  }
}
```
Babel 7:
```jsx
class Foo {
  constructor() {
    Object.defineProperty(this, "value", {
      configurable: true,
      enumerable: true,
      writable: true,
      value: 1
    });
  }
}
```

Enabling `loose` mode reverts the transform back to the Babel 6 behavior.

Simple before/after:
Current behavior:
![image](https://user-images.githubusercontent.com/73488/38266796-36408dbe-373f-11e8-9a72-85c600a7d466.png)

With `loose: true`:
![image](https://user-images.githubusercontent.com/73488/38266652-d6591b3c-373e-11e8-903b-d49ec31763f8.png)



Original MobX issue: https://github.com/mobxjs/mobx/issues/1471