### PR TITLE
Fix typo

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -2613,7 +2613,7 @@ import moment from 'moment';
 import 'moment/locale/fr';
 ```
 
-If import multiple locales this way, you can later switch between them by calling `moment.locale()` with the locale name:
+If you are importing multiple locales this way, you can later switch between them by calling `moment.locale()` with the locale name:
 
 ```js
 import moment from 'moment';


### PR DESCRIPTION
This PR fixes a small typo in the `react-scripts` `template` `README.md`