### PR TITLE
Remove babel-loader customization on eject

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -230,10 +230,10 @@ module.exports = {
               {
                 loader: require.resolve('babel-loader'),
                 options: {
+                  // @remove-on-eject-begin
                   customize: require.resolve(
                     'babel-preset-react-app/webpack-overrides'
                   ),
-                  // @remove-on-eject-begin
                   babelrc: false,
                   configFile: false,
                   presets: [require.resolve('babel-preset-react-app')],

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -284,10 +284,10 @@ module.exports = {
                 // https://github.com/babel/babel-loader/pull/687
                 loader: require.resolve('babel-loader'),
                 options: {
+                  // @remove-on-eject-begin
                   customize: require.resolve(
                     'babel-preset-react-app/webpack-overrides'
                   ),
-                  // @remove-on-eject-begin
                   babelrc: false,
                   configFile: false,
                   presets: [require.resolve('babel-preset-react-app')],


### PR DESCRIPTION
Fixes issue with babel-loader customization function not being found after ejecting.

Tested by ejecting project and verifying start and build still worked.