### PR TITLE
Change severity of no-restricted-globals to warn

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -116,7 +116,7 @@ module.exports = {
     'no-this-before-super': 'warn',
     'no-throw-literal': 'warn',
     'no-undef': 'error',
-    'no-restricted-globals': ['error'].concat(restrictedGlobals),
+    'no-restricted-globals': ['warn'].concat(restrictedGlobals),
     'no-unexpected-multiline': 'warn',
     'no-unreachable': 'warn',
     'no-unused-expressions': [


### PR DESCRIPTION
Sometimes, it is intended to access browser globals like `location`, so we change the severity of this rule to `warn` which allows the app to still start in presence of such an lint issue.