### PR TITLE
Enable staticOptions.redirect to be passed to serve-static.

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -103,5 +103,8 @@ module.exports = function(proxy, allowedHost) {
       // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
       app.use(noopServiceWorkerMiddleware());
     },
+    staticOptions: {
+      redirect: !process.env.NO_REDIRECT_WHEN_PATH_TO_STATIC_DIRECTORY,
+    },
   };
 };


### PR DESCRIPTION
I deploy my app to S3 as a static site. S3 handles routing differently than webpackDevServer does with the default config. Specifically, serve-static is configured to redirect request to files to the folder with the same name when both a file and a folder with the same name exist in the same directory.

Because of this, and the way my app works, my app works fine on S3 but is broken locally because the routing is handled differently.

I found the way to prevent this behavior locally is to set "staticOptions: {redirect: false}" in webpackDevServer.config.js. The way I implemented it retains the existing default behavior, allowing it to be overridden with an environment variable.

This option is a requirement for me in order for my app to work properly both locally and after deployment to S3.
