### PR TITLE
Update svgr

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -60,7 +60,7 @@
     "resolve": "1.6.0",
     "sass-loader": "7.0.1",
     "style-loader": "0.19.1",
-    "svgr": "1.8.1",
+    "svgr": "1.9.2",
     "sw-precache-webpack-plugin": "0.11.4",
     "thread-loader": "1.1.2",
     "uglifyjs-webpack-plugin": "1.1.6",


### PR DESCRIPTION
Update svgr to 1.9.2. This update unpins the JSDOM dependency which should reduce our install size: https://github.com/facebook/create-react-app/issues/3880#issuecomment-388754478
