### PR TITLE
Fix error with formatWebpackMessages trimming warnings

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -26,11 +26,13 @@ function isLikelyASyntaxError(message) {
 function formatMessage(message, isError) {
   var lines = message.split('\n');
 
-  // Remove the useless Module Warning or Module Error message webpack sometimes outputs
+  // Remove the useless Module Warning or Module Error message webpack sometimes outputs,
+  // it interferes with the thread loader stack clipping of the next few lines
   if (
     lines.length > 2 &&
     (lines[1].indexOf('Module Warning') !== -1 ||
-      lines[1].indexOf('Module Error') !== -1)
+      lines[1].indexOf('Module Error') !== -1 ||
+      /thread.loader/i.test(lines[1]))
   ) {
     lines.splice(1, 1);
   }

--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -26,6 +26,11 @@ function isLikelyASyntaxError(message) {
 function formatMessage(message, isError) {
   var lines = message.split('\n');
 
+  // Remove the useless Module Warning message webpack sometimes outputs
+  if (lines.length > 2 && lines[1].indexOf('Module Warning') !== -1) {
+    lines.splice(1, 1);
+  }
+
   if (lines.length > 2 && lines[1] === '') {
     // Remove extra newline.
     lines.splice(1, 1);

--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -37,8 +37,13 @@ function formatMessage(message, isError) {
     lines.splice(1, 1);
   }
 
+  // Remove other thread-loader noise
+  if (lines.length > 2 && /thread.loader/i.test(lines[1])) {
+    lines.splice(1, 1);
+  }
+
+  // Remove extra newline.
   if (lines.length > 2 && lines[1] === '') {
-    // Remove extra newline.
     lines.splice(1, 1);
   }
 

--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -26,8 +26,12 @@ function isLikelyASyntaxError(message) {
 function formatMessage(message, isError) {
   var lines = message.split('\n');
 
-  // Remove the useless Module Warning message webpack sometimes outputs
-  if (lines.length > 2 && lines[1].indexOf('Module Warning') !== -1) {
+  // Remove the useless Module Warning or Module Error message webpack sometimes outputs
+  if (
+    lines.length > 2 &&
+    (lines[1].indexOf('Module Warning') !== -1 ||
+      lines[1].indexOf('Module Error') !== -1)
+  ) {
     lines.splice(1, 1);
   }
 


### PR DESCRIPTION
Hey, I've been using the updated react-dev-utils and found a bug in formatWebpackMessages that happens with newer webpack versions.

Basically webpack (or the thread-loader) in the `stats.toJson().warnings` now outputs also this line, containing a [Module Warning](https://github.com/webpack/webpack/blob/master/lib/ModuleWarning.js) or [Module Error](https://github.com/webpack/webpack/blob/master/lib/ModuleError.js) (?):
```
Module Warning (from ./node_modules/thread-loader/dist/cjs.js):
```
so the [`lines`](https://github.com/facebook/create-react-app/blob/e1ee8032a89eabf58cd45ca539fac9ab0c0689be/packages/react-dev-utils/formatWebpackMessages.js#L27) array now becomes this (see second line):

<img width="718" alt="screen shot 2018-06-20 at 19 02 19" src="https://user-images.githubusercontent.com/7217420/41673976-dd6a629c-74be-11e8-99ca-ffe4eb95a17c.png">
 
instead of the old one

<img width="773" alt="screen shot 2018-06-20 at 19 02 32" src="https://user-images.githubusercontent.com/7217420/41674034-0eab63c4-74bf-11e8-949c-9a2f09a2b030.png">

This fucks with the [thread-loader message remover](https://github.com/facebook/create-react-app/blob/e1ee8032a89eabf58cd45ca539fac9ab0c0689be/packages/react-dev-utils/formatWebpackMessages.js#L55) and actually removes the body of the warning.

This PR checks if that line is present and removes it since it's not relevant to the user.
