### PR TITLE
Remove highlightCode:true because it's now the default

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -267,7 +267,6 @@ module.exports = {
                   cacheDirectory: true,
                   // Don't waste time on Gzipping the cache
                   cacheCompression: false,
-                  highlightCode: true,
                 },
               },
             ],
@@ -304,7 +303,6 @@ module.exports = {
                     'react-scripts',
                   ]),
                   // @remove-on-eject-end
-                  highlightCode: true,
                 },
               },
             ],

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -303,7 +303,6 @@ module.exports = {
                   // Save disk space when time isn't as important
                   cacheCompression: true,
                   compact: true,
-                  highlightCode: true,
                 },
               },
             ],
@@ -335,7 +334,6 @@ module.exports = {
                     'react-scripts',
                   ]),
                   // @remove-on-eject-end
-                  highlightCode: true,
                 },
               },
             ],


### PR DESCRIPTION
From babel7, the `highlightCode` options defaults to true.

Related PR: https://github.com/babel/babel/pull/8546
New docs: https://babeljs.io/docs/en/next/options#highlightcode