### PR TITLE
Upgrade postcss-flexbug-fixes

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -52,7 +52,7 @@
     "jest": "22.4.1",
     "loader-utils": "^1.1.0",
     "object-assign": "4.1.1",
-    "postcss-flexbugs-fixes": "3.2.0",
+    "postcss-flexbugs-fixes": "3.3.1",
     "postcss-loader": "2.0.10",
     "promise": "8.0.1",
     "raf": "3.4.0",


### PR DESCRIPTION
This can safely be upgraded to the latest version as the regression introduced in `3.3.0` has been resolved.

https://github.com/luisrudge/postcss-flexbugs-fixes/blob/master/CHANGELOG.md#331