### PR TITLE
Extract webpack alias configuration in one single file (#4961)

### DIFF
--- a/packages/react-scripts/config/webpack.alias.config.js
+++ b/packages/react-scripts/config/webpack.alias.config.js
@@ -1,0 +1,22 @@
+'use strict';
+
+// @remove-on-eject-begin
+const path = require('path');
+// @remove-on-eject-end
+
+const aliases = {
+  // @remove-on-eject-begin
+  // Resolve Babel runtime relative to react-scripts.
+  // It usually still works on npm 3 without this but it would be
+  // unfortunate to rely on, as react-scripts could be symlinked,
+  // and thus @babel/runtime might not be resolvable from the source.
+  '@babel/runtime': path.dirname(
+    require.resolve('@babel/runtime/package.json')
+  ),
+  // @remove-on-eject-end
+  // Support React Native Web
+  // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
+  'react-native': 'react-native-web',
+};
+
+module.exports = aliases;

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -21,6 +21,7 @@ const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent')
 const getClientEnvironment = require('./env');
 const paths = require('./paths');
 const ManifestPlugin = require('webpack-manifest-plugin');
+const aliases = require('./webpack.alias.config');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // In development, we always serve from the root. This makes config easier.
@@ -144,20 +145,7 @@ module.exports = {
     // `web` extension prefixes have been added for better support
     // for React Native Web.
     extensions: ['.web.js', '.mjs', '.js', '.json', '.web.jsx', '.jsx'],
-    alias: {
-      // @remove-on-eject-begin
-      // Resolve Babel runtime relative to react-scripts.
-      // It usually still works on npm 3 without this but it would be
-      // unfortunate to rely on, as react-scripts could be symlinked,
-      // and thus @babel/runtime might not be resolvable from the source.
-      '@babel/runtime': path.dirname(
-        require.resolve('@babel/runtime/package.json')
-      ),
-      // @remove-on-eject-end
-      // Support React Native Web
-      // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
-      'react-native': 'react-native-web',
-    },
+    alias: aliases,
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).
       // This often causes confusion because we only process files within src/ with babel.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -23,6 +23,7 @@ const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
+const aliases = require('./webpack.alias.config');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
@@ -182,20 +183,7 @@ module.exports = {
     // `web` extension prefixes have been added for better support
     // for React Native Web.
     extensions: ['.web.js', '.mjs', '.js', '.json', '.web.jsx', '.jsx'],
-    alias: {
-      // @remove-on-eject-begin
-      // Resolve Babel runtime relative to react-scripts.
-      // It usually still works on npm 3 without this but it would be
-      // unfortunate to rely on, as react-scripts could be symlinked,
-      // and thus @babel/runtime might not be resolvable from the source.
-      '@babel/runtime': path.dirname(
-        require.resolve('@babel/runtime/package.json')
-      ),
-      // @remove-on-eject-end
-      // Support React Native Web
-      // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
-      'react-native': 'react-native-web',
-    },
+    alias: aliases,
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).
       // This often causes confusion because we only process files within src/ with babel.


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

You can verify that:  

- [Configuration files are created/modified](#configuration-files-are-created-modified)
- [`Aliases` are working](aliases-are-workin)
- [App tests are working](app-tests-are-working)

##  Configuration files are created/modified

create a react app

```shell
yarn create-react-app my-app
```
verify the `alias` configuration
```shell
cat  my-app/node_modules/react-scripts/config/webpack.alias.config.js 
```
the file should look like this: 

```JavaScript
'use strict';

// @remove-on-eject-begin
const path = require('path');
// @remove-on-eject-end

const aliases = {
  // @remove-on-eject-begin
  // Resolve Babel runtime relative to react-scripts.
  // It usually still works on npm 3 without this but it would be
  // unfortunate to rely on, as react-scripts could be symlinked,
  // and thus @babel/runtime might not be resolvable from the source.
  '@babel/runtime': path.dirname(
    require.resolve('@babel/runtime/package.json')
  ),
  // @remove-on-eject-end
  // Support React Native Web
  // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
  'react-native': 'react-native-web',
};

module.exports = aliases;
```

now `eject` the project: 

```shell
cd my-app && yarn eject
```
verify the `alias` config: 

```shell
cat config/webpack.alias.config.js
```
it should be like this: 

```JavaScript
'use strict';



const aliases = {
  
  // Support React Native Web
  // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
  'react-native': 'react-native-web',
};

module.exports = aliases;

```

## `Aliases` are working

edit `config/webpack.alias.config.js` as follow: 

```JavaScript
'use strict';

const path = require('path');
const paths = require('./paths');

const aliases = {
  
  // Support React Native Web
  // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
  'react-native': 'react-native-web',
  'my-alias' : path.resolve(paths.appSrc, 'my-package')
};

module.exports = aliases;

```

edit `src/App.js` as follow 

```JavaScript
import React, { Component } from 'react';
import logo from './logo.svg';
import './App.css';

import hello from 'my-alias';

class App extends Component {
  render() {
    return (
      <div className="App">
        <header className="App-header">
          <p id="alias">{hello}</p>
          <img src={logo} className="App-logo" alt="logo" />
          <p>
            Edit <code>src/App.js</code> and save to reload.
          </p>
          <a
            className="App-link"
            href="https://reactjs.org"
            target="_blank"
            rel="noopener noreferrer"
          >
            Learn React
          </a>
        </header>
      </div>
    );
  }
}

export default App;

```
launch app

```shell
yarn start
```

you should see `hello from my-package` 

![](https://lh3.googleusercontent.com/xzcOK8Tcs-OZ7Qke0nNHM1ClcCQgUWX8QKejyPyB9nXqWgBeHOQ5wjUt_B9pX16IqpqRbatkqlP7Vgszaq5W42xBQsYoClRPUpN7OD0m45QAzEdX03e8QkZ2mOz0RZXQ1YhDkblF0hpQB7sP4HdJT2DitFzcHRv_wlJDY-1UD3XWUd40sMv-nWCsvw5VcbG6oIvolFELy6ySBf0npwf_c1mnvGIupitHRUgYy1SipDkaXiJOLbJCI9ptJXzi68vc5GjVOiroOBxbkAkqYKnw41LsudCayOhVSqg3PUfg56u0_tl7Nscv6lw8X8g70h3t04Ko5uIECOQfUa-SaFR_snjUQKlouM6l3uCau8iwzdvX80XisOvaYYCEJcokA4tCihyjc8sabbaGjODEdh_amfwdqJKnPqa9m1LBGAawVo_9cQQZtjmmenxekTcRDtc6jrpXsgRpddjVL7KISRg2ANrXISlG6NYF72pVIT0cXOD6NQlEUlHWLftc76A2OEJypq5eOYogtETgF-LOKYwSebHwkkx07og1EfKfaWyhPjvNi98gjjyxxgIwLsEjY5fqw8SPkUWAL_9bK8olrW16E8opjlfxUe4BKcOWgnAmWAOcaq7mq91Rro5xnCCFaw=w623-h625-no)

## App tests are working

Add alias to `jest` `moduleNameMapper`, editing the `package.json` file. 

```JSON
...
"jest": {
...
   "moduleNameMapper": {
      "^react-native$": "react-native-web",
      "^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy",
      "my-alias" : "<rootDir>/src/my-package"
    },
...
}
...
```

edit the app test `src/App.test.js` to verify the `import` resolve the aliased `module`

```JavaScript
import React from 'react';
import ReactDOM from 'react-dom';
import App from './App';

it('renders without crashing', () => {
  const div = document.createElement('div');
  ReactDOM.render(<App />, div);

  expect(div.querySelector('#alias').textContent).toBe('Hello from my-package');

  ReactDOM.unmountComponentAtNode(div);
});

```

Run the test 

```shell
yarn test
```
