### PR TITLE
Set the color palette to something a bit more React-y

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -3,25 +3,8 @@
   "localized-strings": {
     "next": "Next",
     "previous": "Previous",
-    "tagline": "A website for testing",
-    "docs": {
-      "doc1": {
-        "title": "Latin-ish",
-        "sidebar_label": "Example Page"
-      },
-      "doc2": {
-        "title": "document number 2"
-      },
-      "doc3": {
-        "title": "This is document number 3"
-      },
-      "doc4": {
-        "title": "Other Document"
-      },
-      "doc5": {
-        "title": "Fifth Document"
-      }
-    },
+    "tagline": "Create React apps with no build configuration.",
+    "docs": {},
     "links": {
       "Docs": "Docs",
       "API": "API",

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -38,8 +38,8 @@ const siteConfig = {
 
   /* Colors for website */
   colors: {
-    primaryColor: '#2E8555',
-    secondaryColor: '#205C3B',
+    primaryColor: '#20232a',
+    secondaryColor: '#61dafb',
   },
 
   /* Custom fonts for website */


### PR DESCRIPTION
This commit sets the primary and secondary color of the Docusaurus page to the same as the main React site (primary = dark gray / black, secondary = bright blue).

Again, we might want to do something else later, but this sure looks more on-theme than the defaults :) 

Addresses #5238