### PR TITLE
Bumps workbox to the next patch release

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -64,7 +64,7 @@
     "webpack": "4.19.1",
     "webpack-dev-server": "3.1.9",
     "webpack-manifest-plugin": "2.0.4",
-    "workbox-webpack-plugin": "3.6.1"
+    "workbox-webpack-plugin": "3.6.2"
   },
   "devDependencies": {
     "react": "^16.3.2",


### PR DESCRIPTION
This diff bumps workbox from 3.6.1 to [3.6.2](https://github.com/GoogleChrome/workbox/releases/tag/v3.6.2). The only change is that it now correctly lists `babel-runtime` as a dependency: https://github.com/GoogleChrome/workbox/pull/1667