### PR TITLE
Update webpack-dev-server 3.1.5 → 3.1.7

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -68,7 +68,7 @@
     "uglifyjs-webpack-plugin": "1.2.5",
     "url-loader": "1.0.1",
     "webpack": "4.8.3",
-    "webpack-dev-server": "3.1.5",
+    "webpack-dev-server": "3.1.7",
     "webpack-manifest-plugin": "2.0.3",
     "whatwg-fetch": "2.0.4"
   },


### PR DESCRIPTION
This fixes the functionality of this dependency for Node 10 and above.

Refs: https://github.com/webpack/webpack-dev-server/pull/1451
Refs: https://github.com/nodejs/node/issues/21665

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
