### PR TITLE
Update paths.js, rename shadow path variable

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -20,14 +20,14 @@ const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 
 const envPublicUrl = process.env.PUBLIC_URL;
 
-function ensureSlash(path, needsSlash) {
-  const hasSlash = path.endsWith('/');
+function ensureSlash(pathIn, needsSlash) {
+  const hasSlash = pathIn.endsWith('/');
   if (hasSlash && !needsSlash) {
-    return path.substr(0, path.length - 1);
+    return pathIn.substr(0, pathIn.length - 1);
   } else if (!hasSlash && needsSlash) {
-    return `${path}/`;
+    return `${pathIn}/`;
   } else {
-    return path;
+    return pathIn;
   }
 }
 

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -20,14 +20,14 @@ const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 
 const envPublicUrl = process.env.PUBLIC_URL;
 
-function ensureSlash(pathIn, needsSlash) {
-  const hasSlash = pathIn.endsWith('/');
+function ensureSlash(inputPath, needsSlash) {
+  const hasSlash = inputPath.endsWith('/');
   if (hasSlash && !needsSlash) {
-    return pathIn.substr(0, pathIn.length - 1);
+    return inputPath.substr(0, inputPath.length - 1);
   } else if (!hasSlash && needsSlash) {
-    return `${pathIn}/`;
+    return `${inputPath}/`;
   } else {
-    return pathIn;
+    return inputPath;
   }
 }
 


### PR DESCRIPTION
This file requires the "path" module and sets it to a variable `path`. The function `ensureSlash` also has a variable `path` that then shadows the `path` module.