### PR TITLE
Simplify ensureSlash

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -20,14 +20,11 @@ const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 
 const envPublicUrl = process.env.PUBLIC_URL;
 
-function ensureSlash(inputPath, needsSlash) {
-  const hasSlash = inputPath.endsWith('/');
-  if (hasSlash && !needsSlash) {
-    return inputPath.substr(0, inputPath.length - 1);
-  } else if (!hasSlash && needsSlash) {
-    return `${inputPath}/`;
+function ensureSlash(path) {
+  if (path.endsWith("/")) {
+    return path;
   } else {
-    return inputPath;
+    return `${path}/`;
   }
 }
 
@@ -44,7 +41,7 @@ function getServedPath(appPackageJson) {
   const publicUrl = getPublicUrl(appPackageJson);
   const servedUrl =
     envPublicUrl || (publicUrl ? url.parse(publicUrl).pathname : '/');
-  return ensureSlash(servedUrl, true);
+  return ensureSlash(servedUrl);
 }
 
 // config after eject: we're in ./config/


### PR DESCRIPTION
### Goal of the PR
The goal of this PR is to simplify the ensureSlash method in `react-scripts/config/paths.js` as the `needsSlash` parameter was never used.

Maybe if you need a function that ensures a trailing slash and one that always removes the trailing slash, it would be better to have 2 functions instead of passing a boolean.

### Testing
This method is quite small, I would suggest to test it directly.