### PR TITLE
use npm init instead of npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cd my-app
 npm start
 ```
 
-*([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))*
+*`npm init` ships with npm 6.1+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))*
 
 Then open [http://localhost:3000/](http://localhost:3000/) to see your app.<br>
 When you’re ready to deploy to production, create a minified bundle with `npm run build`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If something doesn’t work, please [file an issue](https://github.com/facebook/
 ## Quick Overview
 
 ```sh
-npx create-react-app my-app
+npm init create-react-app my-app
 cd my-app
 npm start
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If something doesn’t work, please [file an issue](https://github.com/facebook/
 ## Quick Overview
 
 ```sh
-npm init create-react-app my-app
+npm init react-app my-app
 cd my-app
 npm start
 ```


### PR DESCRIPTION
I notice a lot of people are not aware that npx is shipping with npm and get confused by the npx instruction.

Since `npm init` does the same I believe switching over to `npm init` would be more beginner friendly.