### PR TITLE
Update babel-plugin-macros to fix a bug

### DIFF
--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-env": "7.0.0-beta.46",
     "@babel/preset-flow": "7.0.0-beta.46",
     "@babel/preset-react": "7.0.0-beta.46",
-    "babel-plugin-macros": "2.0.0",
+    "babel-plugin-macros": "2.2.1",
     "babel-plugin-transform-dynamic-import": "2.0.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.12"
   }


### PR DESCRIPTION
Update babel-plugin-macros to 2.2.1. It fixes issue of macros not working with babel-plugin-istanbul e.g. when you run npm test --coverage in create-react-app based project

Reproducible demo of the bug https://github.com/stereobooster/babel-macro-issue

Discussion of bugfix is here https://github.com/kentcdodds/import-all.macro/issues/7