### PR TITLE
Map (s?css|sass) modules to identity-obj-proxy in jest

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -45,11 +45,11 @@ module.exports = (resolve, rootDir, srcRoots) => {
     },
     transformIgnorePatterns: [
       '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$',
-      '^.+\\.module\\.css$',
+      '^.+\\.module\\.(css|sass|scss)$',
     ],
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
-      '^.+\\.module\\.css$': 'identity-obj-proxy',
+      '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
     },
     moduleFileExtensions: [
       'web.js',


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Fixes https://github.com/facebook/create-react-app/issues/4345

SCSS and SASS modules currently aren't getting transformed, instead they are being resolved by the `fileTransform`. This PR instead sends them through the `identity-obj-proxy` so that:

```
<div className={style.container>...</div>
```
becomes
```
<div className="container">...</div>
```
when using `jest`.