### PR TITLE
Update the thread loader test in formatWebpackMessages

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -46,7 +46,7 @@ function formatMessage(message, isError) {
     if (threadLoaderIndex !== -1) {
       return;
     }
-    if (line.indexOf('from thread-loader (worker') !== -1) {
+    if (/thread.loader/i.test(line)) {
       threadLoaderIndex = index;
     }
   });


### PR DESCRIPTION
The fix done in #3847 is outdated, since thread-loader updated his error message, so now this happens:

![screen shot 2018-05-08 at 15 35 46](https://user-images.githubusercontent.com/7217420/39762074-07c38494-52da-11e8-909c-aed4966a03ad.png)

I updated the test so now it's more general.