### PR TITLE
(Micro) Optimize webpack rebuild speed

### DIFF
--- a/packages/react-dev-utils/FileSizeReporter.js
+++ b/packages/react-dev-utils/FileSizeReporter.js
@@ -28,7 +28,7 @@ function printFileSizesAfterBuild(
   var assets = (webpackStats.stats || [webpackStats])
     .map(stats =>
       stats
-        .toJson()
+        .toJson({ all: false, assets: true })
         .assets.filter(asset => /\.(js|css)$/.test(asset.name))
         .map(asset => {
           var fileContents = fs.readFileSync(path.join(root, asset.name));

--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -150,7 +150,11 @@ function createCompiler(webpack, config, appName, urls, useYarn) {
     // We have switched off the default Webpack output in WebpackDevServer
     // options so we are going to "massage" the warnings and errors and present
     // them in a readable focused way.
-    const messages = formatWebpackMessages(stats.toJson({}, true));
+    // We only construct the warnings and errors for speed:
+    // https://github.com/facebook/create-react-app/issues/4492#issuecomment-421959548
+    const messages = formatWebpackMessages(
+      stats.toJson({ all: false, warnings: true, errors: true })
+    );
     const isSuccessful = !messages.errors.length && !messages.warnings.length;
     if (isSuccessful) {
       console.log(chalk.green('Compiled successfully!'));

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -142,7 +142,9 @@ function build(previousFileSizes) {
       if (err) {
         return reject(err);
       }
-      const messages = formatWebpackMessages(stats.toJson({}, true));
+      const messages = formatWebpackMessages(
+        stats.toJson({ all: false, warnings: true, errors: true })
+      );
       if (messages.errors.length) {
         // Only keep the first error. Others are often indicative
         // of the same problem, but confuse the reader with noise.


### PR DESCRIPTION
Derived from https://github.com/facebook/create-react-app/issues/4492#issuecomment-421959548.

This should act on the final suggestion from @sokra, as we switched to Terser in #5026 and inlined the runtime chunk in #5058.

Thanks for the pointers, @sokra!