### PR TITLE
Adjust ESLint configuration for v5

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -39,12 +39,10 @@ module.exports = {
   },
 
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2018,
     sourceType: 'module',
     ecmaFeatures: {
       jsx: true,
-      generators: true,
-      experimentalObjectRestSpread: true,
     },
   },
 
@@ -53,7 +51,7 @@ module.exports = {
     'array-callback-return': 'warn',
     'default-case': ['warn', { commentPattern: '^no default$' }],
     'dot-location': ['warn', 'property'],
-    eqeqeq: ['warn', 'allow-null'],
+    eqeqeq: ['warn', 'smart'],
     'new-parens': 'warn',
     'no-array-constructor': 'warn',
     'no-caller': 'warn',


### PR DESCRIPTION
ESLint 5 dropped `experimentalObjectRestSpread`, the `generators` feature has been gone for a while, and we should support the latest JavaScript features via `ecmaVersion` 6 (2015) => 9 (2018).

`eqeqeq` also has a new `smart` mode that is a little more relaxed than `allow-null`, permitting `==` when testing a string literal against `typeof`.

Follow up to #5050.