### PR TITLE
Switch from cheap-module-source-map eval-source-map

### DIFF
--- a/packages/react-dev-utils/evalSourceMapMiddleware.js
+++ b/packages/react-dev-utils/evalSourceMapMiddleware.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+function base64SourceMap(source) {
+  const base64 = Buffer.from(JSON.stringify(source.map()), 'utf8').toString(
+    'base64'
+  );
+  return `data:application/json;charset=utf-8;base64,${base64}`;
+}
+
+function getSourceById(server, id) {
+  const module = server._stats.compilation.modules.find(m => m.id == id);
+  return module.originalSource();
+}
+
+/*
+ * Middleware responsible for retrieving a generated source
+ * Receives a webpack internal url: "webpack-internal:///<module-id>"
+ * Returns a generated source: "<source-text><sourceMappingURL><sourceURL>"
+ *
+ * Based on EvalSourceMapDevToolModuleTemplatePlugin.js
+ */
+module.exports = function createEvalSourceMapMiddleware(server) {
+  return function handleWebpackInternalMiddleware(req, res, next) {
+    if (req.url.startsWith('/__get-internal-source')) {
+      const fileName = req.query.fileName;
+      const id = fileName.match(/webpack-internal:\/\/\/(.+)/)[1];
+      if (!id || !server._stats) {
+        next();
+      }
+
+      const source = getSourceById(server, id);
+      const sourceMapURL = `//# sourceMappingURL=${base64SourceMap(source)}`;
+      const sourceURL = `//# sourceURL=webpack-internal:///${module.id}`;
+      res.end(`${source.source()}\n${sourceMapURL}\n${sourceURL}`);
+    } else {
+      next();
+    }
+  };
+};

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -17,6 +17,7 @@
     "crossSpawn.js",
     "errorOverlayMiddleware.js",
     "eslintFormatter.js",
+    "evalSourceMapMiddleware.js",
     "FileSizeReporter.js",
     "formatWebpackMessages.js",
     "getCSSModuleLocalIdent.js",

--- a/packages/react-error-overlay/src/utils/mapper.js
+++ b/packages/react-error-overlay/src/utils/mapper.js
@@ -34,7 +34,11 @@ async function map(
   });
   await settle(
     files.map(async fileName => {
-      const fileSource = await fetch(fileName).then(r => r.text());
+      const fetchUrl = fileName.startsWith('webpack-internal:')
+        ? `/__get-internal-source?fileName=${encodeURIComponent(fileName)}`
+        : fileName;
+
+      const fileSource = await fetch(fetchUrl).then(r => r.text());
       const map = await getSourceMap(fileName, fileSource);
       cache[fileName] = { fileSource, map };
     })

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -76,7 +76,7 @@ module.exports = {
   mode: 'development',
   // You may want 'eval' instead if you prefer to see the compiled output in DevTools.
   // See the discussion in https://github.com/facebook/create-react-app/issues/343
-  devtool: 'cheap-module-source-map',
+  devtool: 'eval-source-map',
   // These are the "entry points" to our application.
   // This means they will be the "root" imports that are included in JS bundle.
   // The first two entry points enable "hot" CSS and auto-refreshes for JS.

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -9,6 +9,7 @@
 'use strict';
 
 const errorOverlayMiddleware = require('react-dev-utils/errorOverlayMiddleware');
+const evalSourceMapMiddleware = require('react-dev-utils/evalSourceMapMiddleware');
 const noopServiceWorkerMiddleware = require('react-dev-utils/noopServiceWorkerMiddleware');
 const ignoredFiles = require('react-dev-utils/ignoredFiles');
 const config = require('./webpack.config.dev');
@@ -89,7 +90,10 @@ module.exports = function(proxy, allowedHost) {
     },
     public: allowedHost,
     proxy,
-    before(app) {
+    before(app, server) {
+      // This lets us fetch source contents from webpack for the error overlay
+      app.use(evalSourceMapMiddleware(server));
+
       // This lets us open files from the runtime error overlay.
       app.use(errorOverlayMiddleware());
       // This service worker file is effectively a 'no-op' that will reset any


### PR DESCRIPTION
Fixes [issue]

Switches webpack's devtool [mode] from `cheap-module-source-map` to `source-map` so that the mappings include column positions.

This enables variable and scope mappings in Firefox, which makes it easier to debug applications built with webpack and babel. This should fix the `this` mapping issue. It will also simplify the scopes pane by showing the "original" scopes and variables. It will also enable in-line code preview and console support when evaluating "original" expressions. 

The incremental build times were 25% slower for `source-map` vs `cheap-module-source-maps` (500ms vs 400ms) on a simple [app]. I believe that webpack's cache means that these numbers would not be that different on a larger app.  

Both modes had equivalent breakpoint support on page load and while the app was running. 

### Chrome

<img width="1552" alt="screen shot 2018-08-27 at 4 50 34 pm" src="https://user-images.githubusercontent.com/254562/44686432-359ba880-aa1c-11e8-9942-a07681005132.png">
<img width="1552" alt="screen shot 2018-08-27 at 4 50 24 pm" src="https://user-images.githubusercontent.com/254562/44686433-359ba880-aa1c-11e8-95f3-f3710d5f3fa9.png">

### Firefox

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/254562/44686448-49470f00-aa1c-11e8-87d5-566553d530f6.png">

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/254562/44686480-5f54cf80-aa1c-11e8-9c44-9d7bd054b4f7.png">



[issue]: https://github.com/facebook/create-react-app/issues/3494 
[mode]: https://webpack.js.org/configuration/devtool/
[app]: https://github.com/jasonLaster/tic-tac-toe