### PR TITLE
Replace workspaceRoot with workspaceFolder

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -281,7 +281,7 @@ Then add the block below to your `launch.json` file and put it inside the `.vsco
     "type": "chrome",
     "request": "launch",
     "url": "http://localhost:3000",
-    "webRoot": "${workspaceRoot}/src",
+    "webRoot": "${workspaceFolder}",
     "sourceMapPathOverrides": {
       "webpack:///src/*": "${webRoot}/*"
     }


### PR DESCRIPTION
Updated VS Code launch.json configuration settings so that interactive debugging can be initiated from the debugger menu.

The variable workspaceRoot has been deprecated in favor of workspaceFolder, as per the VS Code website:
https://code.visualstudio.com/docs/editor/variables-reference
>Q: Why isn't ${workspaceRoot} documented?
>A: The variable ${workspaceRoot} was deprecated in favor of ${workspaceFolder} to better align with Multi-root Workspace support.

I confirmed the new configuration as you can see in the screenshot.

![image](https://user-images.githubusercontent.com/1802850/43621600-41e7e402-968d-11e8-8665-36f7a44c1de5.png)
