### PR TITLE
Unpin fsevents to prevent error on node 10. Fixes #4896

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -77,7 +77,7 @@
     "react-dom": "^16.3.2"
   },
   "optionalDependencies": {
-    "fsevents": "1.2.0"
+    "fsevents": "^1.2.0"
   },
   "browserslist": {
     "development": [


### PR DESCRIPTION
Unpin fsEvents on the next branch. This change already occurred on the 1.x branch (https://github.com/facebook/create-react-app/pull/4006). Currently the pinned version causes an error when running install for node 10 (see https://github.com/facebook/create-react-app/issues/4896)