### PR TITLE
Feed correct line number to gvim on launch

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -67,6 +67,7 @@ const COMMON_EDITORS_LINUX = {
   code: 'code',
   'code-insiders': 'code-insiders',
   emacs: 'emacs',
+  gvim: 'gvim',
   'idea.sh': 'idea',
   'phpstorm.sh': 'phpstorm',
   'pycharm.sh': 'pycharm',
@@ -136,6 +137,7 @@ function getArgumentsForLineNumber(
     case 'vim':
     case 'mvim':
     case 'joe':
+    case 'gvim':
       return ['+' + lineNumber, fileName];
     case 'emacs':
     case 'emacsclient':


### PR DESCRIPTION
Clicking Error overlay should feed the correct line number for gvim.

Relates to https://github.com/facebook/create-react-app/issues/2636.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
