### PR TITLE
Prioritize ES5 (main) over ES6 (module) in webpack resolve.mainFields config [build failures are irrelevant]

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -137,6 +137,9 @@ module.exports = {
       // It is guaranteed to exist because we tweak it in `env.js`
       process.env.NODE_PATH.split(path.delimiter).filter(Boolean)
     ),
+    // Since create-react-app doesn't support all ES6 features in dependencies,
+    // prefer to load the ES5 instead of the ES6 if a package provides both.
+    mainFields: ['browser', 'main', 'module'],
     // These are the reasonable defaults supported by the Node ecosystem.
     // We also include JSX as a common component filename extension to support
     // some tools, although we do not recommend using it, see:

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -175,6 +175,9 @@ module.exports = {
       // It is guaranteed to exist because we tweak it in `env.js`
       process.env.NODE_PATH.split(path.delimiter).filter(Boolean)
     ),
+    // Since create-react-app doesn't support all ES6 features in dependencies,
+    // prefer to load the ES5 over the ES6 if a package provides both.
+    mainFields: ['browser', 'main', 'module'],
     // These are the reasonable defaults supported by the Node ecosystem.
     // We also include JSX as a common component filename extension to support
     // some tools, although we do not recommend using it, see:


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Since Webpack by default loads from `module` instead of `main` in `package.json`, any library that publishes both ES5 and ES6 this way will trigger minification errors with `create-react-app`.
But if we change the Webpack config to try `main` first, libraries that publish both ES5 and ES6 won't have this problem, and `create-react-app` will still do its best on libraries that only have ES6.

I'm really surprised no one has made this change already.  [Others have suggested this change](https://github.com/facebook/create-react-app/issues/984#issuecomment-326967779) yet I thought of it independently, so I would think it's obvious.

Here's how I came upon this, devised my fix and verified that it works:
1. A user of my `material-ui-render-props-styles` package, which publishes both ES5 and ES6, [reported problems with `create-react-app`](https://github.com/jcoreio/material-ui-render-props-styles/issues/3#issuecomment-420852708) and gave me an example repo: https://github.com/solayao/dizzy_comic_fe
2. I cloned that repo and installed deps in it, confirmed `yarn build` has the minification error
3. Then I ran `npm edit react-scripts` (I tried linking in my fork, but a few too many things had changed from the version the project was using)
4. I added `mainFields: ['browser', 'main', 'module']` to its `webpack.config.prod.js` `resolve` configuration
5. retried `yarn build` -- it worked!