### PR TITLE
Suggest `reactstrap` instead of `react-bootstrap`

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -774,6 +774,14 @@ Alternatively you may use `yarn`:
 yarn add bootstrap@4 reactstrap 
 ```
 
+Import Bootstrap CSS and optionally Bootstrap theme CSS in the beginning of your ```src/index.js``` file:
+
+```js
+import 'bootstrap/dist/css/bootstrap.min.css';
+// Put any other imports below so that CSS from your
+// components takes precedence over default styles.
+```
+
 Import required Reactstrap components within ```src/App.js``` file or your custom component files:
 
 ```js

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -777,7 +777,7 @@ yarn add bootstrap@4 reactstrap
 Import Bootstrap CSS and optionally Bootstrap theme CSS in the beginning of your ```src/index.js``` file:
 
 ```js
-import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap/dist/css/bootstrap.css';
 // Put any other imports below so that CSS from your
 // components takes precedence over default styles.
 ```

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -782,7 +782,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 // components takes precedence over default styles.
 ```
 
-Import required Reactstrap components within ```src/App.js``` file or your custom component files:
+Import required reactstrap components within ```src/App.js``` file or your custom component files:
 
 ```js
 import { Button } from 'reactstrap';

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -760,36 +760,36 @@ Alternatively, you can force the linter to ignore any line by adding `// eslint-
 
 ## Adding Bootstrap
 
-You don’t have to use [React Bootstrap](https://react-bootstrap.github.io) together with React but it is a popular library for integrating Bootstrap with React apps. If you need it, you can integrate it with Create React App by following these steps:
+You don’t have to use [reactstrap](https://reactstrap.github.io/) together with React but it is a popular library for integrating Bootstrap with React apps. If you need it, you can integrate it with Create React App by following these steps:
 
-Install React Bootstrap and Bootstrap from npm. React Bootstrap does not include Bootstrap CSS so this needs to be installed as well:
+Install  reactstrap and Bootstrap from npm. reactstrap does not include Bootstrap CSS so this needs to be installed as well:
 
 ```sh
-npm install --save react-bootstrap bootstrap@3
+npm install bootstrap --save
+npm install --save reactstrap react react-dom
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add react-bootstrap bootstrap@3
+yarn add bootstrap reactstrap react react-dom
 ```
 
 Import Bootstrap CSS and optionally Bootstrap theme CSS in the beginning of your ```src/index.js``` file:
 
 ```js
-import 'bootstrap/dist/css/bootstrap.css';
-import 'bootstrap/dist/css/bootstrap-theme.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 // Put any other imports below so that CSS from your
 // components takes precedence over default styles.
 ```
 
-Import required React Bootstrap components within ```src/App.js``` file or your custom component files:
+Import required Reactstrap components within ```src/App.js``` file or your custom component files:
 
 ```js
-import { Navbar, Jumbotron, Button } from 'react-bootstrap';
+import { Button } from 'reactstrap';
 ```
 
-Now you are ready to use the imported React Bootstrap components within your component hierarchy defined in the render method. Here is an example [`App.js`](https://gist.githubusercontent.com/gaearon/85d8c067f6af1e56277c82d19fd4da7b/raw/6158dd991b67284e9fc8d70b9d973efe87659d72/App.js) redone using React Bootstrap.
+Now you are ready to use the imported Reactstrap components within your component hierarchy defined in the render method. Here is an example [`App.js`](https://gist.githubusercontent.com/zx6658/d9f128cd57ca69e583ea2b5fea074238/raw/a56701c142d0c622eb6c20a457fbc01d708cb485/App.js) redone using Reactstrap.
 
 ### Using a Custom Theme
 

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -765,22 +765,13 @@ You don’t have to use [reactstrap](https://reactstrap.github.io/) together wit
 Install  reactstrap and Bootstrap from npm. reactstrap does not include Bootstrap CSS so this needs to be installed as well:
 
 ```sh
-npm install bootstrap --save
-npm install --save reactstrap react react-dom
+npm install --save reactstrap bootstrap@4
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add bootstrap reactstrap react react-dom
-```
-
-Import Bootstrap CSS and optionally Bootstrap theme CSS in the beginning of your ```src/index.js``` file:
-
-```js
-import 'bootstrap/dist/css/bootstrap.min.css';
-// Put any other imports below so that CSS from your
-// components takes precedence over default styles.
+yarn add bootstrap@4 reactstrap 
 ```
 
 Import required Reactstrap components within ```src/App.js``` file or your custom component files:
@@ -789,7 +780,7 @@ Import required Reactstrap components within ```src/App.js``` file or your custo
 import { Button } from 'reactstrap';
 ```
 
-Now you are ready to use the imported Reactstrap components within your component hierarchy defined in the render method. Here is an example [`App.js`](https://gist.githubusercontent.com/zx6658/d9f128cd57ca69e583ea2b5fea074238/raw/a56701c142d0c622eb6c20a457fbc01d708cb485/App.js) redone using Reactstrap.
+Now you are ready to use the imported reactstrap components within your component hierarchy defined in the render method. Here is an example [`App.js`](https://gist.githubusercontent.com/zx6658/d9f128cd57ca69e583ea2b5fea074238/raw/a56701c142d0c622eb6c20a457fbc01d708cb485/App.js) redone using reactstrap.
 
 ### Using a Custom Theme
 


### PR DESCRIPTION
I thought it would be great to recommend Reactstrap for now, instead of react-bootstrap. :)