### PR TITLE
fix: update envinfo + implementation, update issue_template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -85,19 +85,18 @@
 ### Environment
 
 <!--
-  Please fill in all the relevant fields by running these commands in terminal.
+  To help identify if a problem is specific to a platform, browser, or module version, information about your environment is required.
+  This enables the maintainers quickly reproduce the issue and give feedback.
+
+  Run the following command in your react app's folder in terminal.
+  Note: The result is copied to your clipboard directly.
+
+  `npx create-react-app --info`
+
+  Paste the output of the command in the section below.
 -->
 
-1. `node -v`: 
-2. `npm -v`:
-3. `yarn --version` (if you use Yarn):
-4. `npm ls react-scripts` (if you haven’t ejected): 
-
-Then, specify:
-
-1. Operating system:
-2. Browser and version (if relevant):
-
+(paste the output of the command here)
 
 ### Steps to Reproduce
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -88,7 +88,7 @@
   To help identify if a problem is specific to a platform, browser, or module version, information about your environment is required.
   This enables the maintainers quickly reproduce the issue and give feedback.
 
-  Run the following command in your react app's folder in terminal.
+  Run the following command in your React app's folder in terminal.
   Note: The result is copied to your clipboard directly.
 
   `npx create-react-app --info`

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -128,7 +128,7 @@ if (program.info) {
       {
         System: ['OS', 'CPU'],
         Binaries: ['Node', 'npm', 'Yarn'],
-        Browsers: ['Chrome', 'Firefox', 'Safari'],
+        Browsers: ['Chrome', 'Edge', 'Internet Explorer', 'Firefox', 'Safari'],
         npmPackages: ['react', 'react-dom', 'react-scripts'],
         npmGlobalPackages: ['create-react-app'],
       },

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -121,15 +121,28 @@ const program = new commander.Command(packageJson.name)
   })
   .parse(process.argv);
 
+if (program.info) {
+  console.log(chalk.bold('\nEnvironment Info:'));
+  return envinfo
+    .run(
+      {
+        System: ['OS', 'CPU'],
+        Binaries: ['Node', 'npm', 'Yarn'],
+        Browsers: ['Chrome', 'Firefox', 'Safari'],
+        npmPackages: ['react', 'react-dom', 'react-scripts'],
+        npmGlobalPackages: ['create-react-app'],
+      },
+      {
+        clipboard: true,
+        duplicates: true,
+        showNotFound: true,
+      }
+    )
+    .then(console.log)
+    .then(() => console.log(chalk.green('Copied To Clipboard!\n')));
+}
+
 if (typeof projectName === 'undefined') {
-  if (program.info) {
-    envinfo.print({
-      packages: ['react', 'react-dom', 'react-scripts'],
-      noNativeIDE: true,
-      duplicates: true,
-    });
-    process.exit(0);
-  }
   console.error('Please specify the project directory:');
   console.log(
     `  ${chalk.cyan(program.name())} ${chalk.green('<project-directory>')}`

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -24,7 +24,7 @@
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "cross-spawn": "^4.0.0",
-    "envinfo": "3.4.2",
+    "envinfo": "5.2.0",
     "fs-extra": "^5.0.0",
     "hyperquest": "^2.1.2",
     "react-dev-utils": "^5.0.0",

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -24,7 +24,7 @@
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "cross-spawn": "^4.0.0",
-    "envinfo": "5.2.0",
+    "envinfo": "5.4.0",
     "fs-extra": "^5.0.0",
     "hyperquest": "^2.1.2",
     "react-dev-utils": "^5.0.0",


### PR DESCRIPTION
This PR fixes a few outstanding issues, and supersedes https://github.com/facebook/create-react-app/pull/3859 and https://github.com/facebook/create-react-app/pull/3797.

There were a couple issues with envinfo, and the issue template that never got resolved - this is my attempt to fix all of that. Also, envinfo has been rewritten for size and speed since originally integrated, and a few more features have been added. The command is the same `create-react-app --info`, but now returns more info, like this:

```
  System:
    OS: macOS High Sierra 10.13
    CPU: x64 Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
  Binaries:
    Node: 8.11.0 - ~/.nvm/versions/node/v8.11.0/bin/node
    Yarn: 1.5.1 - ~/.yarn/bin/yarn
    npm: 5.6.0 - ~/.nvm/versions/node/v8.11.0/bin/npm
  Browsers:
    Chrome: 65.0.3325.181
    Firefox: 59.0.2
    Safari: 11.0
  npmPackages:
    react: ^16.3.2 => 16.3.2 
    react-dom: ^16.3.2 => 16.3.2 
    react-scripts: 1.1.4 => 1.1.4 
  npmGlobalPackages:
    create-react-app: 1.5.2
```

<img width="864" alt="screen shot 2018-04-27 at 3 11 03 pm" src="https://user-images.githubusercontent.com/2925048/39381067-c9b75148-4a2e-11e8-8822-c7fac2f3ee3a.png">

Since you no longer recommend installing CRA (using via npx instead), also adding `npx envinfo --preset create-react-app` might be a faster option. envinfo is extremely light and fast via npx, and can be locked to a specific version - `npx envinfo@5.2.0 --preset create-react-app`, or just installed directly `yarn global add envinfo && envinfo --preset create-react-app` in the case of pre npm 5.2 installs. I can add this to the template upon request.

@bondz This may interest you. 
