### PR TITLE
Enable eval-source-map for firefox

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -131,7 +131,7 @@ module.exports = function(webpackEnv) {
       ? shouldUseSourceMap
         ? 'source-map'
         : false
-      : isEnvDevelopment && 'cheap-module-source-map',
+      : isEnvDevelopment && 'eval-source-map',
     // These are the "entry points" to our application.
     // This means they will be the "root" imports that are included in JS bundle.
     entry: [


### PR DESCRIPTION
Follow up for #4930.

This enables `eval-source-map` for firefox browsers, which makes it possible to see mapped scopes and variables. Hopefully in a couple of months chrome will also support `eval-source-map` and we can drop the check.