### PR TITLE
Allow a custom URL to be opened

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -79,7 +79,7 @@ function prepareUrls(protocol, host, port) {
     prettyHost = host;
   }
   const localUrlForTerminal = prettyPrintUrl(prettyHost);
-  const localUrlForBrowser = formatUrl(prettyHost);
+  const localUrlForBrowser = process.env.BROWSER_URL || formatUrl(prettyHost);
   return {
     lanUrlForConfig,
     lanUrlForTerminal,


### PR DESCRIPTION
Open a specific URL instead of hard-coded `/` path.

For example, `BROWSER_URL='http://localhost:3000/admin' react-scripts start`, would open http://localhost:3000/admin in user's default browser, instead of `http://localhost:3000/` (that is if custom `PROTOCOL`, `HOST`, and `PORT` are not provided).

This aligns perfectly, in my opinion, with existing behavior of opening with a different browser (i.e. `BROWSER='google chrome' react-scripts start`).

What do you think?

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->