### PR TITLE
Update usage for Serve 7

### DIFF
--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
+'use strict'
 
-const chalk = require('chalk');
-const url = require('url');
-const globalModules = require('global-modules');
-const fs = require('fs');
+const chalk = require('chalk')
+const url = require('url')
+const globalModules = require('global-modules')
+const fs = require('fs')
 
 function printHostingInstructions(
   appPackage,
@@ -21,26 +21,26 @@ function printHostingInstructions(
 ) {
   if (publicUrl && publicUrl.includes('.github.io/')) {
     // "homepage": "http://user.github.io/project"
-    const publicPathname = url.parse(publicPath).pathname;
-    const hasDeployScript = typeof appPackage.scripts.deploy !== 'undefined';
-    printBaseMessage(buildFolder, publicPathname);
+    const publicPathname = url.parse(publicPath).pathname
+    const hasDeployScript = typeof appPackage.scripts.deploy !== 'undefined'
+    printBaseMessage(buildFolder, publicPathname)
 
-    printDeployInstructions(publicUrl, hasDeployScript, useYarn);
+    printDeployInstructions(publicUrl, hasDeployScript, useYarn)
   } else if (publicPath !== '/') {
     // "homepage": "http://mywebsite.com/project"
-    printBaseMessage(buildFolder, publicPath);
+    printBaseMessage(buildFolder, publicPath)
   } else {
     // "homepage": "http://mywebsite.com"
     //   or no homepage
-    printBaseMessage(buildFolder, publicUrl);
+    printBaseMessage(buildFolder, publicUrl)
 
-    printStaticServerInstructions(buildFolder, useYarn);
+    printStaticServerInstructions(buildFolder, useYarn)
   }
-  console.log();
-  console.log('Find out more about deployment here:');
-  console.log();
-  console.log(`  ${chalk.yellow('http://bit.ly/CRA-deploy')}`);
-  console.log();
+  console.log()
+  console.log('Find out more about deployment here:')
+  console.log()
+  console.log(`  ${chalk.yellow('http://bit.ly/CRA-deploy')}`)
+  console.log()
 }
 
 function printBaseMessage(buildFolder, hostingLocation) {
@@ -48,79 +48,79 @@ function printBaseMessage(buildFolder, hostingLocation) {
     `The project was built assuming it is hosted at ${chalk.green(
       hostingLocation || 'the server root'
     )}.`
-  );
+  )
   console.log(
     `You can control this with the ${chalk.green(
       'homepage'
     )} field in your ${chalk.cyan('package.json')}.`
-  );
+  )
 
   if (!hostingLocation) {
-    console.log('For example, add this to build it for GitHub Pages:');
-    console.log();
+    console.log('For example, add this to build it for GitHub Pages:')
+    console.log()
 
     console.log(
       `  ${chalk.green('"homepage"')} ${chalk.cyan(':')} ${chalk.green(
         '"http://myname.github.io/myapp"'
       )}${chalk.cyan(',')}`
-    );
+    )
   }
-  console.log();
-  console.log(`The ${chalk.cyan(buildFolder)} folder is ready to be deployed.`);
+  console.log()
+  console.log(`The ${chalk.cyan(buildFolder)} folder is ready to be deployed.`)
 }
 
 function printDeployInstructions(publicUrl, hasDeployScript, useYarn) {
-  console.log(`To publish it at ${chalk.green(publicUrl)}, run:`);
-  console.log();
+  console.log(`To publish it at ${chalk.green(publicUrl)}, run:`)
+  console.log()
 
   // If script deploy has been added to package.json, skip the instructions
   if (!hasDeployScript) {
     if (useYarn) {
-      console.log(`  ${chalk.cyan('yarn')} add --dev gh-pages`);
+      console.log(`  ${chalk.cyan('yarn')} add --dev gh-pages`)
     } else {
-      console.log(`  ${chalk.cyan('npm')} install --save-dev gh-pages`);
+      console.log(`  ${chalk.cyan('npm')} install --save-dev gh-pages`)
     }
-    console.log();
+    console.log()
 
     console.log(
       `Add the following script in your ${chalk.cyan('package.json')}.`
-    );
-    console.log();
+    )
+    console.log()
 
-    console.log(`    ${chalk.dim('// ...')}`);
-    console.log(`    ${chalk.yellow('"scripts"')}: {`);
-    console.log(`      ${chalk.dim('// ...')}`);
+    console.log(`    ${chalk.dim('// ...')}`)
+    console.log(`    ${chalk.yellow('"scripts"')}: {`)
+    console.log(`      ${chalk.dim('// ...')}`)
     console.log(
       `      ${chalk.yellow('"predeploy"')}: ${chalk.yellow(
         '"npm run build",'
       )}`
-    );
+    )
     console.log(
       `      ${chalk.yellow('"deploy"')}: ${chalk.yellow(
         '"gh-pages -d build"'
       )}`
-    );
-    console.log('    }');
-    console.log();
+    )
+    console.log('    }')
+    console.log()
 
-    console.log('Then run:');
-    console.log();
+    console.log('Then run:')
+    console.log()
   }
-  console.log(`  ${chalk.cyan(useYarn ? 'yarn' : 'npm')} run deploy`);
+  console.log(`  ${chalk.cyan(useYarn ? 'yarn' : 'npm')} run deploy`)
 }
 
 function printStaticServerInstructions(buildFolder, useYarn) {
-  console.log('You may serve it with a static server:');
-  console.log();
+  console.log('You may serve it with a static server:')
+  console.log()
 
   if (!fs.existsSync(`${globalModules}/serve`)) {
     if (useYarn) {
-      console.log(`  ${chalk.cyan('yarn')} global add serve`);
+      console.log(`  ${chalk.cyan('yarn')} global add serve`)
     } else {
-      console.log(`  ${chalk.cyan('npm')} install -g serve`);
+      console.log(`  ${chalk.cyan('npm')} install -g serve`)
     }
   }
-  console.log(`  ${chalk.cyan('serve')} -s ${buildFolder}`);
+  console.log(`  ${chalk.cyan('serve')} ${buildFolder}`)
 }
 
-module.exports = printHostingInstructions;
+module.exports = printHostingInstructions

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -2092,16 +2092,10 @@ For environments using [Node](https://nodejs.org/), the easiest way to handle th
 
 ```sh
 npm install -g serve
-serve -s build
+serve build
 ```
 
-The last command shown above will serve your static site on the port **5000**. Like many of [serve](https://github.com/zeit/serve)’s internal settings, the port can be adjusted using the `-p` or `--port` flags.
-
-Run this command to get a full list of the options available:
-
-```sh
-serve -h
-```
+The last command shown above will serve your static site on the port **3000**.
 
 ### Other Solutions
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
[Serve](https://www.npmjs.com/package/serve) has some breaking changes. Most of the command line options including `-s` and `-p` have been removed or replaced with a config file. For the sake of simplicity I decided to remove info about non-defaults, but we could link to the docs on rewrite configs (which replace `-s`) somewhere: https://github.com/zeit/serve-handler#rewrites-array