### PR TITLE
Added solution for when `npm run build` fails to minify for those who have ejected.

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -2475,6 +2475,8 @@ To resolve this:
 
 3. If the dependency is small enough, copy it to your `src/` folder and treat it as application code.
 
+4. If you have ejected, make sure all of your sources are included by `babel-loader` in the Webpack configuration.
+
 In the future, we might start automatically compiling incompatible third-party modules, but it is not currently supported. This approach would also slow down the production builds.
 
 ## Alternatives to Ejecting


### PR DESCRIPTION
`npm run build` failure gives a link to this document, even for those who have ejected. 

Making sure sources are loaded by `babel-loader` is an easy mistake to make for those who have ejected.