### PR TITLE
ensureSlash: Fix accidental string-to-NaN coercion

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -23,7 +23,7 @@ const envPublicUrl = process.env.PUBLIC_URL;
 function ensureSlash(path, needsSlash) {
   const hasSlash = path.endsWith('/');
   if (hasSlash && !needsSlash) {
-    return path.substr(path, path.length - 1);
+    return path.substr(0, path.length - 1);
   } else if (!hasSlash && needsSlash) {
     return `${path}/`;
   } else {


### PR DESCRIPTION
Summary:
The `hasSlash` method uses `path.substr(path, path.length - 1)` to
remove the last character from `path`. Clearly, the first parameter is
suspect; it should be `0`. The code works as written, but only very
accidentally: the first parameter is coerced by `ToNumber` to `NaN`,
which is then coerced by `ToInteger` to `+0`, per [the spec][1].

[1]: https://www.ecma-international.org/ecma-262/6.0/#sec-string.prototype.substr

Test Plan:
Reading the spec should be sufficient. To verify in the Real World:
```js
const path = "has-slash-but-does-not-need-slash/"
const a = path.substr(path, path.length - 1);
const b = path.substr(0, path.length - 1);
console.log(a === b);  // true
console.log(a);        // has-slash-but-does-not-need-slash
```

wchargin-branch: ensureslash-accidental-coercion

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
