### PR TITLE
Failed to compile message without any detail

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -52,7 +52,7 @@ function formatMessage(message, isError) {
   });
 
   if (threadLoaderIndex !== -1) {
-    lines = lines.slice(0, threadLoaderIndex);
+    lines.splice(threadLoaderIndex, 1);
   }
 
   lines = lines.filter(function(line) {


### PR DESCRIPTION
Closes #5008 
- Fix for thread.loader case in formatWebpackMessages that prevents error messages from mistakenly clearing out.

If you have any suggestions or recommendations please comment.

