### PR TITLE
Normalize babel caching across the board

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -249,6 +249,8 @@ module.exports = {
                   // It enables caching results in ./node_modules/.cache/babel-loader/
                   // directory for faster rebuilds.
                   cacheDirectory: true,
+                  // Don't waste time on Gzipping the cache
+                  cacheCompression: false,
                   highlightCode: true,
                 },
               },
@@ -276,6 +278,8 @@ module.exports = {
                     require.resolve('babel-preset-react-app/dependencies'),
                   ],
                   cacheDirectory: true,
+                  // Don't waste time on Gzipping the cache
+                  cacheCompression: false,
                   highlightCode: true,
                 },
               },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -282,6 +282,9 @@ module.exports = {
                       },
                     ],
                   ],
+                  cacheDirectory: true,
+                  // Save disk space when time isn't as important
+                  cacheCompression: true,
                   compact: true,
                   highlightCode: true,
                 },
@@ -305,6 +308,8 @@ module.exports = {
                     require.resolve('babel-preset-react-app/dependencies'),
                   ],
                   cacheDirectory: true,
+                  // Save disk space when time isn't as important
+                  cacheCompression: true,
                   highlightCode: true,
                 },
               },


### PR DESCRIPTION
Make sure babel caching is on *everywhere*. Also, we want to turn off Gzip compression during development to help with cold boot/rebuild speed.