### PR TITLE
Add onOffline/onError callbacks in serviceWorker.js (next)

### DIFF
--- a/packages/react-scripts/template/src/serviceWorker.js
+++ b/packages/react-scripts/template/src/serviceWorker.js
@@ -88,6 +88,11 @@ function registerValidSW(swUrl, config) {
     })
     .catch(error => {
       console.error('Error during service worker registration:', error);
+
+      // Execute callback
+      if (config.onError) {
+        config.onError(error);
+      }
     });
 }
 
@@ -115,6 +120,11 @@ function checkValidServiceWorker(swUrl, config) {
       console.log(
         'No internet connection found. App is running in offline mode.'
       );
+
+      // Execute callback
+      if (config.onOffline) {
+        config.onOffline();
+      }
     });
 }
 


### PR DESCRIPTION
Hello,

i added onOffline and onError callback to the serviceWorker.js

They are useful ie. to display user message when in offline 
and ie. to log the error on serviceWorker register fail.
