### PR TITLE
Add instructions on alternative methods of app creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,25 +39,25 @@ Just create a project, and you’re good to go.
 To create a new app, you may choose one of the following methods:
 
 ### npx
+
 ```sh
 npx create-react-app my-app
 ```
 
 *([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))*
 
-### npm init
+### NPM
 
-Since npm of 6+ `npm init <name> <...args>` command may be used as an alias for `npx create-<name> <...args>`:
 ```sh
 npm init react-app my-app
 ```
-
-### yarn create
-Since v0.25.0 yarn has alias for `create-*` commands:
-
+*`npm init <initializer>` is available since npm 6+*
+### Yarn
 ```sh
 yarn create react-app my-app
 ```
+*`yarn create` command is available since Yarn 0.25+*
+
 ---
 It will create a directory called `my-app` inside the current folder.<br>
 Inside that directory, it will generate the initial project structure and install the transitive dependencies:

--- a/README.md
+++ b/README.md
@@ -36,14 +36,29 @@ Just create a project, and you’re good to go.
 
 **You’ll need to have Node >= 6 on your local development machine** (but it’s not required on the server). You can use [nvm](https://github.com/creationix/nvm#installation) (macOS/Linux) or [nvm-windows](https://github.com/coreybutler/nvm-windows#node-version-manager-nvm-for-windows) to easily switch Node versions between different projects.
 
-To create a new app, run a single command:
+To create a new app, you may choose one of the following methods:
 
+### npx
 ```sh
 npx create-react-app my-app
 ```
 
 *([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))*
 
+### npm init
+
+Since npm of 6+ `npm init <name> <...args>` command may be used as an alias for `npx create-<name> <...args>`:
+```sh
+npm init react-app my-app
+```
+
+### yarn create
+Since v0.25.0 yarn has alias for `create-*` commands:
+
+```sh
+yarn create react-app my-app
+```
+---
 It will create a directory called `my-app` inside the current folder.<br>
 Inside that directory, it will generate the initial project structure and install the transitive dependencies:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ npx create-react-app my-app
 npm init react-app my-app
 ```
 *`npm init <initializer>` is available since npm 6+*
+
 ### Yarn
 ```sh
 yarn create react-app my-app

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ npm init react-app my-app
 *`npm init <initializer>` is available since npm 6+*
 
 ### Yarn
+
 ```sh
 yarn create react-app my-app
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npx create-react-app my-app
 
 *([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))*
 
-### NPM
+### npm
 
 ```sh
 npm init react-app my-app
@@ -59,8 +59,6 @@ npm init react-app my-app
 yarn create react-app my-app
 ```
 *`yarn create` command is available since Yarn 0.25+*
-
----
 
 It will create a directory called `my-app` inside the current folder.<br>
 Inside that directory, it will generate the initial project structure and install the transitive dependencies:

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ npx create-react-app my-app
 ```sh
 npm init react-app my-app
 ```
-*`npm init <initializer>` is available since npm 6+*
+*`npm init <initializer>` is available in npm 6+*
 
 ### Yarn
 
 ```sh
 yarn create react-app my-app
 ```
-*`yarn create` command is available since Yarn 0.25+*
+*`yarn create` is available in Yarn 0.25+*
 
 It will create a directory called `my-app` inside the current folder.<br>
 Inside that directory, it will generate the initial project structure and install the transitive dependencies:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ yarn create react-app my-app
 *`yarn create` command is available since Yarn 0.25+*
 
 ---
+
 It will create a directory called `my-app` inside the current folder.<br>
 Inside that directory, it will generate the initial project structure and install the transitive dependencies:
 


### PR DESCRIPTION
Added instructions for:
- `npm init react-app <name>`
- `yarn create react-app <name>`


closes https://github.com/facebook/create-react-app/issues/4478