### PR TITLE
keep @preserve @license comments on Uglify

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -140,7 +140,7 @@ module.exports = {
           },
           output: {
             ecma: 5,
-            comments: false,
+            comments: true,
             // Turned on because emoji and regex is not minified properly using default
             // https://github.com/facebook/create-react-app/issues/2488
             ascii_only: true,

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -140,7 +140,7 @@ module.exports = {
           },
           output: {
             ecma: 5,
-            comments: true,
+            comments: "some",
             // Turned on because emoji and regex is not minified properly using default
             // https://github.com/facebook/create-react-app/issues/2488
             ascii_only: true,


### PR DESCRIPTION
Fix for this [issue](https://github.com/facebook/create-react-app/issues/4596)

Found the resolve with `output:` options of Uglify webpack plugin here [Uglify output options](https://github.com/mishoo/UglifyJS2/tree/harmony#output-options) and [implementation here](https://github.com/mishoo/UglifyJS2/blob/master/lib/output.js#L48)