### PR TITLE
Format SVG React snapshots as <svg> tag with props

### DIFF
--- a/packages/react-scripts/config/jest/fileTransform.js
+++ b/packages/react-scripts/config/jest/fileTransform.js
@@ -27,10 +27,7 @@ module.exports = {
           ref: null,
           key: null,
           props: Object.assign({}, props, {
-            children: '/* ${assetFilename.slice(
-              1,
-              assetFilename.length - 1
-            )} */'
+            children: ${assetFilename}
           })
         }),
       };`;

--- a/packages/react-scripts/config/jest/fileTransform.js
+++ b/packages/react-scripts/config/jest/fileTransform.js
@@ -21,7 +21,18 @@ module.exports = {
       return `module.exports = {
         __esModule: true,
         default: ${assetFilename},
-        ReactComponent: () => ${assetFilename},
+        ReactComponent: (props) => ({
+          $$typeof: Symbol.for('react.element'),
+          type: 'svg',
+          ref: null,
+          key: null,
+          props: Object.assign({}, props, {
+            children: '/* ${assetFilename.slice(
+              1,
+              assetFilename.length - 1
+            )} */'
+          })
+        }),
       };`;
     }
 


### PR DESCRIPTION
Fixes the issue in https://github.com/facebook/create-react-app/pull/5147#issuecomment-425768441.

We used to just emit filename for SVG snapshots when imported as React components. But that's not super useful and we forgot to change it before the release.

This prints it as an SVG tag instead, with any props passed in. But we don't render the inside.

Before and after:

```diff
-     logo.svg
+     <svg
+       className="lol"
+     >
+       logo.svg
+     </svg>
```

Closes #5191.