### PR TITLE
Adds a version check when using --use-pnp

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -242,7 +242,22 @@ function createApp(name, verbose, version, useNpm, usePnp, template) {
       // Fall back to latest supported react-scripts for npm 3
       version = 'react-scripts@0.9.x';
     }
+  } else if (usePnp) {
+    const yarnInfo = checkYarnVersion();
+    if (!yarnInfo.hasMinYarnPnp) {
+      if (yarnInfo.yarnVersion) {
+        chalk.yellow(
+          `You are using Yarn ${
+            yarnInfo.yarnVersion
+          } together with the --use-pnp flag, but Plug'n'Play is only supported starting from the 1.12 release.\n\n` +
+            `Please update to Yarn 1.12 or higher for a better, fully supported experience.\n`
+        );
+      }
+      // 1.11 had an issue with webpack-dev-middleware, so better not use PnP with it (never reached stable, but still)
+      usePnp = false;
+    }
   }
+
   run(
     root,
     appName,
@@ -562,6 +577,23 @@ function checkNpmVersion() {
   return {
     hasMinNpm: hasMinNpm,
     npmVersion: npmVersion,
+  };
+}
+
+function checkYarnVersion() {
+  let hasMinYarnPnp = false;
+  let yarnVersion = null;
+  try {
+    yarnVersion = execSync('yarnpkg --version')
+      .toString()
+      .trim();
+    hasMinYarnPnp = semver.gte(yarnVersion, '1.12.0');
+  } catch (err) {
+    // ignore
+  }
+  return {
+    hasMinYarnPnp: hasMinYarnPnp,
+    yarnVersion: yarnVersion,
   };
 }
 


### PR DESCRIPTION
This PR ensures that users of `--use-pnp` are using at least the 1.12 release, which is the first one supported by `create-react-app`.

Ref #5255