### PR TITLE
Install husky, lint-staged, and prettier to dev deps

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -313,13 +313,13 @@ Prettier is an opinionated code formatter with support for JavaScript, CSS and J
 To format our code whenever we make a commit in git, we need to install the following dependencies:
 
 ```sh
-npm install --save husky lint-staged prettier
+npm install --save-dev husky lint-staged prettier
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add husky lint-staged prettier
+yarn add --dev husky lint-staged prettier
 ```
 
 * `husky` makes it easy to use githooks as if they are npm scripts.


### PR DESCRIPTION
- A small fix

I really like using `husky`, `lint-staged`,  and `prettier` with `create-react-app`. 

I don't see why they should be included in the production bundle though, so I just updated the docs accordingly to make sure people install them as dev dependencies. 