### PR TITLE
Always lint with latest React version

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -185,6 +185,7 @@ module.exports = {
               // @remove-on-eject-begin
               baseConfig: {
                 extends: [require.resolve('eslint-config-react-app')],
+                settings: { react: { version: '999.999.999' } },
               },
               ignore: false,
               useEslintrc: false,

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -228,6 +228,7 @@ module.exports = {
               // e.g. to enable no-console and no-debugger only in production.
               baseConfig: {
                 extends: [require.resolve('eslint-config-react-app')],
+                settings: { react: { version: '999.999.999' } },
               },
               ignore: false,
               useEslintrc: false,


### PR DESCRIPTION
This is the best behavior so people have seamless upgrades to new React majors.

This is probably a terrible default warning from the ESLint plugin, and we need to wait for https://github.com/yannickcr/eslint-plugin-react/issues/1955 before changing this hardcoded behavior.

Closes #5034

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
