### PR TITLE
Update README.md - Swap paywalled tutorial for free tutorial

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1770,7 +1770,7 @@ After that, follow the instructions on the screen.
 
 Learn more about React Storybook:
 
-* Screencast: [Getting Started with React Storybook](https://egghead.io/lessons/react-getting-started-with-react-storybook)
+* Screencast: [Getting Started with React Storybook](https://www.youtube.com/watch?v=E2c183LS4lA)
 * [GitHub Repo](https://github.com/storybooks/storybook)
 * [Documentation](https://storybook.js.org/basics/introduction/)
 * [Snapshot Testing UI](https://github.com/storybooks/storybook/tree/master/addons/storyshots) with Storybook + addon/storyshot


### PR DESCRIPTION
In the "Storybook" section

It doesn't seem right to send people toward a paywalled resource when there are free ones available.

I put in the first Youtube result which is a free tutorial by the same name from FullStack Academy, but  I'm also in favor of replacing this link with a Youtube search for the term.    

```https://www.youtube.com/results?search_query=getting+started+with+react+storybook```


![capture](https://user-images.githubusercontent.com/843228/45716696-82baf800-bb4c-11e8-9355-24883df0d701.PNG)
![capture2](https://user-images.githubusercontent.com/843228/45716697-82baf800-bb4c-11e8-9e81-08c7504a2b64.PNG)

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
