### PR TITLE
Correct Babel dependency behavior

### DIFF
--- a/packages/babel-preset-react-app/dependencies.js
+++ b/packages/babel-preset-react-app/dependencies.js
@@ -48,6 +48,17 @@ module.exports = function(api, opts) {
         // Latest stable ECMAScript features
         require('@babel/preset-env').default,
         {
+          // We want Create React App to be IE 9 compatible until React itself
+          // no longer works with IE 9
+          targets: {
+            ie: 9,
+          },
+          // Users cannot override this behavior because this Babel
+          // configuration is highly tuned for ES5 support
+          ignoreBrowserslistConfig: true,
+          // If users import all core-js they're probably not concerned with
+          // bundle size. We shouldn't rely on magic to try and shrink it.
+          useBuiltIns: false,
           // Do not transform modules to CJS
           modules: false,
         },

--- a/packages/babel-preset-react-app/dependencies.js
+++ b/packages/babel-preset-react-app/dependencies.js
@@ -64,5 +64,29 @@ module.exports = function(api, opts) {
         },
       ],
     ].filter(Boolean),
+    plugins: [
+      // Polyfills the runtime needed for async/await, generators, and friends
+      // https://babeljs.io/docs/en/babel-plugin-transform-runtime
+      [
+        require('@babel/plugin-transform-runtime').default,
+        {
+          corejs: false,
+          helpers: false,
+          regenerator: true,
+          // https://babeljs.io/docs/en/babel-plugin-transform-runtime#useesmodules
+          // We should turn this on once the lowest version of Node LTS
+          // supports ES Modules.
+          useESModules: isEnvDevelopment || isEnvProduction,
+        },
+      ],
+      // function* () { yield 42; yield 43; }
+      !isEnvTest && [
+        require('@babel/plugin-transform-regenerator').default,
+        {
+          // Async functions are converted to generators by @babel/preset-env
+          async: false,
+        },
+      ],
+    ].filter(Boolean),
   };
 };


### PR DESCRIPTION
Babel was compiling async/generators incorrectly in dependency using *just* `preset-env`. We need to rewrite these to use the non-global regenerator and apply other tweaks from the application configuration.

On a side note, it took me forever to figure out there was some bad actor in Yarn Workspaces/Babel that required me to `git clean -fdx && yarn install` every time I changed `dependencies.js`.