### PR TITLE
Updated the URL in index.html

### DIFF
--- a/packages/react-scripts/template/public/index.html
+++ b/packages/react-scripts/template/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000">
     <!--
       manifest.json provides metadata used when your web app is added to the
-      homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+      homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <!--


### PR DESCRIPTION
It seems correct URL is https://developers.google.com/web/fundamentals/web-app-manifest/
Current URL (https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/) is redirecting to there.
