### PR TITLE
add direction attribute to html

### DIFF
--- a/packages/react-scripts/template/public/index.html
+++ b/packages/react-scripts/template/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
It helps automating styles between LTR and RTL if you have something like *postcss-rtl* or something similar.

If this attribute is missing the styles won't work, unless somebody figure out they have the dir="ltr" missing on the html tag at the top.