### PR TITLE
Expose `reportRuntimeError`

### DIFF
--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -6,7 +6,10 @@
  */
 
 /* @flow */
-import { listenToRuntimeErrors } from './listenToRuntimeErrors';
+import {
+  listenToRuntimeErrors,
+  crashWithFrames,
+} from './listenToRuntimeErrors';
 import { iframeStyle } from './styles';
 import { applyStyles } from './utils/dom/css';
 
@@ -45,6 +48,14 @@ export function setEditorHandler(handler: EditorHandler | null) {
 export function reportBuildError(error: string) {
   currentBuildError = error;
   update();
+}
+
+export function reportRuntimeError(
+  error: Error,
+  options?: RuntimeReportingOption = {}
+) {
+  currentRuntimeErrorOptions = options;
+  crashWithFrames(handleRuntimeError)(error);
 }
 
 export function dismissBuildError() {

--- a/packages/react-error-overlay/src/listenToRuntimeErrors.js
+++ b/packages/react-error-overlay/src/listenToRuntimeErrors.js
@@ -37,34 +37,40 @@ export type ErrorRecord = {|
   stackFrames: StackFrame[],
 |};
 
+export const crashWithFrames = (crash: ErrorRecord => void) => (
+  error: Error,
+  unhandledRejection = false
+) => {
+  getStackFrames(error, unhandledRejection, CONTEXT_SIZE)
+    .then(stackFrames => {
+      if (stackFrames == null) {
+        return;
+      }
+      crash({
+        error,
+        unhandledRejection,
+        contextSize: CONTEXT_SIZE,
+        stackFrames,
+      });
+    })
+    .catch(e => {
+      console.log('Could not get the stack frames of error:', e);
+    });
+};
+
 export function listenToRuntimeErrors(
   crash: ErrorRecord => void,
   filename: string = '/static/js/bundle.js'
 ) {
-  function crashWithFrames(error: Error, unhandledRejection = false) {
-    getStackFrames(error, unhandledRejection, CONTEXT_SIZE)
-      .then(stackFrames => {
-        if (stackFrames == null) {
-          return;
-        }
-        crash({
-          error,
-          unhandledRejection,
-          contextSize: CONTEXT_SIZE,
-          stackFrames,
-        });
-      })
-      .catch(e => {
-        console.log('Could not get the stack frames of error:', e);
-      });
-  }
-  registerError(window, error => crashWithFrames(error, false));
-  registerPromise(window, error => crashWithFrames(error, true));
+  const crashWithFramesRunTime = crashWithFrames(crash);
+
+  registerError(window, error => crashWithFramesRunTime(error, false));
+  registerPromise(window, error => crashWithFramesRunTime(error, true));
   registerStackTraceLimit();
   registerReactStack();
   permanentRegisterConsole('error', (warning, stack) => {
     const data = massageWarning(warning, stack);
-    crashWithFrames(
+    crashWithFramesRunTime(
       // $FlowFixMe
       {
         message: data.message,


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Enables calling `reportRuntimeError` to display a full stack trace.

* factor out crashWithFrames 
* expose reportRuntimeError

closes #4705 

My Usage:

```js
{
	onError: e => reportRuntimeError(e)
}
```

Result:

<img width="577" alt="screen shot 2018-06-29 at 11 03 14 pm" src="https://user-images.githubusercontent.com/1192452/42122048-a4d5a912-7bf0-11e8-87df-28776f44a90a.png">

