### PR TITLE
Fix displaying third party webpack plugins errors

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -32,6 +32,11 @@ function formatMessage(message, isError) {
     return message.indexOf('Thread Loader (Worker') === -1;
   });
 
+  // Add empty line for errors from third-party webpack plugins
+  if (lines.length < 2) {
+    lines[1] = '';
+  }
+
   // Strip `ModuleWarning` head off message before parsing (because of ESLint)
   // https://github.com/webpack/webpack/blob/c77030573de96b8293c69dd396492f8e2d46561e/lib/ModuleWarning.js
   var moduleWarningPrefix = 'Module Warning: ';


### PR DESCRIPTION
Some third party webpack plugins can generate custom single-line compiler errors without stacktrace.

For example with `html-webpack-plugin` I got following error as `formatMessage` argument:
```js
'Template execution failed: TypeError: Cannot read property \'main\' of undefined' 
```

As fast solution I propose to add empty line to avoid big changes in `formatMessage` logic.
