### PR TITLE
Update eslint-plugin-jsx-a11y version

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -40,7 +40,7 @@
     "eslint-loader": "2.1.1",
     "eslint-plugin-flowtype": "2.50.1",
     "eslint-plugin-import": "2.14.0",
-    "eslint-plugin-jsx-a11y": "6.1.1",
+    "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-react": "7.11.1",
     "file-loader": "2.0.0",
     "fs-extra": "7.0.0",


### PR DESCRIPTION
Updated the version of `eslint-plugin-jsx-a11y` from `6.1.1` to `6.1.2`.

Properly closes #4141 

Adds clearer error messages for the `anchor-is-valid` rule as per https://github.com/evcohen/eslint-plugin-jsx-a11y/pull/486.