### PR TITLE
Eliminate regenerator from preset-react-app plugins

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -118,14 +118,6 @@ module.exports = function(api, opts, env) {
           removeImport: true,
         },
       ],
-      // function* () { yield 42; yield 43; }
-      !isEnvTest && [
-        require('@babel/plugin-transform-regenerator').default,
-        {
-          // Async functions are converted to generators by @babel/preset-env
-          async: false,
-        },
-      ],
       // Adds syntax support for import()
       require('@babel/plugin-syntax-dynamic-import').default,
       isEnvTest &&


### PR DESCRIPTION
Regenerator is already included by preset-env.

Fixes #4627

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
