### PR TITLE
Change install instructions

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -312,13 +312,13 @@ Prettier is an opinionated code formatter with support for JavaScript, CSS and J
 To format our code whenever we make a commit in git, we need to install the following dependencies:
 
 ```sh
-npm install --save husky lint-staged prettier
+npm install --save-dev husky lint-staged prettier
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add husky lint-staged prettier
+yarn add --dev husky lint-staged prettier
 ```
 
 * `husky` makes it easy to use githooks as if they are npm scripts.


### PR DESCRIPTION
There's no reason for prettier or husky to be installed as a production dependency. This minor change makes that more clear in the user guide.
