### PR TITLE
Fix eqeqeq lint rule to allow nulls

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -112,7 +112,7 @@ module.exports = {
     'array-callback-return': 'warn',
     'default-case': ['warn', { commentPattern: '^no default$' }],
     'dot-location': ['warn', 'property'],
-    eqeqeq: ['warn', 'allow-null'],
+    eqeqeq: ["warn", "always", {"null": "ignore"}],
     'new-parens': 'warn',
     'no-array-constructor': 'warn',
     'no-caller': 'warn',


### PR DESCRIPTION
Fixes #4807

Replaced the deprecated option following https://eslint.org/docs/rules/eqeqeq