### PR TITLE
Don't crash npm test when hg/git are missing

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -31,7 +31,26 @@ if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
 // @remove-on-eject-end
 
 const jest = require('jest');
+const execSync = require('child_process').execSync;
 let argv = process.argv.slice(2);
+
+function isInGitRepository() {
+  try {
+    execSync('git rev-parse --is-inside-work-tree', { stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function isInMercurialRepository() {
+  try {
+    execSync('hg --cwd . root', { stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
 
 // Watch unless on CI, in coverage mode, or explicitly running all tests
 if (
@@ -39,7 +58,9 @@ if (
   argv.indexOf('--coverage') === -1 &&
   argv.indexOf('--watchAll') === -1
 ) {
-  argv.push('--watch');
+  // https://github.com/facebook/create-react-app/issues/5210
+  const hasSourceControl = isInGitRepository() || isInMercurialRepository();
+  argv.push(hasSourceControl ? '--watch' : '--watchAll');
 }
 
 // @remove-on-eject-begin


### PR DESCRIPTION
Fixes https://github.com/facebook/create-react-app/issues/5210 with a clunky workaround.
I hope this more or less matches the Jest logic.