### PR TITLE
Treat .css and .sass/.scss as side effectful

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -370,6 +370,11 @@ module.exports = {
               importLoaders: 1,
               sourceMap: shouldUseSourceMap,
             }),
+            // Don't consider CSS imports dead code even if the
+            // containing package claims to have no side effects.
+            // Remove this when webpack adds a warning or an error for this.
+            // See https://github.com/webpack/webpack/issues/6571
+            sideEffects: true,
           },
           // Adds support for CSS Modules (https://github.com/css-modules/css-modules)
           // using the extension .module.css
@@ -397,6 +402,11 @@ module.exports = {
               },
               'sass-loader'
             ),
+            // Don't consider CSS imports dead code even if the
+            // containing package claims to have no side effects.
+            // Remove this when webpack adds a warning or an error for this.
+            // See https://github.com/webpack/webpack/issues/6571
+            sideEffects: true,
           },
           // Adds support for CSS Modules, but using SASS
           // using the extension .module.scss or .module.sass


### PR DESCRIPTION
Fixes https://github.com/facebook/create-react-app/issues/5140. Fixes https://github.com/facebook/create-react-app/issues/5188.

While unfortunate due to concerns in https://github.com/facebook/create-react-app/issues/5188#issuecomment-425844969, I don't feel comfortable with webpack's default behavior until webpack adds a warning or an error for this (https://github.com/webpack/webpack/issues/6571#issuecomment-425897134). When webpack does, we can reconsider and go with webpack's default behavior.

I checked that this change fixes the reproducing case in https://github.com/cdaringe/will-u-load-my-styl.