### PR TITLE
`.mjs` should not resolve before .js files (#4085) (#4317)

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -53,12 +53,12 @@ module.exports = (resolve, rootDir, srcRoots) => {
     },
     moduleFileExtensions: [
       'web.js',
-      'mjs',
       'js',
       'json',
       'web.jsx',
       'jsx',
       'node',
+      'mjs',
     ],
   };
   if (rootDir) {


### PR DESCRIPTION
This has been merged to master, but I've cherrypicked it to next, so it goes into the next release. see #4317

Support for .mjs files added in #3239 did not account for npm libraries which ship native mjs files alongside js files. This accounts for this by ensuring .js files resolve before their accompanying .mjs file. Note that this is not an ideal end state since selecting a .mjs over a .js extension should be the result of whether `import` was used instead of `require()` in a node environment with native ESM support (currently via `--experimental-modules`). Instead, this change just *always* selects a .js extension before the .mjs extension if it exists.

This unbreaks support for using GraphQL (relay, apollo, etc) within create-react-app projects.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
