### PR TITLE
Fix file size report after build (#5333)

### DIFF
--- a/packages/react-dev-utils/FileSizeReporter.js
+++ b/packages/react-dev-utils/FileSizeReporter.js
@@ -17,9 +17,9 @@ var gzipSize = require('gzip-size').sync;
 
 function canReadAsset(asset) {
   return (
-    /\.(js|css)$/.test(asset.name) &&
-    !/service-worker\.js/.test(asset.name) &&
-    !/precache-manifest\.[0-9a-f]+\.js/.test(asset.name)
+    /\.(js|css)$/.test(asset) &&
+    !/service-worker\.js/.test(asset) &&
+    !/precache-manifest\.[0-9a-f]+\.js/.test(asset)
   );
 }
 
@@ -37,7 +37,7 @@ function printFileSizesAfterBuild(
     .map(stats =>
       stats
         .toJson({ all: false, assets: true })
-        .assets.filter(canReadAsset)
+        .assets.filter(asset => canReadAsset(asset.name))
         .map(asset => {
           var fileContents = fs.readFileSync(path.join(root, asset.name));
           var size = gzipSize(fileContents);


### PR DESCRIPTION
Fixes #5333

printFileSizesAfterBuild calls canReadAsset with an object containing
the file name while measureFileSizesBeforeBuild calls it with just the
name. When canReadAsset only receives the name it returns false since
accessing the `name` property results in undefined.

This PR fixes that by having canReadAssset instead expect only the
file name and making printFileSizesAfterBuild just like
measureFileSizesBeforeBuild only provide the name as argument.