### PR TITLE
Update getCSSModuleLocalIdent to support Sass

### DIFF
--- a/packages/react-dev-utils/getCSSModuleLocalIdent.js
+++ b/packages/react-dev-utils/getCSSModuleLocalIdent.js
@@ -15,8 +15,10 @@ module.exports = function getLocalIdent(
   localName,
   options
 ) {
-  // Use the filename or folder name, based on some uses the index.js / index.module.css project style
-  const fileNameOrFolder = context.resourcePath.endsWith('index.module.css')
+  // Use the filename or folder name, based on some uses the index.js / index.module.(css|scss|sass) project style
+  const fileNameOrFolder = context.resourcePath.match(
+    /index\.module\.(css|scss|sass)$/
+  )
     ? '[folder]'
     : '[name]';
   // Create a hash based on a the file location and class name. Will be unique across a project, and close to globally unique.

--- a/packages/react-scripts/fixtures/kitchensink/integration/webpack.test.js
+++ b/packages/react-scripts/fixtures/kitchensink/integration/webpack.test.js
@@ -51,9 +51,9 @@ describe('Integration', () => {
         /.+scss-styles_scssModulesInclusion.+\{background:.+;color:.+}/
       );
       expect(
-        doc.getElementsByTagName('style')[0].textContent.replace(/\s/g, '')
+        doc.getElementsByTagName('style')[1].textContent.replace(/\s/g, '')
       ).to.match(
-        /.+assets_scssModulesIndexInclusion__.+\{background:.+;color:.+}/
+        /.+assets_scssModulesIndexInclusion.+\{background:.+;color:.+}/
       );
     });
 
@@ -74,9 +74,9 @@ describe('Integration', () => {
         /.+sass-styles_sassModulesInclusion.+\{background:.+;color:.+}/
       );
       expect(
-        doc.getElementsByTagName('style')[0].textContent.replace(/\s/g, '')
+        doc.getElementsByTagName('style')[1].textContent.replace(/\s/g, '')
       ).to.match(
-        /.+assets_sassModulesIndexInclusion__.+\{background:.+;color:.+}/
+        /.+assets_sassModulesIndexInclusion.+\{background:.+;color:.+}/
       );
     });
 

--- a/packages/react-scripts/fixtures/kitchensink/integration/webpack.test.js
+++ b/packages/react-scripts/fixtures/kitchensink/integration/webpack.test.js
@@ -50,6 +50,11 @@ describe('Integration', () => {
       ).to.match(
         /.+scss-styles_scssModulesInclusion.+\{background:.+;color:.+}/
       );
+      expect(
+        doc.getElementsByTagName('style')[0].textContent.replace(/\s/g, '')
+      ).to.match(
+        /.+assets_scssModulesIndexInclusion__.+\{background:.+;color:.+}/
+      );
     });
 
     it('sass inclusion', async () => {
@@ -67,6 +72,11 @@ describe('Integration', () => {
         doc.getElementsByTagName('style')[0].textContent.replace(/\s/g, '')
       ).to.match(
         /.+sass-styles_sassModulesInclusion.+\{background:.+;color:.+}/
+      );
+      expect(
+        doc.getElementsByTagName('style')[0].textContent.replace(/\s/g, '')
+      ).to.match(
+        /.+assets_sassModulesIndexInclusion__.+\{background:.+;color:.+}/
       );
     });
 

--- a/packages/react-scripts/fixtures/kitchensink/src/features/webpack/SassModulesInclusion.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/features/webpack/SassModulesInclusion.js
@@ -7,7 +7,13 @@
 
 import React from 'react';
 import styles from './assets/sass-styles.module.sass';
+import indexStyles from './assets/index.module.sass';
 
 export default () => (
-  <p className={styles.sassModulesInclusion}>SASS Modules are working!</p>
+  <div>
+    <p className={styles.sassModulesInclusion}>SASS Modules are working!</p>
+    <p className={indexStyles.sassModulesIndexInclusion}>
+      SASS Modules with index are working!
+    </p>
+  </div>
 );

--- a/packages/react-scripts/fixtures/kitchensink/src/features/webpack/ScssModulesInclusion.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/features/webpack/ScssModulesInclusion.js
@@ -7,7 +7,13 @@
 
 import React from 'react';
 import styles from './assets/scss-styles.module.scss';
+import indexStyles from './assets/index.module.scss';
 
 export default () => (
-  <p className={styles.scssModulesInclusion}>SCSS Modules are working!</p>
+  <div>
+    <p className={styles.scssModulesInclusion}>SCSS Modules are working!</p>
+    <p className={indexStyles.scssModulesIndexInclusion}>
+      SCSS Modules with index are working!
+    </p>
+  </div>
 );

--- a/packages/react-scripts/fixtures/kitchensink/src/features/webpack/assets/index.module.sass
+++ b/packages/react-scripts/fixtures/kitchensink/src/features/webpack/assets/index.module.sass
@@ -1,0 +1,4 @@
+.sassModulesIndexInclusion
+  background: darkblue
+  color: lightblue
+

--- a/packages/react-scripts/fixtures/kitchensink/src/features/webpack/assets/index.module.scss
+++ b/packages/react-scripts/fixtures/kitchensink/src/features/webpack/assets/index.module.scss
@@ -1,0 +1,4 @@
+.scssModulesIndexInclusion {
+  background: darkblue;
+  color: lightblue;
+}


### PR DESCRIPTION
I updated `react-dev-utils/getCSSModuleLocalIdent` to make the cases of `index.module.scss` and `index.module.sass` consistent with its behavior for `index.module.css`, meaning that all three should (approximately) output `[folder]_[localName]__[hash]` as their `localIdent`.

I also added tests to ensure this works correctly, but sadly I couldn't run them on my machine so I'll piggyback your CI.
