### PR TITLE
Updated the link to firebase hosting

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -2219,7 +2219,7 @@ Now, after you create a production build with `npm run build`, you can deploy it
     Hosting URL: https://example-app-fd690.firebaseapp.com
 ```
 
-For more information see [Add Firebase to your JavaScript Project](https://firebase.google.com/docs/web/setup).
+For more information see [Firebase Hosting](https://firebase.google.com/docs/hosting).
 
 ### [GitHub Pages](https://pages.github.com/)
 


### PR DESCRIPTION
Firebase link was targeting Firebase JS SDK which is not correct for this part of the documentation. This section of the documentation is trying to outline various deployment methods, Firebase JS SDK has nothing to do with deployment. Instead, the link should be pointing to Firebase Hosting Docs.

