### PR TITLE
Allow users to override default template in InterpolateHtmlPlugin

### DIFF
--- a/packages/react-dev-utils/InterpolateHtmlPlugin.js
+++ b/packages/react-dev-utils/InterpolateHtmlPlugin.js
@@ -17,8 +17,9 @@
 const escapeStringRegexp = require('escape-string-regexp');
 
 class InterpolateHtmlPlugin {
-  constructor(replacements) {
+  constructor(replacements, { makeReplacementRegexp } = {}) {
     this.replacements = replacements;
+    this.makeReplacementRegexp = makeReplacementRegexp || makeReplacementRegexpDefault;
   }
 
   apply(compiler) {
@@ -30,7 +31,7 @@ class InterpolateHtmlPlugin {
           Object.keys(this.replacements).forEach(key => {
             const value = this.replacements[key];
             data.html = data.html.replace(
-              new RegExp('%' + escapeStringRegexp(key) + '%', 'g'),
+              this.makeReplacementRegexp(key, escapeStringRegexp),
               value
             );
           });
@@ -38,6 +39,10 @@ class InterpolateHtmlPlugin {
       );
     });
   }
+}
+
+function makeReplacementRegexpDefault(key, escapeRegexp) {
+  return new RegExp('%' + escapeRegexp(key) + '%', 'g');
 }
 
 module.exports = InterpolateHtmlPlugin;

--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -18,7 +18,7 @@ If you don’t use Create React App, or if you [ejected](https://github.com/face
 
 There is no single entry point. You can only import individual top-level modules.
 
-#### `new InterpolateHtmlPlugin(replacements: {[key:string]: string})`
+#### `new InterpolateHtmlPlugin(replacements: {[key:string]: string}, options?: { makeReplacementRegexp?: function })`
 
 This Webpack plugin lets us interpolate custom variables into `index.html`.<br>
 It works in tandem with [HtmlWebpackPlugin](https://github.com/ampedandwired/html-webpack-plugin) 2.x via its [events](https://github.com/ampedandwired/html-webpack-plugin#events).
@@ -49,6 +49,9 @@ module.exports = {
       PUBLIC_URL: publicUrl
       // You can pass any key-value pairs, this was just an example.
       // WHATEVER: 42 will replace %WHATEVER% with 42 in index.html.
+    }, {
+      // Override default %WHATEVER% replacement template.
+      makeReplacementRegexp: (key, escapeRegexp) => new RegExp('%' + escapeRegexp(key) + '%', 'g')
     }),
     // ...
   ],
@@ -362,4 +365,3 @@ module: {
    ]
 }
 ```
-


### PR DESCRIPTION
This PR intends to allow users to override the default `%VAR%` template in `index.html`. In production, my company uses a nginx which changes variables in the `$VAR` format at runtime (using Docker, when starting the container), so I find it easier to keep my variables in the same format for webpack in development mode via webpack-dev-server.

## Testing

1. Forked the repo at https://github.com/lfbvr/create-react-app.
2. Run `npm link` in that repo.
3. Run `npm link react-dev-utils` in my project folder.
4. Run webpack with this config: 

`webpack.config.js`
![image](https://user-images.githubusercontent.com/5919935/44098045-70e61034-9fdf-11e8-8b89-272a27fe28c5.png)


`index.html` (template)
![image](https://user-images.githubusercontent.com/5919935/44098016-58963e46-9fdf-11e8-975e-9a3957778d96.png)

`index.html` (result)
![image](https://user-images.githubusercontent.com/5919935/44098081-8b97ce86-9fdf-11e8-8848-b5a682d153c2.png)

Setting the InterpolateHtmlPlugin without options works as before.