### PR TITLE
Allow dynamic import proposal in node_modules

### DIFF
--- a/packages/babel-preset-react-app/dependencies.js
+++ b/packages/babel-preset-react-app/dependencies.js
@@ -87,6 +87,8 @@ module.exports = function(api, opts) {
           async: false,
         },
       ],
+      // Adds syntax support for import()
+      require('@babel/plugin-syntax-dynamic-import').default,
     ].filter(Boolean),
   };
 };


### PR DESCRIPTION
[This proposal](https://github.com/tc39/proposal-dynamic-import) is in stage 3, is supported in Node 9.7 behind a feature flag, and shipped in Chrome 63/Safari Preview 24.

It's unlikely to change and is the basis for all modern bundler code-splitting.