### PR TITLE
[create-react-app] avoid copying cached yarn.lock for custom scripts

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -258,7 +258,7 @@ function createApp(name, verbose, version, useNpm, usePnp, template) {
     }
   }
 
-  if (useYarn && !version) {
+  if (useYarn && !semver.valid(version)) {
     fs.copySync(
       require.resolve('./yarn.lock.cached'),
       path.join(root, 'yarn.lock')

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -258,7 +258,7 @@ function createApp(name, verbose, version, useNpm, usePnp, template) {
     }
   }
 
-  if (useYarn) {
+  if (useYarn && !version) {
     fs.copySync(
       require.resolve('./yarn.lock.cached'),
       path.join(root, 'yarn.lock')


### PR DESCRIPTION
per discussion in facebook/create-react-app#5270, do not copy cached `yarn.lock` file if `--scripts-version=[custom-package]` is provided.

May this save us weird PRs ("your lockfile is breaking my package") in the future... :)