### PR TITLE
Use same executable for spawn as the current process

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -42,7 +42,7 @@ function getBrowserEnv() {
 
 function executeNodeScript(scriptPath, url) {
   const extraArgs = process.argv.slice(2);
-  const child = spawn('node', [scriptPath, ...extraArgs, url], {
+  const child = spawn(process.execPath, [scriptPath, ...extraArgs, url], {
     stdio: 'inherit',
   });
   child.on('close', code => {

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -30,7 +30,7 @@ switch (script) {
   case 'start':
   case 'test': {
     const result = spawn.sync(
-      'node',
+      process.execPath,
       nodeArgs
         .concat(require.resolve('../scripts/' + script))
         .concat(args.slice(scriptIndex + 1)),


### PR DESCRIPTION
When starting a react-script from a node process which is not in the
path, the scripts would spawn the wrong node executable, or even fail.
This can happen when starting node with an absolute path, for instance
in a Bazel build.

Changes verified by both creating a new project, building and running it, and
also by applying the same changes in another internal project -- this fixed
our Bazel build issue.