### PR TITLE
Fix: remove error about localStorage security

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     ]
   },
   "resolutions": {
-    "@babel/core": "7.0.0-beta.46",
-    "babel-core": "7.0.0-bridge.0"
+    "@babel/core": "7.0.0-beta.46"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,9 @@
     "yarn.lock": [
       "git rm --cached"
     ]
+  },
+  "resolutions": {
+    "@babel/core": "7.0.0-beta.46",
+    "babel-core": "7.0.0-bridge.0"
   }
 }

--- a/packages/confusing-browser-globals/package.json
+++ b/packages/confusing-browser-globals/package.json
@@ -16,6 +16,6 @@
     "index.js"
   ],
   "devDependencies": {
-    "jest": "22.4.3"
+    "jest": "23.5.0"
   }
 }

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -62,7 +62,7 @@
     "text-table": "0.2.0"
   },
   "devDependencies": {
-    "jest": "22.4.3"
+    "jest": "23.5.0"
   },
   "scripts": {
     "test": "jest"

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -50,7 +50,7 @@
     "eslint-plugin-react": "7.8.2",
     "flow-bin": "^0.63.1",
     "html-entities": "1.2.1",
-    "jest": "22.4.3",
+    "jest": "23.5.0",
     "jest-fetch-mock": "1.5.0",
     "object-assign": "4.1.1",
     "promise": "8.0.1",

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -36,7 +36,7 @@
     "anser": "1.4.6",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^8.2.2",
-    "babel-jest": "^22.4.3",
+    "babel-jest": "^23.4.2",
     "babel-loader": "^8.0.0-beta.0",
     "babel-preset-react-app": "^3.1.1",
     "chalk": "^2.3.2",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -50,7 +50,7 @@
     "html-webpack-plugin": "3.2.0",
     "identity-obj-proxy": "3.0.0",
     "loader-utils": "^1.1.0",
-    "jest": "22.4.3",
+    "jest": "23.5.0",
     "mini-css-extract-plugin": "^0.4.0",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.3.1",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -26,7 +26,7 @@
     "autoprefixer": "8.5.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "8.2.3",
-    "babel-jest": "22.4.3",
+    "babel-jest": "^23.4.2",
     "babel-loader": "8.0.0-beta.4",
     "babel-plugin-named-asset-import": "^0.1.0",
     "babel-preset-react-app": "^3.1.1",


### PR DESCRIPTION
Upgrading Jest to latest version removes "SecurityError: localStorage is not available for opaque origins" error.