### PR TITLE
override settings for @babel/preset-env and regenerator.

### DIFF
--- a/packages/babel-preset-react-app/dependencies.js
+++ b/packages/babel-preset-react-app/dependencies.js
@@ -20,6 +20,12 @@ const validateBoolOption = (name, value, defaultValue) => {
   return value;
 };
 
+// @babel/preset-env provides good validations and error messages for bogus
+// options. Here we are simply falling back to default if the overrides are
+// falsey.
+const validatePresetEnvOptions = (options, defaultOptions) =>
+  options || defaultOptions;
+
 module.exports = function(api, opts) {
   if (!opts) {
     opts = {};
@@ -37,6 +43,11 @@ module.exports = function(api, opts) {
   var isEnvTest = env === 'test';
 
   var areHelpersEnabled = validateBoolOption('helpers', opts.helpers, false);
+  var isRegeneratorEnabled = validateBoolOption(
+    'regenerator',
+    opts.regenerator,
+    true
+  );
   var useAbsoluteRuntime = validateBoolOption(
     'absoluteRuntime',
     opts.absoluteRuntime,
@@ -49,6 +60,13 @@ module.exports = function(api, opts) {
       require.resolve('@babel/runtime/package.json')
     );
   }
+
+  // We allow for separate preset overrides for production/development and test.
+  var presetEnvOverrides = validatePresetEnvOptions(opts.presetEnv, undefined);
+  var presetEnvTestOverrides = validatePresetEnvOptions(
+    opts.presetEnvTest,
+    undefined
+  );
 
   if (!isEnvDevelopment && !isEnvProduction && !isEnvTest) {
     throw new Error(
@@ -70,36 +88,42 @@ module.exports = function(api, opts) {
       isEnvTest && [
         // ES features necessary for user's Node version
         require('@babel/preset-env').default,
-        {
-          targets: {
-            node: 'current',
+        Object.assign(
+          {
+            targets: {
+              node: 'current',
+            },
+            // Do not transform modules to CJS
+            modules: false,
+            // Exclude transforms that make all code slower
+            exclude: ['transform-typeof-symbol'],
           },
-          // Do not transform modules to CJS
-          modules: false,
-          // Exclude transforms that make all code slower
-          exclude: ['transform-typeof-symbol'],
-        },
+          presetEnvTestOverrides
+        ),
       ],
       (isEnvProduction || isEnvDevelopment) && [
         // Latest stable ECMAScript features
         require('@babel/preset-env').default,
-        {
-          // We want Create React App to be IE 9 compatible until React itself
-          // no longer works with IE 9
-          targets: {
-            ie: 9,
+        Object.assign(
+          {
+            // We want Create React App to be IE 9 compatible until React itself
+            // no longer works with IE 9
+            targets: {
+              ie: 9,
+            },
+            // Users cannot override this behavior because this Babel
+            // configuration is highly tuned for ES5 support
+            ignoreBrowserslistConfig: true,
+            // If users import all core-js they're probably not concerned with
+            // bundle size. We shouldn't rely on magic to try and shrink it.
+            useBuiltIns: false,
+            // Do not transform modules to CJS
+            modules: false,
+            // Exclude transforms that make all code slower
+            exclude: ['transform-typeof-symbol'],
           },
-          // Users cannot override this behavior because this Babel
-          // configuration is highly tuned for ES5 support
-          ignoreBrowserslistConfig: true,
-          // If users import all core-js they're probably not concerned with
-          // bundle size. We shouldn't rely on magic to try and shrink it.
-          useBuiltIns: false,
-          // Do not transform modules to CJS
-          modules: false,
-          // Exclude transforms that make all code slower
-          exclude: ['transform-typeof-symbol'],
-        },
+          presetEnvOverrides
+        ),
       ],
     ].filter(Boolean),
     plugins: [
@@ -110,7 +134,7 @@ module.exports = function(api, opts) {
         {
           corejs: false,
           helpers: areHelpersEnabled,
-          regenerator: true,
+          regenerator: isRegeneratorEnabled,
           // https://babeljs.io/docs/en/babel-plugin-transform-runtime#useesmodules
           // We should turn this on once the lowest version of Node LTS
           // supports ES Modules.


### PR DESCRIPTION
https://github.com/facebook/create-react-app/issues/5216

Adds a few new options for `babel-preset-react-app`. This is useful for cases where you want to customize your build targets, like building for node. This is required for adding server-side rendering to a forked/ejected react-scripts project.

- `presetEnv` - defaults to undefined. Used to override the default values for development and prod. Can be any valid options for `@babel/present-env`
- `presetEnvTest` - defaults to undefined. Used to override the default values for test. Can be any valid options for `@babel/present-env`
- `regenerator` - defaults to true, set to false in cases where your targets all support generators natively (like for a node target)

**Usage:**

Compare to [`webpack.config.prod.js` application bundle](https://github.com/facebook/create-react-app/blob/b41e69662a378c1f851246cfbb94dc068c7f785c/packages/react-scripts/config/webpack.config.prod.js#L299)
```js
presets: [
  [
    require.resolve('babel-preset-react-app'),
    {
      presetEnv: {
        modules: 'cjs',
        targets: { node: 'current' },
      },
      regenerator: false,
    },
  ],
],
```

Compare to [`webpack.config.prod.js` dependency bundle](https://github.com/facebook/create-react-app/blob/b41e69662a378c1f851246cfbb94dc068c7f785c/packages/react-scripts/config/webpack.config.prod.js#L340-L345)
```js
presets: [
  [
    require.resolve('babel-preset-react-app/dependencies'),
    {
      helpers: true,
      presetEnv: {
        modules: 'cjs',
        targets: { node: 'current' },
      },
      regenerator: false,
    },
  ],
],
```