### PR TITLE
Fix CI: non-semver compliant Yarn versions

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -594,7 +594,11 @@ function checkYarnVersion() {
     yarnVersion = execSync('yarnpkg --version')
       .toString()
       .trim();
-    hasMinYarnPnp = semver.gte(yarnVersion, '1.12.0');
+    let trimmedYarnVersion = /^(.+?)[-+].+$/.exec(yarnVersion);
+    if (trimmedYarnVersion) {
+      trimmedYarnVersion = trimmedYarnVersion.pop();
+    }
+    hasMinYarnPnp = semver.gte(trimmedYarnVersion || yarnVersion, '1.12.0');
   } catch (err) {
     // ignore
   }


### PR DESCRIPTION
/cc @arcanis

```bash
> require('semver').gte('v1.13.0-a20181006.0202', '1.1.0')
TypeError: Invalid Version: v1.13.0-a20181006.0202
    at new SemVer (/Users/joe/Documents/Development/OSS/create-react-app/node_modules/semver/semver.js:305:11)
    at compare (/Users/joe/Documents/Development/OSS/create-react-app/node_modules/semver/semver.js:578:10)
    at Function.gte (/Users/joe/Documents/Development/OSS/create-react-app/node_modules/semver/semver.js:627:10)
> require('semver').gte('v1.13.0-a201810060202', '1.1.0')
true
> require('semver').gte('v1.13.0-a20181006+0202', '1.1.0')
true
> require('semver').gte('v1.13.0-a20181006-0202', '1.1.0')
true
```