### PR TITLE
Fix formatWebpackMessages - fixes empty errors in console and overlay

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -52,7 +52,10 @@ function formatMessage(message, isError) {
   });
 
   if (threadLoaderIndex !== -1) {
-    lines = lines.slice(0, threadLoaderIndex);
+    // Naïvely get rid of the thread-loader entry and
+    // the following two lines, which are a blank, followed
+    // by the absolute file path
+    lines.splice(threadLoaderIndex, 3);
   }
 
   lines = lines.filter(function(line) {


### PR DESCRIPTION
The old version of this function looked for any mention of thread-loaded and then deleted everything thereafter - which most of the time included the actual stack trace that you wanted.

My fix just gets rid of the 3 lines from the threadLoaderIndex and leaves the rest in. 

I feel this is a very naive fix, as I don't know the full breadth of errors to check against to know if I'm lopping anything else off at the wrong moment.....but it seems to work in my very limited testing thus far

Before:
<img width="686" alt="screen shot 2018-08-28 at 16 01 28" src="https://user-images.githubusercontent.com/2256434/44731732-c5ecf280-aadb-11e8-826d-6e6d21f2fa72.png">

After: 
<img width="683" alt="screen shot 2018-08-28 at 15 59 31" src="https://user-images.githubusercontent.com/2256434/44731761-d1d8b480-aadb-11e8-844c-a99cb2e54d73.png">
