### PR TITLE
Fix formatMessage wrongly filtering warning messages

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -41,19 +41,9 @@ function formatMessage(message, isError) {
   }
 
   // Remove unnecessary stack added by `thread-loader`
-  var threadLoaderIndex = -1;
-  lines.forEach(function(line, index) {
-    if (threadLoaderIndex !== -1) {
-      return;
-    }
-    if (/thread.loader/i.test(line)) {
-      threadLoaderIndex = index;
-    }
+  lines = lines.filter(function(line) {
+    return /thread.loader/i.test(line) === false;
   });
-
-  if (threadLoaderIndex !== -1) {
-    lines = lines.slice(0, threadLoaderIndex);
-  }
 
   lines = lines.filter(function(line) {
     // Webpack adds a list of entry points to warning messages:


### PR DESCRIPTION
If a webpack warning message is present with a line:

"Module Warning (from ./node_modules/thread-loader/dist/cjs.js):"

The formatMessage function was wrongly slicing the warning message.

This fix filters out the lines as initially intended and keeps the
remaining warning message to output correctly.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
