### PR TITLE
Use yarn build command in predeploy script if using yarn

### DIFF
--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -92,7 +92,7 @@ function printDeployInstructions(publicUrl, hasDeployScript, useYarn) {
     console.log(`      ${chalk.dim('// ...')}`);
     console.log(
       `      ${chalk.yellow('"predeploy"')}: ${chalk.yellow(
-        '"npm run build",'
+        `"${useYarn ? 'yarn' : 'npm run'} build",`
       )}`
     );
     console.log(


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

This PR just changes the printed output when running `yarn build` with a homepage set in the `package.json` to show `yarn build` instead of `npm run build` for the predeploy command if using yarn.

This matches the rest of the output, which also displays the yarn commands.

**Changes:**
```
    // ...
    "scripts": {
      // ...
      "predeploy": “npm run build",
      "deploy": "gh-pages -d build"
    }
```
**To:**
```
    // ...
    "scripts": {
      // ...
      "predeploy": “yarn build",
      "deploy": "gh-pages -d build"
    }
```


Tested manually to check that it is working. Screenshot below:
<img width="442" alt="screenshot 2018-06-16 at 22 41 33" src="https://user-images.githubusercontent.com/5689874/41502642-8aef4b8c-71b6-11e8-9034-15f05676eca3.png">

