### PR TITLE
Bump babel-loader to fix npm warning

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -27,7 +27,7 @@
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "8.2.3",
     "babel-jest": "22.4.3",
-    "babel-loader": "8.0.0-beta.0",
+    "babel-loader": "8.0.0-beta.4",
     "babel-plugin-named-asset-import": "^0.1.0",
     "babel-preset-react-app": "^3.1.1",
     "bfj": "5.2.0",


### PR DESCRIPTION
No more:
```bash
warning "react-scripts > babel-loader@8.0.0-beta.0" has incorrect peer dependency "webpack@2 || 3".
```