### PR TITLE
Fix `mjs` handling for graphql

### DIFF
--- a/fixtures/browser/issue-5234-direct-mjs-package/__snapshots__/index.test.js.snap
+++ b/fixtures/browser/issue-5234-direct-mjs-package/__snapshots__/index.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue #5234 (mjs files are imported as static files) correctly bundles files in development 1`] = `
+Object {
+  "graphql": "undefined",
+  "parse": "function",
+  "test": "/static/media/Test.4478d87c.mjs",
+}
+`;

--- a/fixtures/browser/issue-5234-direct-mjs-package/index.test.js
+++ b/fixtures/browser/issue-5234-direct-mjs-package/index.test.js
@@ -1,0 +1,29 @@
+const { bootstrap, startDevelopmentServer } = require('../../utils');
+const puppeteer = require('puppeteer');
+
+beforeEach(async () => {
+  await bootstrap({ directory: global.testDirectory, template: __dirname });
+  global.appPort = await startDevelopmentServer({
+    directory: global.testDirectory,
+  });
+  await new Promise(resolve => setTimeout(resolve, 3000));
+});
+
+// https://github.com/facebook/create-react-app/issues/5234
+describe('issue #5234 (mjs files are imported as static files)', () => {
+  it('correctly bundles files in development', async () => {
+    const browser = await puppeteer.launch({ headless: true });
+    try {
+      const page = await browser.newPage();
+      console.log(`http://localhost:${global.appPort}/`);
+      await page.goto(`http://localhost:${global.appPort}/`);
+      await page.waitForSelector('.App-Ready');
+      const output = await page.evaluate(() => {
+        return document.testData;
+      });
+      expect(output).toMatchSnapshot();
+    } finally {
+      browser.close();
+    }
+  });
+});

--- a/fixtures/browser/issue-5234-direct-mjs-package/package.json
+++ b/fixtures/browser/issue-5234-direct-mjs-package/package.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "react": "^16.5.2",
+    "react-dom": "^16.5.2",
+    "graphql": "14.0.2"
+  }
+}

--- a/fixtures/browser/issue-5234-direct-mjs-package/public/index.html
+++ b/fixtures/browser/issue-5234-direct-mjs-package/public/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <title>React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/fixtures/browser/issue-5234-direct-mjs-package/src/Test.mjs
+++ b/fixtures/browser/issue-5234-direct-mjs-package/src/Test.mjs
@@ -1,0 +1,6 @@
+export function foo() {
+  console.log('fooey');
+}
+export default function bar() {
+  console.log('barrio');
+}

--- a/fixtures/browser/issue-5234-direct-mjs-package/src/index.html
+++ b/fixtures/browser/issue-5234-direct-mjs-package/src/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <title>React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/fixtures/browser/issue-5234-direct-mjs-package/src/index.js
+++ b/fixtures/browser/issue-5234-direct-mjs-package/src/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import graphql, { parse } from 'graphql';
+import test from './Test.mjs';
+
+class App extends React.Component {
+  state = { ready: false };
+  async componentDidMount() {
+    document.testData = { graphql: typeof graphql, parse: typeof parse, test };
+    this.setState({ ready: true });
+  }
+  render() {
+    return this.state.ready ? <div className="App-Ready" /> : null;
+  }
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/fixtures/browser/jest.config.js
+++ b/fixtures/browser/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.js'],
+  testPathIgnorePatterns: ['/src/', 'node_modules'],
+  setupTestFrameworkScriptFile: './setupSmokeTests.js',
+};

--- a/fixtures/browser/setupSmokeTests.js
+++ b/fixtures/browser/setupSmokeTests.js
@@ -1,0 +1,10 @@
+const fs = require('fs-extra');
+const tempy = require('tempy');
+
+beforeEach(() => {
+  global.testDirectory = tempy.directory();
+  jest.setTimeout(1000 * 60 * 5);
+});
+afterEach(() => {
+  fs.removeSync(global.testDirectory);
+});

--- a/fixtures/utils.js
+++ b/fixtures/utils.js
@@ -111,6 +111,24 @@ async function getOutputDevelopment({ directory, env = {} }) {
   }
 }
 
+async function startDevelopmentServer({ directory, env = {} }) {
+  const port = await getPort();
+  execa('./node_modules/.bin/react-scripts', ['start'], {
+    cwd: directory,
+    env: Object.assign(
+      {},
+      {
+        BROWSER: 'none',
+        PORT: port,
+        CI: 'false',
+        FORCE_COLOR: '0',
+      },
+      env
+    ),
+  });
+  return port;
+}
+
 async function getOutputProduction({ directory, env = {} }) {
   try {
     const { stdout, stderr } = await execa(
@@ -141,5 +159,6 @@ module.exports = {
   isSuccessfulProduction,
   isSuccessfulTest,
   getOutputDevelopment,
+  startDevelopmentServer,
   getOutputProduction,
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "meow": "^5.0.0",
     "multimatch": "^2.1.0",
     "prettier": "1.14.3",
+    "puppeteer": "^1.8.0",
     "strip-ansi": "^4.0.0",
     "svg-term-cli": "^2.1.1",
     "tempy": "^0.2.1"

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -206,7 +206,6 @@ module.exports = {
         // the use of this extension, so we need to tell webpack to fall back
         // to auto mode (ES Module interop, allows ESM to import CommonJS).
         test: /\.mjs$/,
-        include: /node_modules/,
         type: 'javascript/auto',
       },
       {
@@ -271,10 +270,23 @@ module.exports = {
               cacheCompression: false,
             },
           },
+          // Make sure `mjs` files get processed as files, not JS. We don't
+          // support `mjs`, so we deliver a file for now.
+          {
+            test: /\.mjs$/,
+            include: paths.appSrc,
+            loader: require.resolve('file-loader'),
+            options: {
+              name: 'static/media/[name].[hash:8].[ext]',
+            },
+          },
           // Process any JS outside of the app with Babel.
           // Unlike the application JS, we only compile the standard ES features.
+          // `mjs` needs to be included here because some libraries forcibly
+          // import files with the `mjs` extension, or have set their `browser`
+          // or `module` field to a `mjs` file.
           {
-            test: /\.js$/,
+            test: /\.m?js$/,
             exclude: /@babel(?:\/|\\{1,2})runtime/,
             loader: require.resolve('babel-loader'),
             options: {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -274,7 +274,6 @@ module.exports = {
         // the use of this extension, so we need to tell webpack to fall back
         // to auto mode (ES Module interop, allows ESM to import CommonJS).
         test: /\.mjs$/,
-        include: /node_modules/,
         type: 'javascript/auto',
       },
       {
@@ -284,6 +283,7 @@ module.exports = {
         oneOf: [
           // "url" loader works just like "file" loader but it also embeds
           // assets smaller than specified size as data URLs to avoid requests.
+          // A missing `test` is equivalent to a match.
           {
             test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
             loader: require.resolve('url-loader'),
@@ -337,10 +337,23 @@ module.exports = {
               compact: true,
             },
           },
+          // Make sure `mjs` files get processed as files, not JS. We don't
+          // support `mjs`, so we deliver a file for now.
+          {
+            test: /\.mjs$/,
+            include: paths.appSrc,
+            loader: require.resolve('file-loader'),
+            options: {
+              name: 'static/media/[name].[hash:8].[ext]',
+            },
+          },
           // Process any JS outside of the app with Babel.
           // Unlike the application JS, we only compile the standard ES features.
+          // `mjs` needs to be included here because some libraries forcibly
+          // import files with the `mjs` extension, or have set their `browser`
+          // or `module` field to a `mjs` file.
           {
-            test: /\.js$/,
+            test: /\.m?js$/,
             exclude: /@babel(?:\/|\\{1,2})runtime/,
             loader: require.resolve('babel-loader'),
             options: {

--- a/tasks/e2e-behavior.sh
+++ b/tasks/e2e-behavior.sh
@@ -95,6 +95,9 @@ git clean -df
 # Now that we have published them, run all tests as if they were released.
 # ******************************************************************************
 
+# Browser tests
+CI=true ./node_modules/.bin/jest --config fixtures/browser/jest.config.js
+
 # Smoke tests
 CI=true ./node_modules/.bin/jest --config fixtures/smoke/jest.config.js
 


### PR DESCRIPTION
Fixes #5234.
Closes #5235.

This pull request allows packages to import from dependencies who export a `mjs` file (instead of us giving a URL).
It also ensures that a user who uses `mjs` in *their* application gets a file.

I'm really getting tired of all of these `mjs` hacks, because now we "sort of" support `mjs`. e.g.:
If a user defines their `module` field in `package.json` as `index.mjs` and then explicitly import files with `.mjs` instead of being extensionless, we'll keep loading them.

---

I wonder if we can somehow tell webpack to not use `module` if the field is `mjs`? That would prevent this hack.