### PR TITLE
verifyPackageTree is checking dependencies in parent directories

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyPackageTree.js
+++ b/packages/react-scripts/scripts/utils/verifyPackageTree.js
@@ -50,7 +50,7 @@ function verifyPackageTree() {
   while (true) {
     const previousDir = currentDir;
     currentDir = path.resolve(currentDir, '..');
-    if (currentDir === previousDir) {
+    if (currentDir === previousDir || currentDir === process.cwd()) {
       // We've reached the root.
       break;
     }


### PR DESCRIPTION
I'm upgrading a project to use version 2.0.0 and found the following issue:

```
yarn start
yarn run v1.10.1
$ react-scripts start

There might be a problem with the project dependency tree.
It is likely not a bug in Create React App, but something you need to fix locally.

The react-scripts package provided by Create React App requires a dependency:

  "webpack": "4.19.1"

Don't try to install it manually: your package manager does it automatically.
However, a different version of webpack was detected higher up in the tree:

  /Users/mcampa/myproject/node_modules/webpack (version: 3.8.1)

Manually installing incompatible versions is known to cause hard-to-debug issues.
To fix the dependency tree, try following the steps below in the exact order:

  1. Delete package-lock.json (not package.json!) and/or yarn.lock in your project folder.

  2. Delete node_modules in your project folder.

  3. Remove "webpack" from dependencies and/or devDependencies in the package.json file in your project folder.

  4. Run npm install or yarn, depending on the package manager you use.

In most cases, this should be enough to fix the problem.
If this has not helped, there are a few other things you can try:

  5. If you used npm, install yarn (http://yarnpkg.com/) and repeat the above steps with it instead.
     This may help because npm has known issues with package hoisting which may get resolved in future versions.

  6. Check if /Users/mcampa/myproject/node_modules/webpack is outside your project directory.
     For example, you might have accidentally installed something in your home folder.

  7. Try running npm ls webpack in your project folder.
     This will tell you which other package (apart from the expected react-scripts) installed webpack.

If nothing else helps, add SKIP_PREFLIGHT_CHECK=true to an .env file in your project.
That would permanently disable this preflight check in case you want to proceed anyway.

P.S. We know this message is long but please read the steps above :-) We hope you find them helpful!

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The problem is that my project is nested inside a legacy repository that contains a different `node_modules` at the root.

Something like this:
```
repository-root/
├── node_modules/
├── package.json
├── client-apps/
    ├── my-react-app/
         ├── node_modules/
         └── package.json
```

`verifyPackageTree.js` is checking  dependencies at the root level instead of stopping  `my-react-app/`

### Workaround
```
SKIP_PREFLIGHT_CHECK=true yarn start
```

### Fix
Stop going up the directory tree until it gets to the current directory `process.cwd()`

