### PR TITLE
test for gql files in graphql-tag/loader

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -225,7 +225,7 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
-                  poolTimeout: Infinity, // keep workers alive for more effective watch mode
+                  poolTimeout: Infinity // keep workers alive for more effective watch mode
                 },
               },
               {
@@ -266,7 +266,7 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
-                  poolTimeout: Infinity, // keep workers alive for more effective watch mode
+                  poolTimeout: Infinity // keep workers alive for more effective watch mode
                 },
               },
               {
@@ -329,7 +329,7 @@ module.exports = {
               'sass-loader'
             ),
           },
-          // The GraphQL loader preprocesses GraphQL queries in .graphql and .gql files.
+          // The GraphQL loader preprocesses GraphQL queries in .graphql files.
           {
             test: /\.(graphql|gql)$/,
             loader: 'graphql-tag/loader',

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -225,7 +225,7 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
-                  poolTimeout: Infinity // keep workers alive for more effective watch mode
+                  poolTimeout: Infinity, // keep workers alive for more effective watch mode
                 },
               },
               {
@@ -266,7 +266,7 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
-                  poolTimeout: Infinity // keep workers alive for more effective watch mode
+                  poolTimeout: Infinity, // keep workers alive for more effective watch mode
                 },
               },
               {
@@ -329,7 +329,7 @@ module.exports = {
               'sass-loader'
             ),
           },
-          // The GraphQL loader preprocesses GraphQL queries in .graphql files.
+          // The GraphQL loader preprocesses GraphQL queries in .graphql and .gql files.
           {
             test: /\.(graphql|gql)$/,
             loader: 'graphql-tag/loader',

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -331,7 +331,7 @@ module.exports = {
           },
           // The GraphQL loader preprocesses GraphQL queries in .graphql files.
           {
-            test: /\.(graphql)$/,
+            test: /\.(graphql|gql)$/,
             loader: 'graphql-tag/loader',
           },
           // "file" loader makes sure those assets get served by WebpackDevServer.

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -225,7 +225,7 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
-                  poolTimeout: Infinity, // keep workers alive for more effective watch mode
+                  poolTimeout: Infinity // keep workers alive for more effective watch mode
                 },
               },
               {
@@ -266,7 +266,7 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
-                  poolTimeout: Infinity, // keep workers alive for more effective watch mode
+                  poolTimeout: Infinity // keep workers alive for more effective watch mode
                 },
               },
               {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -363,7 +363,7 @@ module.exports = {
               'sass-loader'
             ),
           },
-          // The GraphQL loader preprocesses GraphQL queries in .graphql and .gql files.
+          // The GraphQL loader preprocesses GraphQL queries in .graphql files.
           {
             test: /\.(graphql|gql)$/,
             loader: 'graphql-tag/loader',

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -363,7 +363,7 @@ module.exports = {
               'sass-loader'
             ),
           },
-          // The GraphQL loader preprocesses GraphQL queries in .graphql files.
+          // The GraphQL loader preprocesses GraphQL queries in .graphql and .gql files.
           {
             test: /\.(graphql|gql)$/,
             loader: 'graphql-tag/loader',

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -365,7 +365,7 @@ module.exports = {
           },
           // The GraphQL loader preprocesses GraphQL queries in .graphql files.
           {
-            test: /\.(graphql)$/,
+            test: /\.(graphql|gql)$/,
             loader: 'graphql-tag/loader',
           },
           // "file" loader makes sure assets end up in the `build` folder.


### PR DESCRIPTION
#4831

Added support for `.gql` files.

graphql-tag/loader now supports both `.graphql` and `.gql` files. Files with the`.gql` extension allow the import of graphql operations by name.

e.g.

```
import { MyQuery1, MyQuery2 } from 'query.gql'
```

For graphql-tag/loader documentation, see: https://github.com/apollographql/graphql-tag#webpack-preprocessing-with-graphql-tagloader