### PR TITLE
Upgrade svgr to v2 and disable Prettier & SVGO

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -251,7 +251,8 @@ module.exports = {
                       {
                         loaderMap: {
                           svg: {
-                            ReactComponent: 'svgr/webpack![path]',
+                            ReactComponent:
+                              '@svgr/webpack?-prettier,-svgo![path]',
                           },
                         },
                       },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -289,7 +289,8 @@ module.exports = {
                       {
                         loaderMap: {
                           svg: {
-                            ReactComponent: 'svgr/webpack![path]',
+                            ReactComponent:
+                              '@svgr/webpack?-prettier,-svgo![path]',
                           },
                         },
                       },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@babel/core": "7.1.0",
     "@babel/runtime": "7.0.0",
+    "@svgr/webpack": "2.4.1",
     "autoprefixer": "9.1.5",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "9.0.0",
@@ -63,7 +64,6 @@
     "resolve": "1.8.1",
     "sass-loader": "7.1.0",
     "style-loader": "0.23.0",
-    "svgr": "1.9.2",
     "sw-precache-webpack-plugin": "0.11.5",
     "terser-webpack-plugin": "1.1.0",
     "thread-loader": "1.2.0",


### PR DESCRIPTION
Continuation of #4799 by @kopacki.

This updates `svgr` and disables Prettier / SVGO.

Prettier is disabled because it just increases compile-time latency, there's no true benefit here.

SVGO is disabled because there's no "safe defaults" that keep it useful IMO, and we don't apply optimizations to SVGs imported as URLs.
Different optimization behavior based on how the SVG is imported would be confusing/unexpected to the user, especially during debugging.

If we go down the SVGO path, we'll probably only do it for Production and for both ReactComponents and URLs.

This PR will be a great first step.