### PR TITLE
Disable source maps for node_modules

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -308,6 +308,11 @@ module.exports = {
                   ]),
                   // @remove-on-eject-end
                   highlightCode: true,
+                  // If an error happens in a package, it's possible to be
+                  // because it was compiled. Thus, we don't want the browser
+                  // debugger to show the original code. Instead, the code
+                  // being evaluated would be much more helpful.
+                  sourceMaps: false,
                 },
               },
             ],

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -342,6 +342,11 @@ module.exports = {
                   ]),
                   // @remove-on-eject-end
                   highlightCode: true,
+                  // If an error happens in a package, it's possible to be
+                  // because it was compiled. Thus, we don't want the browser
+                  // debugger to show the original code. Instead, the code
+                  // being evaluated would be much more helpful.
+                  sourceMaps: false,
                 },
               },
             ],


### PR DESCRIPTION
Disabling source maps for `node_modules` is a good default because an error might've happened in the context of being compiled, thus debugging against the source actually being evaluated (barring minification) would be a lot easier.

This should also be faster.