### PR TITLE
Add configuration item

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -134,6 +134,7 @@ module.exports = {
             // Pending further investigation:
             // https://github.com/mishoo/UglifyJS2/issues/2011
             comparisons: false,
+            drop_console: true,
           },
           mangle: {
             safari10: true,


### PR DESCRIPTION

This can delete the presence of the test console in the project . Add uglifyjs-webpack-plugin configuration。eg: 'drop_console: true'. 