### PR TITLE
Fix CI error (kitchensink)

### DIFF
--- a/packages/react-scripts/fixtures/kitchensink/.template.dependencies.json
+++ b/packages/react-scripts/fixtures/kitchensink/.template.dependencies.json
@@ -5,7 +5,7 @@
     "@babel/register": "7.0.0-beta.46",
     "bootstrap": "4.1.0",
     "chai": "3.5.0",
-    "jsdom": "9.8.3",
+    "jsdom": "11.11.0",
     "mocha": "3.2.0",
     "node-sass": "4.8.3",
     "normalize.css": "7.0.0",

--- a/packages/react-scripts/fixtures/kitchensink/integration/initDOM.js
+++ b/packages/react-scripts/fixtures/kitchensink/integration/initDOM.js
@@ -7,9 +7,14 @@
 
 const fs = require('fs');
 const http = require('http');
-const jsdom = require('jsdom');
 const path = require('path');
 const { expect } = require('chai');
+let jsdom;
+try {
+  jsdom = require("jsdom/lib/old-api.js"); // jsdom >= 10.x
+} catch (e) {
+  jsdom = require("jsdom"); // jsdom <= 9.x
+}
 
 let getMarkup;
 export let resourceLoader;


### PR DESCRIPTION
#4635 i referenced this issue
1. i fixed ci error by version up jsdom. i found **kichensink's jsdom version was outdated(9.8.3)**. so I versioned up to latest what can fix ci error 

(after jsdom 11.6.0, Error: Could not parse CSS stylesheet issue was solved)
I referenced this url. By this issue fixed, jsdom was version up. so i resolved error by version up jsdom :)
**https://github.com/jsdom/jsdom/issues/2131**

2. when i fixed #4635  i found latest jsdom has **TypeError: jsdom.createVirtualConsole is not a **functio**n**(deprecated) error, so i referenced https://github.com/jsdom/jsdom/issues/1820, i solved the issue.