### PR TITLE
[hot]fix broken css module support in prod

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -310,7 +310,7 @@ module.exports = {
           // Adds support for CSS Modules (https://github.com/css-modules/css-modules)
           // using the extension .module.css
           {
-            test: cssRegex,
+            test: cssModuleRegex,
             loader: getStyleLoaders({
               importLoaders: 1,
               minimize: true,


### PR DESCRIPTION
hot fix missmatch between .dev and .prod making css modules not matched correctly when building for production. 

long term fix will be to break out common config to seperate file to avoid missmatch.

