### PR TITLE
Switch back to cheap-module-source-map

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -77,7 +77,7 @@ module.exports = {
   mode: 'development',
   // You may want 'eval' instead if you prefer to see the compiled output in DevTools.
   // See the discussion in https://github.com/facebook/create-react-app/issues/343
-  devtool: 'eval-source-map',
+  devtool: 'cheap-module-source-map',
   // These are the "entry points" to our application.
   // This means they will be the "root" imports that are included in JS bundle.
   // The first two entry points enable "hot" CSS and auto-refreshes for JS.


### PR DESCRIPTION
Follow up #4930

It looks like chrome stable and safari fail to show the error overlay with `eval-source-map`. Based on that, I think we should likely switch back to `cheap-module-source-map` for the time being. 