### PR TITLE
Fix: Failing builds when running in CI Environments

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -225,7 +225,8 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
-                  poolTimeout: Infinity // keep workers alive for more effective watch mode
+                  poolTimeout: Infinity, // keep workers alive for more effective watch mode
+                  workers: process.env.CI && 2, // prevent CI builds from crashing
                 },
               },
               {
@@ -266,7 +267,8 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
-                  poolTimeout: Infinity // keep workers alive for more effective watch mode
+                  poolTimeout: Infinity, // keep workers alive for more effective watch mode
+                  workers: process.env.CI && 2, // prevent CI builds from crashing
                 },
               },
               {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -261,7 +261,12 @@ module.exports = {
             use: [
               // This loader parallelizes code compilation, it is optional but
               // improves compile time on larger projects
-              require.resolve('thread-loader'),
+              {
+                loader: require.resolve('thread-loader'),
+                options: {
+                  workers: process.env.CI && 2, // prevent CI builds from crashing
+                },
+              },
               {
                 loader: require.resolve('babel-loader'),
                 options: {
@@ -294,7 +299,12 @@ module.exports = {
             use: [
               // This loader parallelizes code compilation, it is optional but
               // improves compile time on larger projects
-              require.resolve('thread-loader'),
+              {
+                loader: require.resolve('thread-loader'),
+                options: {
+                  workers: process.env.CI && 2, // prevent CI builds from crashing
+                },
+              },
               {
                 loader: require.resolve('babel-loader'),
                 options: {


### PR DESCRIPTION
Related issue: https://github.com/facebook/create-react-app/issues/4870

Limits CI builds to 2 threads