### PR TITLE
Changes the start script to tap on the done and failed hooks of the c…

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -112,7 +112,20 @@ checkBrowsers(paths.appPath, isInteractive)
         clearConsole();
       }
       console.log(chalk.cyan('Starting the development server...\n'));
-      openBrowser(urls.localUrlForBrowser);
+      
+      /** Creates a function to control when the browser is open only once :) */
+      const openBrowserIfNotOpen = ((isBrowserOpen) => () => {
+        if (isBrowserOpen) {
+          return;
+        }
+
+        isBrowserOpen = true;
+        openBrowser(urls.localUrlForBrowser);
+      })(false);
+
+      /** Taps on the done or failed events */
+      compiler.hooks.done.tap('openBrowserIfNotOpen', () => openBrowserIfNotOpen());
+      compiler.hooks.failed.tap('openBrowserIfNotOpen', () => openBrowserIfNotOpen());
     });
 
     ['SIGINT', 'SIGTERM'].forEach(function(sig) {


### PR DESCRIPTION
# What does this PR do:

  * Changes the start script to tap on the done and failed hooks of the compiler to know the right time to run.

# Where should the reviewer start:

  * The `packages/react-scripts/scripts/start.js` was modified, more specifically the `devServer.listen()` callback.

 # What is this trying to solve:

  * When doing `yarn start` the server boots up, opens the browser, but renders a blank page (with the `<script>` tags properly injected.
  * After getting that, tried to reproduce the same behaviour with `yarn build` and `serve -s build`, which I was unable to. That led me to think that the problem was between the dev server or bundle compilation
  * Next step, I edited the `node_modules/react-scripts/scripts/start.js`, in the same area I've changed for this PR, but placing only a `setTimeout(() => openBrowser(urls.localUrlForBrowser), 5000);` ... That _solved_ it - but looked _hackish_... Led to the obvious question of "What if bundling would take more than X seconds set in the timeout? Not cool"...
    * So I changed the implementation to call on `done` or `failed` hooks on the compiler.
    * Last but not the least, I created a function that returns a closure controlling if the browser is already open. I'm totally fine with changing it to make it more readable, or even removing it totally if `openBrowser` already checks that.

Let me know your thoughts on this and how can I improve it, or if it's something that I shouldn't be doing. I'm all for learning more about it 👍 