### PR TITLE
Still emit runtime chunk

### DIFF
--- a/packages/react-dev-utils/InlineChunkHtmlPlugin.js
+++ b/packages/react-dev-utils/InlineChunkHtmlPlugin.js
@@ -43,13 +43,16 @@ class InlineChunkHtmlPlugin {
         assets.headTags = assets.headTags.map(tagFunction);
         assets.bodyTags = assets.bodyTags.map(tagFunction);
       });
-      hooks.afterEmit.tap('InlineChunkHtmlPlugin', () => {
-        Object.keys(compilation.assets).forEach(assetName => {
-          if (this.tests.some(test => assetName.match(test))) {
-            delete compilation.assets[assetName];
-          }
-        });
-      });
+
+      // Still emit the runtime chunk for users who do not use our generated
+      // index.html file.
+      // hooks.afterEmit.tap('InlineChunkHtmlPlugin', () => {
+      //   Object.keys(compilation.assets).forEach(assetName => {
+      //     if (this.tests.some(test => assetName.match(test))) {
+      //       delete compilation.assets[assetName];
+      //     }
+      //   });
+      // });
     });
   }
 }


### PR DESCRIPTION
This emits the runtime chunk and puts it in the `asset-manifest.json`.
It is still inlined into `index.html` and is not required via `<script src="..." />`.

Fixes #5172
Fixes #5144