### PR TITLE
Adds instructions to README on how to customize Bootstrap with Sass

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -810,7 +810,7 @@ Now you are ready to use the imported reactstrap components within your componen
 Sometimes you might need to tweak the visual styles of Bootstrap (or equivalent package).<br>
 As of `react-scripts@2.0.0` you can import `.scss` files. This makes it possible to use a package's built-in Sass variables for global style preferences.
 
-To customize Bootstrap, create a `.scss` file and import the Bootstrap source stlysheet. Add any overrides _before_ the imported file(s). You can reference [Bootstrap's documentation](http://getbootstrap.com/docs/4.1/getting-started/theming/#css-variables) for the names of the available variables.
+To customize Bootstrap, create a `.scss` file and import the Bootstrap source stylesheet. Add any overrides _before_ the imported file(s). You can reference [Bootstrap's documentation](http://getbootstrap.com/docs/4.1/getting-started/theming/#css-variables) for the names of the available variables.
 
 ```scss
 // Override default variables before the import

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -807,9 +807,10 @@ Now you are ready to use the imported reactstrap components within your componen
 
 ### Using a Custom Theme
 
-Sometimes you might need to tweak the visual styles of Bootstrap (or equivalent package). As of `react-scripts@2.0.0` you can easily import `.scss` files. This makes it possible to directly use the provided Bootstrap `.scss` files and customize them, without editing the core files.
+Sometimes you might need to tweak the visual styles of Bootstrap (or equivalent package).<br>
+As of `react-scripts@2.0.0` you can import `.scss` files. This makes it possible to use a package's built-in Sass variables for global style preferences.
 
-Create a `.scss` file and import the Bootstrap files you need. Add any overrides _before_ the imported file(s). You can reference Bootstraps `_variables.scss` for the names of the available variables.
+To customize Bootstrap, create a `.scss` file and import the Bootstrap source stlysheet. Add any overrides _before_ the imported file(s). You can reference [Bootstrap's documentation](http://getbootstrap.com/docs/4.1/getting-started/theming/#css-variables) for the names of the available variables.
 
 ```scss
 // Override default variables before the import
@@ -821,7 +822,7 @@ $body-bg: #000;
 
 > **Note:** You must prefix imports from `node_modules` with `~` as displayed above.
 
-Next, import the newly created `.scss` file instead of the default Bootstrap `.css`:
+Finally, import the newly created `.scss` file instead of the default Bootstrap `.css` in the beginning of your `src/index.js` file:
 
 ```javascript
 import './styles/custom.scss';

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -807,10 +807,12 @@ Now you are ready to use the imported reactstrap components within your componen
 
 ### Using a Custom Theme
 
+> Note: this feature is available with `react-scripts@2.0.0` and higher.
+
 Sometimes you might need to tweak the visual styles of Bootstrap (or equivalent package).<br>
 As of `react-scripts@2.0.0` you can import `.scss` files. This makes it possible to use a package's built-in Sass variables for global style preferences.
 
-To customize Bootstrap, create a `.scss` file and import the Bootstrap source stylesheet. Add any overrides _before_ the imported file(s). You can reference [Bootstrap's documentation](http://getbootstrap.com/docs/4.1/getting-started/theming/#css-variables) for the names of the available variables.
+To customize Bootstrap, create a file called `src/custom.scss` (or similar) and import the Bootstrap source stylesheet. Add any overrides _before_ the imported file(s). You can reference [Bootstrap's documentation](http://getbootstrap.com/docs/4.1/getting-started/theming/#css-variables) for the names of the available variables.
 
 ```scss
 // Override default variables before the import
@@ -822,10 +824,10 @@ $body-bg: #000;
 
 > **Note:** You must prefix imports from `node_modules` with `~` as displayed above.
 
-Finally, import the newly created `.scss` file instead of the default Bootstrap `.css` in the beginning of your `src/index.js` file:
+Finally, import the newly created `.scss` file instead of the default Bootstrap `.css` in the beginning of your `src/index.js` file, for example:
 
 ```javascript
-import './styles/custom.scss';
+import './custom.scss';
 ```
 
 ## Adding Flow

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -684,8 +684,8 @@ An alternative way of handling static assets is described in the next section.
 One way to add SVG files was described in the section above. You can also import SVGs directly as React components. You can use either of the two approaches. In your code it would look like this:
 
 ```js
-import { ReactComponent as Logo } from './logo.svg'
- const App = () => (
+import { ReactComponent as Logo } from './logo.svg';
+const App = () => (
   <div>
     {/* Logo is an actual React component */}
     <Logo />
@@ -807,14 +807,25 @@ Now you are ready to use the imported reactstrap components within your componen
 
 ### Using a Custom Theme
 
-Sometimes you might need to tweak the visual styles of Bootstrap (or equivalent package).<br>
-We suggest the following approach:
+Sometimes you might need to tweak the visual styles of Bootstrap (or equivalent package). As of `react-scripts@2.0.0` you can easily import `.scss` files. This makes it possible to directly use the provided Bootstrap `.scss` files and customize them, without editing the core files.
 
-- Create a new package that depends on the package you wish to customize, e.g. Bootstrap.
-- Add the necessary build steps to tweak the theme, and publish your package on npm.
-- Install your own theme npm package as a dependency of your app.
+Create a `.scss` file and import the Bootstrap files you need. Add any overrides _before_ the imported file(s). You can reference Bootstraps `_variables.scss` for the names of the available variables.
 
-Here is an example of adding a [customized Bootstrap](https://medium.com/@tacomanator/customizing-create-react-app-aa9ffb88165) that follows these steps.
+```scss
+// Override default variables before the import
+$body-bg: #000;
+
+// Import Bootstrap and its default variables
+@import '~bootstrap/scss/bootstrap.scss';
+```
+
+> **Note:** You must prefix imports from `node_modules` with `~` as displayed above.
+
+Next, import the newly created `.scss` file instead of the default Bootstrap `.css`:
+
+```javascript
+import './styles/custom.scss';
+```
 
 ## Adding Flow
 


### PR DESCRIPTION
As discussed in #5154 there's an easier way to customize Bootstrap in React using Sass (starting from `react-scripts@2.0.0`). I've changed the section in the docs to make use of Sass (and tested the code of course). I'm hoping the level of detail is good here. I thought about going deeper but I felt it wasn't needed. 