### PR TITLE
Update FileSizeReporter.js

### DIFF
--- a/packages/react-dev-utils/FileSizeReporter.js
+++ b/packages/react-dev-utils/FileSizeReporter.js
@@ -99,7 +99,7 @@ function removeFileNameHash(buildFolder, fileName) {
   return fileName
     .replace(buildFolder, '')
     .replace(
-      /\/?(.*)(\.[0-9a-f]+)(\.chunk)?(\.js|\.css)/,
+      /\/?(.*)(\.[0-9a-f]+)?(\.chunk)?(\.js|\.css)/,
       (match, p1, p2, p3, p4) => p1 + p4
     );
 }


### PR DESCRIPTION
If I don't contain [hash] or [chunkhash] on output bundle file name,

this function(`removeFileNameHash`) return `/` include in front of result

for example,

parameters
buildFolder: `/resources/app/dist`
fileName: `/resources/app/dist/mobile-cs-center-v2/bundle.js`

return value
expected: `mobile-cs-center-v2/bundle.js`
result: `/mobile-cs-center-v2/bundle.js`

It's effect on `printFileSizesAfterBuild` function to print difference file size.

