### PR TITLE
Added learnstorybook.com to Storybook links

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1808,6 +1808,7 @@ Learn more about React Storybook:
 
 * [GitHub Repo](https://github.com/storybooks/storybook)
 * [Documentation](https://storybook.js.org/basics/introduction/)
+* [Learn Storybook (tutorial)](https://learnstorybook.com)
 * [Snapshot Testing UI](https://github.com/storybooks/storybook/tree/master/addons/storyshots) with Storybook + addon/storyshot
 
 ### Getting Started with Styleguidist


### PR DESCRIPTION
Learnstorybook is a tutorial for Storybook that both uses CRA and is at a level of introductionary detail appropriate for CRA users.
