### PR TITLE
Forwards args through thread-loader

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -225,6 +225,11 @@ module.exports = {
                 loader: require.resolve('thread-loader'),
                 options: {
                   poolTimeout: Infinity, // keep workers alive for more effective watch mode
+                  // Forwards the process args (such as --require) to the child
+                  // workers. Ensures that the worker operates in the same kind
+                  // of environment than the current one (important in case a
+                  // preloaded script modifies the env)
+                  workerNodeArgs: process.execArgv,
                 },
               },
               {
@@ -284,6 +289,11 @@ module.exports = {
                 loader: require.resolve('thread-loader'),
                 options: {
                   poolTimeout: Infinity, // keep workers alive for more effective watch mode
+                  // Forwards the process args (such as --require) to the child
+                  // workers. Ensures that the worker operates in the same kind
+                  // of environment than the current one (important in case a
+                  // preloaded script modifies the env)
+                  workerNodeArgs: process.execArgv,
                 },
               },
               {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -280,6 +280,10 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
+                  // Forwards the process args (such as --require) to the child
+                  // workers. Ensures that the worker operates in the same kind
+                  // of environment than the current one (important in case a
+                  // preloaded script modifies the env)
                   workerNodeArgs: process.execArgv,
                 },
               },
@@ -340,6 +344,10 @@ module.exports = {
               {
                 loader: require.resolve('thread-loader'),
                 options: {
+                  // Forwards the process args (such as --require) to the child
+                  // workers. Ensures that the worker operates in the same kind
+                  // of environment than the current one (important in case a
+                  // preloaded script modifies the env)
                   workerNodeArgs: process.execArgv,
                 },
               },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -277,7 +277,12 @@ module.exports = {
             use: [
               // This loader parallelizes code compilation, it is optional but
               // improves compile time on larger projects
-              require.resolve('thread-loader'),
+              {
+                loader: require.resolve('thread-loader'),
+                options: {
+                  workerNodeArgs: process.execArgv,
+                },
+              },
               {
                 // We need to use our own loader until `babel-loader` supports
                 // customization
@@ -332,7 +337,12 @@ module.exports = {
             use: [
               // This loader parallelizes code compilation, it is optional but
               // improves compile time on larger projects
-              require.resolve('thread-loader'),
+              {
+                loader: require.resolve('thread-loader'),
+                options: {
+                  workerNodeArgs: process.execArgv,
+                },
+              },
               {
                 loader: require.resolve('babel-loader'),
                 options: {


### PR DESCRIPTION
Related: #5136

This diff ensures that the process arguments (in particular `--require`) are correctly forwarded to the spawned subthreads. This is important, since preload scripts typically modify the environment in some capacity.