### PR TITLE
Lists loader-utils in the dependencies

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -52,6 +52,7 @@
     "gzip-size": "5.0.0",
     "inquirer": "6.2.0",
     "is-root": "2.0.0",
+    "loader-utils": "1.1.0",
     "opn": "5.4.0",
     "pkg-up": "2.0.0",
     "react-error-overlay": "^5.0.0",


### PR DESCRIPTION
The `loader-utils` package is defined in `getCSSModuleLocalIdent` ([source](https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/getCSSModuleLocalIdent.js#L10)), but isn't declared in the package.json. I took the version used by `react-scripts`.