### PR TITLE
Write manifest.json theme color to index.html on build

### DIFF
--- a/packages/react-dev-utils/setThemeColor.js
+++ b/packages/react-dev-utils/setThemeColor.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+var fs = require('fs');
+
+function setThemeColor(publicPath) {
+  const manifest = require(publicPath + '/manifest.json');
+  const themeColor = manifest.theme_color || '#000000';
+  const publicHtmlFile = publicPath + '/index.html';
+  fs.readFile(publicHtmlFile, 'utf8', function(err, data) {
+    if (err) {
+      return console.log(err);
+    }
+    var result = data.replace('#000000', themeColor);
+
+    fs.writeFile(publicHtmlFile, result, 'utf8', function(err) {
+      if (err) {
+        return console.log(err);
+      }
+    });
+  });
+}
+
+module.exports = setThemeColor;

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -41,6 +41,7 @@ const printHostingInstructions = require('react-dev-utils/printHostingInstructio
 const FileSizeReporter = require('react-dev-utils/FileSizeReporter');
 const printBuildError = require('react-dev-utils/printBuildError');
 const { printBrowsers } = require('react-dev-utils/browsersHelper');
+const setThemeColor = require('react-dev-utils/setThemeColor');
 
 const measureFileSizesBeforeBuild =
   FileSizeReporter.measureFileSizesBeforeBuild;
@@ -68,6 +69,7 @@ checkBrowsers(paths.appPath)
     // Remove all content but keep the directory so that
     // if you're in it, you don't end up in Trash
     fs.emptyDirSync(paths.appBuild);
+    setThemeColor(paths.appPublic);
     // Merge with the public folder
     copyPublicFolder();
     // Start the webpack build


### PR DESCRIPTION
This fixes issue #4325 - theme-color meta tag is inconsistent with manifest's theme-color.

I verified that my changes work through changing values in the manifest theme color and building the app.