### PR TITLE
Bump `fsevents`.

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -75,7 +75,7 @@
     "react-dom": "^16.0.0"
   },
   "optionalDependencies": {
-    "fsevents": "1.1.3"
+    "fsevents": "1.2.0"
   },
   "browserslist": {
     "development": [


### PR DESCRIPTION
`fsevents@1.2.0` uses `node-pre-gyp@0.9.0`, which no longer uses an old version of `request`.  So the install size will be a bit smaller for Mac users.