### PR TITLE
check the yarn globle modules if useYarn

### DIFF
--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -11,6 +11,7 @@ const chalk = require('chalk');
 const url = require('url');
 const globalModules = require('global-modules');
 const fs = require('fs');
+const execSync = require('child_process').execSync;
 
 function printHostingInstructions(
   appPackage,
@@ -113,12 +114,13 @@ function printStaticServerInstructions(buildFolder, useYarn) {
   console.log('You may serve it with a static server:');
   console.log();
 
-  if (!fs.existsSync(`${globalModules}/serve`)) {
-    if (useYarn) {
+  if (useYarn) {
+    const yarnGlobalDir = execSync('yarn global dir').toString().replace('\n','');
+    if (!fs.existsSync(`${yarnGlobalModules}/node_modules/serve`)) {
       console.log(`  ${chalk.cyan('yarn')} global add serve`);
-    } else {
-      console.log(`  ${chalk.cyan('npm')} install -g serve`);
     }
+  } else if (!fs.existsSync(`${globalModules}/serve`)) {
+    console.log(`  ${chalk.cyan('npm')} install -g serve`);
   }
   console.log(`  ${chalk.cyan('serve')} -s ${buildFolder}`);
 }

--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -116,7 +116,7 @@ function printStaticServerInstructions(buildFolder, useYarn) {
 
   if (useYarn) {
     const yarnGlobalDir = execSync('yarn global dir').toString().replace('\n','');
-    if (!fs.existsSync(`${yarnGlobalModules}/node_modules/serve`)) {
+    if (!fs.existsSync(`${yarnGlobalDir}/node_modules/serve`)) {
       console.log(`  ${chalk.cyan('yarn')} global add serve`);
     }
   } else if (!fs.existsSync(`${globalModules}/serve`)) {


### PR DESCRIPTION
'global-modules' can only get the global packages installed by npm:
 https://www.npmjs.com/package/global-modules

get the current global modues installed by yarn:
 https://github.com/yarnpkg/yarn/issues/2049#issuecomment-337870443

Since the global module dir is different with yarn and npm, we should check the corresponding global modules dir if use yarn.