### PR TITLE
downgrade inquirer

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -50,7 +50,7 @@
     "global-modules": "1.0.0",
     "globby": "8.0.1",
     "gzip-size": "4.1.0",
-    "inquirer": "5.1.0",
+    "inquirer": "3.3.0",
     "is-root": "1.0.0",
     "opn": "5.3.0",
     "pkg-up": "2.0.0",


### PR DESCRIPTION
https://github.com/facebook/create-react-app/issues/3880#issuecomment-392097146

Basically removes rxjs dependency, which is around 18MB.
Tested yarn eject, yes/no.