### PR TITLE
Add support for .mjs extension from dependencies (such as graphql)

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -225,7 +225,7 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
-                  poolTimeout: Infinity // keep workers alive for more effective watch mode
+                  poolTimeout: Infinity, // keep workers alive for more effective watch mode
                 },
               },
               {
@@ -266,7 +266,7 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
-                  poolTimeout: Infinity // keep workers alive for more effective watch mode
+                  poolTimeout: Infinity, // keep workers alive for more effective watch mode
                 },
               },
               {
@@ -282,6 +282,12 @@ module.exports = {
                 },
               },
             ],
+          },
+          // Process any dependencies using .mjs files such as graphql
+          {
+            test: /\.mjs$/,
+            include: /node_modules/,
+            type: 'javascript/auto',
           },
           // "postcss" loader applies autoprefixer to our CSS.
           // "css" loader resolves paths in CSS and adds assets as dependencies.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -309,6 +309,12 @@ module.exports = {
               },
             ],
           },
+          // Process any dependencies using .mjs files such as graphql
+          {
+            test: /\.mjs$/,
+            include: /node_modules/,
+            type: 'javascript/auto',
+          },
           // "postcss" loader applies autoprefixer to our CSS.
           // "css" loader resolves paths in CSS and adds assets as dependencies.
           // `MiniCSSExtractPlugin` extracts styles into CSS

--- a/packages/react-scripts/fixtures/kitchensink/integration/webpack.test.js
+++ b/packages/react-scripts/fixtures/kitchensink/integration/webpack.test.js
@@ -11,40 +11,43 @@ import url from 'url';
 
 const matchCSS = (doc, regexes) => {
   if (process.env.E2E_FILE) {
-      const elements = doc.getElementsByTagName('link');
-      let href = "";
-      for (const elem of elements) {
-        if (elem.rel === 'stylesheet') {
-          href = elem.href;
-        }
+    const elements = doc.getElementsByTagName('link');
+    let href = '';
+    for (const elem of elements) {
+      if (elem.rel === 'stylesheet') {
+        href = elem.href;
       }
-      resourceLoader(
-        { url: url.parse(href) },
-        (_, textContent) => {
-          for (const regex of regexes) {
-          expect(textContent).to.match(regex);
-          }
-        }
-      );
-    
+    }
+    resourceLoader({ url: url.parse(href) }, (_, textContent) => {
+      for (const regex of regexes) {
+        expect(textContent).to.match(regex);
+      }
+    });
   } else {
     for (let i = 0; i < regexes.length; ++i) {
-      expect(doc.getElementsByTagName('style')[i].textContent.replace(/\s/g, '')).to.match(regexes[i]);
+      expect(
+        doc.getElementsByTagName('style')[i].textContent.replace(/\s/g, '')
+      ).to.match(regexes[i]);
     }
   }
-}
+};
 
 describe('Integration', () => {
   describe('Webpack plugins', () => {
     it('css inclusion', async () => {
       const doc = await initDOM('css-inclusion');
-      matchCSS(doc, [/html\{/, /#feature-css-inclusion\{background:.+;color:.+}/]);
+      matchCSS(doc, [
+        /html\{/,
+        /#feature-css-inclusion\{background:.+;color:.+}/,
+      ]);
     });
 
     it('css modules inclusion', async () => {
       const doc = await initDOM('css-modules-inclusion');
-      matchCSS(doc, [/.+style_cssModulesInclusion__.+\{background:.+;color:.+}/,
-            /.+assets_cssModulesIndexInclusion__.+\{background:.+;color:.+}/]);
+      matchCSS(doc, [
+        /.+style_cssModulesInclusion__.+\{background:.+;color:.+}/,
+        /.+assets_cssModulesIndexInclusion__.+\{background:.+;color:.+}/,
+      ]);
     });
 
     it('scss inclusion', async () => {
@@ -54,9 +57,10 @@ describe('Integration', () => {
 
     it('scss modules inclusion', async () => {
       const doc = await initDOM('scss-modules-inclusion');
-      matchCSS(doc, [/.+scss-styles_scssModulesInclusion.+\{background:.+;color:.+}/,
-        /.+assets_scssModulesIndexInclusion.+\{background:.+;color:.+}/]);
-      
+      matchCSS(doc, [
+        /.+scss-styles_scssModulesInclusion.+\{background:.+;color:.+}/,
+        /.+assets_scssModulesIndexInclusion.+\{background:.+;color:.+}/,
+      ]);
     });
 
     it('sass inclusion', async () => {
@@ -66,8 +70,10 @@ describe('Integration', () => {
 
     it('sass modules inclusion', async () => {
       const doc = await initDOM('sass-modules-inclusion');
-      matchCSS(doc, [/.+sass-styles_sassModulesInclusion.+\{background:.+;color:.+}/,
-            /.+assets_sassModulesIndexInclusion.+\{background:.+;color:.+}/]);
+      matchCSS(doc, [
+        /.+sass-styles_sassModulesInclusion.+\{background:.+;color:.+}/,
+        /.+assets_sassModulesIndexInclusion.+\{background:.+;color:.+}/,
+      ]);
     });
 
     it('graphql files inclusion', async () => {
@@ -78,6 +84,12 @@ describe('Integration', () => {
       expect(children[0].textContent.replace(/\s/g, '')).to.equal(
         '{"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","variableDefinitions":[],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"test"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"test"},"value":{"kind":"StringValue","value":"test","block":false}}],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"test"},"arguments":[],"directives":[]}]}}]}}],"loc":{"start":0,"end":40,"source":{"body":"{\\ntest(test:\\"test\\"){\\ntest\\n}\\n}\\n","name":"GraphQLrequest","locationOffset":{"line":1,"column":1}}}}'
       );
+    });
+
+    it('ES .mjs files inclusion', async () => {
+      const doc = await initDOM('mjs-inclusion');
+      const text = doc.getElementById('mjs-inclusion__component').textContent;
+      expect(text).to.equal('.mjs support');
     });
 
     it('image inclusion', async () => {

--- a/packages/react-scripts/fixtures/kitchensink/src/App.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/App.js
@@ -28,7 +28,10 @@ class BuiltEmitter extends Component {
   }
 
   render() {
-    const { props: { feature }, handleReady } = this;
+    const {
+      props: { feature },
+      handleReady,
+    } = this;
     return (
       <div>
         {createElement(feature, {
@@ -133,6 +136,11 @@ class App extends Component {
         break;
       case 'graphql-inclusion':
         import('./features/webpack/GraphQLInclusion').then(f =>
+          this.setFeature(f.default)
+        );
+        break;
+      case 'mjs-inclusion':
+        import('./features/webpack/esModuleExtInclusion').then(f =>
           this.setFeature(f.default)
         );
         break;

--- a/packages/react-scripts/fixtures/kitchensink/src/features/webpack/assets/aComponentWithMJSExt.mjs
+++ b/packages/react-scripts/fixtures/kitchensink/src/features/webpack/assets/aComponentWithMJSExt.mjs
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default () => <div id='mjs-inclusion__component'>.mjs support</div>;

--- a/packages/react-scripts/fixtures/kitchensink/src/features/webpack/esModuleExtInclusion.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/features/webpack/esModuleExtInclusion.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Component from './assets/aComponentWithMJSExt';
+
+export default () => (
+  <p id="mjs-inclusion">
+    <Component />
+  </p>
+);

--- a/packages/react-scripts/fixtures/kitchensink/src/features/webpack/esModuleExtInclusion.test.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/features/webpack/esModuleExtInclusion.test.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import esModuleExtInclusion from './esModuleExtInclusion';
+
+describe('es module extension (.mjs) inclusion', () => {
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+    ReactDOM.render(<esModuleExtInclusion />, div);
+  });
+});


### PR DESCRIPTION
Here is the fix for supporting `.mjs` files from dependencies referenced here: https://github.com/facebook/create-react-app/issues/4637

I've verified the changes both before and after, here's the after screenshot:

![graphql loaded successfully](https://i.imgur.com/8HvvqJ1.png)

I tried writing some tests for the `.mjs` support but failed to get the e2e docker tests running on my local machine after following [this guide](https://github.com/facebook/create-react-app/blob/next/packages/react-scripts/fixtures/kitchensink/README.md) (was failing with user permissions?)

I'm hoping that CI will pick it up and run smoothly, if not I'd really appreciate some help in getting the tests to run locally :+1: