### PR TITLE
Add preload-webpack-plugin for preloading scripts to boost performance

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -12,6 +12,7 @@ const autoprefixer = require('autoprefixer');
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const PreloadWebpackPlugin = require('preload-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
@@ -407,6 +408,7 @@ module.exports = {
         minifyURLs: true,
       },
     }),
+    new PreloadWebpackPlugin(),
     // Makes some environment variables available in index.html.
     // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
     // <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -56,6 +56,7 @@
     "postcss-flexbugs-fixes": "3.3.1",
     "optimize-css-assets-webpack-plugin": "^4.0.1",
     "postcss-loader": "2.1.5",
+    "preload-webpack-plugin": "^2.3.0",
     "promise": "8.0.1",
     "raf": "3.4.0",
     "react-dev-utils": "^5.0.0",


### PR DESCRIPTION
We have been using [preload-webpack-plugin](https://github.com/GoogleChromeLabs/preload-webpack-plugin) and found it a quick win for performance boost.

![image](https://user-images.githubusercontent.com/1476974/45397513-c3fe6400-b683-11e8-91c1-214d42a241fc.png)

P.S. Sorry for stealing the #5000 pull request :(