### PR TITLE
Enable setting various types of sourcemaps.

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -28,7 +28,8 @@ const getClientEnvironment = require('./env');
 // It requires a trailing slash, or the file assets will get an incorrect path.
 const publicPath = paths.servedPath;
 // Source maps are resource heavy and can cause out of memory issue for large source files.
-const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
+// We want to enable different types of sourcemaps since certain platforms only support certain types of sourcemaps.
+const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP;
 // `publicUrl` is just like `publicPath`, but we will provide it to our app
 // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
 // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -29,7 +29,7 @@ const getClientEnvironment = require('./env');
 const publicPath = paths.servedPath;
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 // We want to enable different types of sourcemaps since certain platforms only support certain types of sourcemaps.
-const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP;
+const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 // `publicUrl` is just like `publicPath`, but we will provide it to our app
 // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
 // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
@@ -96,7 +96,7 @@ module.exports = {
   bail: true,
   // We generate sourcemaps in production. This is slow but gives good results.
   // You can exclude the *.map files from the build during deployment.
-  devtool: shouldUseSourceMap ? 'source-map' : false,
+  devtool: process.env.GENERATE_SOURCEMAP,
   // In production, we only want to load the polyfills and the app code.
   entry: [require.resolve('./polyfills'), paths.appIndexJs],
   output: {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -28,8 +28,9 @@ const getClientEnvironment = require('./env');
 // It requires a trailing slash, or the file assets will get an incorrect path.
 const publicPath = paths.servedPath;
 // Source maps are resource heavy and can cause out of memory issue for large source files.
-// We want to enable different types of sourcemaps since certain platforms only support certain types of sourcemaps.
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
+//if there was a SOURCEMAP_TYPE env variable specified, use it, otherwise default to 'source-map'
+const sourceMapType = process.env.SOURCEMAP_TYPE && process.env.SOURCEMAP_TYPE.trim() !== '' ? process.env.SOURCEMAP_TYPE : 'source-map';
 // `publicUrl` is just like `publicPath`, but we will provide it to our app
 // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
 // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
@@ -96,7 +97,7 @@ module.exports = {
   bail: true,
   // We generate sourcemaps in production. This is slow but gives good results.
   // You can exclude the *.map files from the build during deployment.
-  devtool: process.env.GENERATE_SOURCEMAP,
+  devtool: shouldUseSourceMap ? sourceMapType : false,
   // In production, we only want to load the polyfills and the app code.
   entry: [require.resolve('./polyfills'), paths.appIndexJs],
   output: {


### PR DESCRIPTION
On certain platforms (for eg. Tizen TVs) we need the ability to enable a specific type of sourcemap (eval-source-map). True/false is too limiting.

I verified this minor change by running yarn build with different values for the GENERATE_SOURCEMAP environment variable then inspecting the resulting main.<hash>.js under build/static/js/
Setting the env var to false preserves existing behavior. Setting it to other allowed sourcemap values correctly changes the resulting output JS bundle.