### PR TITLE
Fix IE 11 compatibility

### DIFF
--- a/packages/react-error-overlay/src/utils/mapper.js
+++ b/packages/react-error-overlay/src/utils/mapper.js
@@ -34,9 +34,10 @@ async function map(
   });
   await settle(
     files.map(async fileName => {
-      const fetchUrl = fileName.startsWith('webpack-internal:')
-        ? `/__get-internal-source?fileName=${encodeURIComponent(fileName)}`
-        : fileName;
+      const fetchUrl =
+        fileName.indexOf('webpack-internal:') === 0
+          ? `/__get-internal-source?fileName=${encodeURIComponent(fileName)}`
+          : fileName;
 
       const fileSource = await fetch(fetchUrl).then(r => r.text());
       const map = await getSourceMap(fileName, fileSource);


### PR DESCRIPTION
`String.startsWith` doesn't exist in Internet Explorer.