### PR TITLE
Updated documentation to reduce command duplication

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -621,13 +621,13 @@ Then in `package.json`, add the following lines to `scripts`:
 ```diff
    "scripts": {
 +    "build-css": "node-sass-chokidar src/ -o src/",
-+    "watch-css": "node-sass-chokidar src/ -o src/ --watch",
++    "watch-css": "npm run build-css -- --watch", # when using yarn you don't need the -- between build-css and --watch
      "start": "react-scripts start",
      "build": "react-scripts build",
      "test": "react-scripts test --env=jsdom",
 ```
 
->Note: To use a different preprocessor, replace `build-css` and `watch-css` commands according to your preprocessor’s documentation.
+>Note: To use a different preprocessor, replace the `build-css` command according to your preprocessor’s documentation.
 
 Now you can rename `src/App.css` to `src/App.scss` and run `npm run watch-css`. The watcher will find every Sass file in `src` subdirectories, and create a corresponding CSS file next to it, in our case overwriting `src/App.css`. Since `src/App.js` still imports `src/App.css`, the styles become a part of your application. You can now edit `src/App.scss`, and `src/App.css` will be regenerated.
 
@@ -637,7 +637,7 @@ To enable importing files without using relative paths, you can add the  `--incl
 
 ```
 "build-css": "node-sass-chokidar --include-path ./node_modules src/ -o src/",
-"watch-css": "node-sass-chokidar --include-path ./node_modules src/ -o src/ --watch",
+"watch-css": "npm run build-css -- --watch", # when using yarn you don't need the -- between build-css and --watch
 ```
 
 This will allow you to do imports like
@@ -666,7 +666,7 @@ Then we can change `start` and `build` scripts to include the CSS preprocessor c
 ```diff
    "scripts": {
      "build-css": "node-sass-chokidar src/ -o src/",
-     "watch-css": "npm run build-css && node-sass-chokidar src/ -o src/ --watch --recursive",
+     "watch-css": "npm run build-css -- --watch --recursive --follow", # when using yarn you don't need the -- between build-css and --watch
 -    "start": "react-scripts start",
 -    "build": "react-scripts build",
 +    "start-js": "react-scripts start",


### PR DESCRIPTION
Co-authored-by: Ernesto Garcia <gnapse@gmail.com>

In our own project we use this method to avoid command duplication.

If the documentation switches to `yarn` we could write it even shorter, without `run` and `--`.