### PR TITLE
Fixes multiple instances of styled-components in mono-repos

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -157,6 +157,10 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      // @remove-on-eject-end
+      // Fixes multiple instances of styled-components when working with symlinks in mono-repos.
+      // https://www.styled-components.com/docs/faqs#why-am-i-getting-a-warning-about-several-instances-of-module-on-the-page
+      'styled-components': path.resolve(paths.appNodeModules, 'styled-components'),
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).


### PR DESCRIPTION
## Motivation
When working in a monorepo (possibly regular repos as well) and using a dependency that is using `styled-components` a warning appears showing a duplicated instance was found. This happens during development phase when packages are linked using `npm link`.

## The issue
The monorepo I'm working on has two packages:
1. `components`
2. `app`

`components` has `styled-components` as peerDependency and is placed in devDependencies. I bundled the app using `rollup` and styled-components is placed as external.
```js
const config = {
  input: './src/index.js',
  output: [
    {
      file: pkg.main,
      format: 'cjs',
      external: ['react', 'react-dom', 'styled-components'],
    },
  ],
  ...
}
```
I checked the final bundle and in `styled-components` is not bundled 👍 

`app` has`styled-components`and `components` (the other package in monorepo) but used `npm link` as I'm still doing lots of changes and I'd rather not have a new version for every small change or debug process.

Then I ran the app and it all works but the following message appears:
<img width="699" alt="screen shot 2018-08-23 at 08 25 21" src="https://user-images.githubusercontent.com/726113/44508491-cbe36d80-a6ae-11e8-862e-570cdd67b1fc.png">

## How to fix
Luckily there's an easy fix already documented here:
https://www.styled-components.com/docs/faqs#why-am-i-getting-a-warning-about-several-instances-of-module-on-the-page

I'd rather avoid `ejecting` my project just to add this alias. I checked by modifying `react-scripts` in `node_modules` directly and fix works! Styles are back and everything is working.

## How to reproduce
Clone [this repo](https://github.com/victorhqc/create-react-app-styled-components) and follow instructions.