### PR TITLE
Removing unnecessary spread plugin proposal since it's in @babel@7

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -120,15 +120,6 @@ module.exports = function(api, opts, env) {
           loose: true,
         },
       ],
-      // The following two plugins use Object.assign directly, instead of Babel's
-      // extends helper. Note that this assumes `Object.assign` is available.
-      // { ...todo, completed: true }
-      [
-        require('@babel/plugin-proposal-object-rest-spread').default,
-        {
-          useBuiltIns: true,
-        },
-      ],
       // Polyfills the runtime needed for async/await, generators, and friends
       // https://babeljs.io/docs/en/babel-plugin-transform-runtime
       [


### PR DESCRIPTION
Related to the issue #5310 that's a correct observation since ```"@babel/core": "7.1.0"``` is already a dependency make this plugin unnecessary. 

https://babeljs.io/blog/2018/08/27/7.0.0#tc39-proposals-https-githubcom-tc39-proposals-support