### PR TITLE
Fix GENERATE_SOURCEMAP env not working for css sourcemap

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -171,14 +171,16 @@ module.exports = {
       new OptimizeCSSAssetsPlugin({
         cssProcessorOptions: {
           parser: safePostCssParser,
-          map: {
-            // `inline: false` forces the sourcemap to be output into a
-            // separate file
-            inline: false,
-            // `annotation: true` appends the sourceMappingURL to the end of
-            // the css file, helping the browser find the sourcemap
-            annotation: true,
-          },
+          map: shouldUseSourceMap
+            ? {
+                // `inline: false` forces the sourcemap to be output into a
+                // separate file
+                inline: false,
+                // `annotation: true` appends the sourceMappingURL to the end of
+                // the css file, helping the browser find the sourcemap
+                annotation: true,
+              }
+            : false,
         },
       }),
     ],


### PR DESCRIPTION
This fixes `GENERATE_SOURCEMAP` env option not being respected for css sourcemap, by checking its presence before passing sourcemap options to `OptimizeCSSAssetsPlugin`.

It can be simply tested by running `react-scripts build` with and without `GENERATE_SOURCEMAP=false`, and see if any sourcemaps are being created under `build/static/css`