### PR TITLE
Disable Symbol typeof transform

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -82,6 +82,8 @@ module.exports = function(api, opts, env) {
           useBuiltIns: false,
           // Do not transform modules to CJS
           modules: false,
+          // Exclude transforms that make all code slower
+          exclude: ['transform-typeof-symbol'],
         },
       ],
       [

--- a/packages/babel-preset-react-app/dependencies.js
+++ b/packages/babel-preset-react-app/dependencies.js
@@ -76,6 +76,8 @@ module.exports = function(api, opts) {
           },
           // Do not transform modules to CJS
           modules: false,
+          // Exclude transforms that make all code slower
+          exclude: ['transform-typeof-symbol'],
         },
       ],
       (isEnvProduction || isEnvDevelopment) && [
@@ -95,6 +97,8 @@ module.exports = function(api, opts) {
           useBuiltIns: false,
           // Do not transform modules to CJS
           modules: false,
+          // Exclude transforms that make all code slower
+          exclude: ['transform-typeof-symbol'],
         },
       ],
     ].filter(Boolean),


### PR DESCRIPTION
I think leaving it on was a mistake. It causes some issues (https://github.com/facebook/create-react-app/issues/5267), but more fundamentally, it's a leaky abstraction. It tries to make `typeof` behave to return `'symbol'` for Symbols by hijacking every single `typeof`. This leads to slowing down all code for the benefit of edge cases that likely won't work 100% correctly anyway. It *definitely* makes React slower (I've measured this before).

I considered disabling it just for `node_modules` at first. But I don't see good reasons to leave it on in application code either. Code that relies on this is inherently fragile and can break in other ways.

We're early enough in 2.x cycle that I consider this a bugfix. It definitely *will* fix bugs for some libraries in `node_modules`. And arguably performance improvements in the application code are worth the edge case issues that this would uncover.