### PR TITLE
Fix code coverage for monorepos.

### DIFF
--- a/packages/react-dev-utils/workspaceUtils.js
+++ b/packages/react-dev-utils/workspaceUtils.js
@@ -31,7 +31,7 @@ const findPkgs = (rootPath, globPatterns) => {
 
 const findMonorepo = appDir => {
   const monoPkgPath = findPkg.sync(path.resolve(appDir, '..'));
-  const monoRootPath = path.dirname(monoPkgPath);
+  const monoRootPath = monoPkgPath && path.dirname(monoPkgPath);
   const monoPkg = monoPkgPath && require(monoPkgPath);
   const workspaces = monoPkg && monoPkg.workspaces;
   const patterns = (workspaces && workspaces.packages) || workspaces;

--- a/packages/react-dev-utils/workspaceUtils.js
+++ b/packages/react-dev-utils/workspaceUtils.js
@@ -31,11 +31,12 @@ const findPkgs = (rootPath, globPatterns) => {
 
 const findMonorepo = appDir => {
   const monoPkgPath = findPkg.sync(path.resolve(appDir, '..'));
+  const monoRootPath = path.dirname(monoPkgPath);
   const monoPkg = monoPkgPath && require(monoPkgPath);
   const workspaces = monoPkg && monoPkg.workspaces;
   const patterns = (workspaces && workspaces.packages) || workspaces;
   const isYarnWs = Boolean(patterns);
-  const allPkgs = patterns && findPkgs(path.dirname(monoPkgPath), patterns);
+  const allPkgs = patterns && findPkgs(monoRootPath, patterns);
   const isIncluded = dir => allPkgs && allPkgs.indexOf(dir) !== -1;
   const isAppIncluded = isIncluded(appDir);
   const pkgs = allPkgs
@@ -46,6 +47,7 @@ const findMonorepo = appDir => {
     isAppIncluded,
     isYarnWs,
     pkgs,
+    rootPath: monoRootPath,
   };
 };
 

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -126,6 +126,8 @@ if (checkForMonorepo) {
   const mono = findMonorepo(appDirectory);
   if (mono.isAppIncluded) {
     Array.prototype.push.apply(module.exports.srcPaths, mono.pkgs);
+    module.exports.isMonorepo = true;
+    module.exports.monorepoRoot = mono.rootPath;
   }
   module.exports.useYarn = module.exports.useYarn || mono.isYarnWs;
 }

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -107,7 +107,7 @@ inquirer
 
     // Prepare Jest config early in case it throws
     const jestConfig = createJestConfig(
-      filePath => path.posix.join('<rootDir>', filePath),
+      filePath => path.posix.join('.', filePath),
       null,
       paths.srcPaths
     );

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -21,6 +21,8 @@ module.exports = (resolve, rootDir, srcRoots) => {
 
   const toRelRootDir = f => '<rootDir>/' + path.relative(rootDir || '', f);
 
+  const resolveRelRoot = f => toRelRootDir(resolve(f));
+
   const setupTestsFile = fs.existsSync(paths.testsSetup)
     ? toRelRootDir(paths.testsSetup)
     : undefined;
@@ -31,7 +33,7 @@ module.exports = (resolve, rootDir, srcRoots) => {
     collectCoverageFrom: srcRoots
       .map(root => path.join(toRelRootDir(root), '**/*.{js,jsx,mjs}'))
       .concat(['!**/build*/**']),
-    setupFiles: [resolve('config/polyfills.js')],
+    setupFiles: [resolveRelRoot('config/polyfills.js')],
     setupTestFrameworkScriptFile: setupTestsFile,
     testMatch: [
       '**/__tests__/**/*.{js,jsx,mjs}',
@@ -42,10 +44,10 @@ module.exports = (resolve, rootDir, srcRoots) => {
     testEnvironment: 'node',
     testURL: 'http://localhost',
     transform: {
-      '^.+\\.(js|jsx|mjs)$': resolve('config/jest/babelTransform.js'),
-      '^.+\\.css$': resolve('config/jest/cssTransform.js'),
-      '^.+\\.(graphql)$': resolve('config/jest/graphqlTransform.js'),
-      '^(?!.*\\.(js|jsx|mjs|css|json|graphql)$)': resolve(
+      '^.+\\.(js|jsx|mjs)$': resolveRelRoot('config/jest/babelTransform.js'),
+      '^.+\\.css$': resolveRelRoot('config/jest/cssTransform.js'),
+      '^.+\\.(graphql)$': resolveRelRoot('config/jest/graphqlTransform.js'),
+      '^(?!.*\\.(js|jsx|mjs|css|json|graphql)$)': resolveRelRoot(
         'config/jest/fileTransform.js'
       ),
     },


### PR DESCRIPTION
Previously, source files from outside the app were not included in the coverage report.

Fixes: #4645