### PR TITLE
Add `.mjs` support back to webpack (it has native ESM support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ matrix:
     - os: osx
       node_js: 8
       env: TEST_SUITE=behavior
-    - node_js: 4
+    - node_js: 6
       env: TEST_SUITE=old-node

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -144,7 +144,7 @@ module.exports = {
     // https://github.com/facebook/create-react-app/issues/290
     // `web` extension prefixes have been added for better support
     // for React Native Web.
-    extensions: ['.web.js', '.js', '.json', '.web.jsx', '.jsx'],
+    extensions: ['.mjs', '.web.js', '.js', '.json', '.web.jsx', '.jsx'],
     alias: {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
@@ -178,7 +178,7 @@ module.exports = {
       // First, run the linter.
       // It's important to do this before Babel processes the JS.
       {
-        test: /\.(js|jsx)$/,
+        test: /\.(js|mjs|jsx)$/,
         enforce: 'pre',
         use: [
           {
@@ -200,16 +200,6 @@ module.exports = {
         include: paths.appSrc,
       },
       {
-        // `mjs` support is still in its infancy in the ecosystem, so we don't
-        // support it.
-        // Modules who define their `browser` or `module` key as `mjs` force
-        // the use of this extension, so we need to tell webpack to fall back
-        // to auto mode (ES Module interop, allows ESM to import CommonJS).
-        test: /\.mjs$/,
-        include: /node_modules/,
-        type: 'javascript/auto',
-      },
-      {
         // "oneOf" will traverse all following loaders until one will
         // match the requirements. When no loader matches it will fall
         // back to the "file" loader at the end of the loader list.
@@ -228,7 +218,7 @@ module.exports = {
           // Process application JS with Babel.
           // The preset includes JSX, Flow, and some ESnext features.
           {
-            test: /\.(js|jsx)$/,
+            test: /\.(js|mjs|jsx)$/,
             include: paths.appSrc,
             loader: require.resolve('babel-loader'),
             options: {
@@ -274,7 +264,7 @@ module.exports = {
           // Process any JS outside of the app with Babel.
           // Unlike the application JS, we only compile the standard ES features.
           {
-            test: /\.js$/,
+            test: /\.(js|mjs)$/,
             exclude: /@babel(?:\/|\\{1,2})runtime/,
             loader: require.resolve('babel-loader'),
             options: {
@@ -361,7 +351,7 @@ module.exports = {
             // its runtime that would otherwise be processed through "file" loader.
             // Also exclude `html` and `json` extensions so they get processed
             // by webpacks internal loaders.
-            exclude: [/\.(js|jsx)$/, /\.html$/, /\.json$/],
+            exclude: [/\.(js|mjs|jsx)$/, /\.html$/, /\.json$/],
             loader: require.resolve('file-loader'),
             options: {
               name: 'static/media/[name].[hash:8].[ext]',

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -174,15 +174,6 @@ module.exports = {
     rules: [
       // Disable require.ensure as it's not a standard language feature.
       { parser: { requireEnsure: false } },
-      // webpack 4 turned on stricter defaults for .mjs, preventing it from
-      // performing ESM/CommonJS interoperation. While the ecosystem is
-      // fleshing out experimental .mjs support, we need to relax this
-      // constraint.
-      // https://github.com/facebook/create-react-app/pull/5258#discussion_r222155465
-      {
-        test: /\.mjs$/,
-        type: 'javascript/auto',
-      },
 
       // First, run the linter.
       // It's important to do this before Babel processes the JS.

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -174,6 +174,15 @@ module.exports = {
     rules: [
       // Disable require.ensure as it's not a standard language feature.
       { parser: { requireEnsure: false } },
+      // webpack 4 turned on stricter defaults for .mjs, preventing it from
+      // performing ESM/CommonJS interoperation. While the ecosystem is
+      // fleshing out experimental .mjs support, we need to relax this
+      // constraint.
+      // https://github.com/facebook/create-react-app/pull/5258#discussion_r222155465
+      {
+        test: /\.mjs$/,
+        type: 'javascript/auto',
+      },
 
       // First, run the linter.
       // It's important to do this before Babel processes the JS.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -210,7 +210,7 @@ module.exports = {
     // https://github.com/facebook/create-react-app/issues/290
     // `web` extension prefixes have been added for better support
     // for React Native Web.
-    extensions: ['.web.js', '.js', '.json', '.web.jsx', '.jsx'],
+    extensions: ['.mjs', '.web.js', '.js', '.json', '.web.jsx', '.jsx'],
     alias: {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
@@ -244,7 +244,7 @@ module.exports = {
       // First, run the linter.
       // It's important to do this before Babel processes the JS.
       {
-        test: /\.(js|jsx)$/,
+        test: /\.(js|mjs|jsx)$/,
         enforce: 'pre',
         use: [
           {
@@ -268,16 +268,6 @@ module.exports = {
         include: paths.appSrc,
       },
       {
-        // `mjs` support is still in its infancy in the ecosystem, so we don't
-        // support it.
-        // Modules who define their `browser` or `module` key as `mjs` force
-        // the use of this extension, so we need to tell webpack to fall back
-        // to auto mode (ES Module interop, allows ESM to import CommonJS).
-        test: /\.mjs$/,
-        include: /node_modules/,
-        type: 'javascript/auto',
-      },
-      {
         // "oneOf" will traverse all following loaders until one will
         // match the requirements. When no loader matches it will fall
         // back to the "file" loader at the end of the loader list.
@@ -295,7 +285,7 @@ module.exports = {
           // Process application JS with Babel.
           // The preset includes JSX, Flow, and some ESnext features.
           {
-            test: /\.(js|jsx)$/,
+            test: /\.(js|mjs|jsx)$/,
             include: paths.appSrc,
 
             loader: require.resolve('babel-loader'),
@@ -340,7 +330,7 @@ module.exports = {
           // Process any JS outside of the app with Babel.
           // Unlike the application JS, we only compile the standard ES features.
           {
-            test: /\.js$/,
+            test: /\.(js|mjs)$/,
             exclude: /@babel(?:\/|\\{1,2})runtime/,
             loader: require.resolve('babel-loader'),
             options: {
@@ -445,7 +435,7 @@ module.exports = {
             // it's runtime that would otherwise be processed through "file" loader.
             // Also exclude `html` and `json` extensions so they get processed
             // by webpacks internal loaders.
-            exclude: [/\.(js|jsx)$/, /\.html$/, /\.json$/],
+            exclude: [/\.(js|mjs|jsx)$/, /\.html$/, /\.json$/],
             options: {
               name: 'static/media/[name].[hash:8].[ext]',
             },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -240,6 +240,15 @@ module.exports = {
     rules: [
       // Disable require.ensure as it's not a standard language feature.
       { parser: { requireEnsure: false } },
+      // webpack 4 turned on stricter defaults for .mjs, preventing it from
+      // performing ESM/CommonJS interoperation. While the ecosystem is
+      // fleshing out experimental .mjs support, we need to relax this
+      // constraint.
+      // https://github.com/facebook/create-react-app/pull/5258#discussion_r222155465
+      {
+        test: /\.mjs$/,
+        type: 'javascript/auto',
+      },
 
       // First, run the linter.
       // It's important to do this before Babel processes the JS.

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -240,15 +240,6 @@ module.exports = {
     rules: [
       // Disable require.ensure as it's not a standard language feature.
       { parser: { requireEnsure: false } },
-      // webpack 4 turned on stricter defaults for .mjs, preventing it from
-      // performing ESM/CommonJS interoperation. While the ecosystem is
-      // fleshing out experimental .mjs support, we need to relax this
-      // constraint.
-      // https://github.com/facebook/create-react-app/pull/5258#discussion_r222155465
-      {
-        test: /\.mjs$/,
-        type: 'javascript/auto',
-      },
 
       // First, run the linter.
       // It's important to do this before Babel processes the JS.


### PR DESCRIPTION
Fixes #5234.
Closes #5257.
Closes #5235.

Webpack was never the problem with `.mjs` support, so we probably shouldn't of removed it.

We still want to figure out a story for Jest, we're just not sure what that is yet.

---

I opted to resolve `.mjs` before `.web.js` this time, does this seem OK?