### PR TITLE
use React.Component instead of Component

### DIFF
--- a/packages/react-scripts/fixtures/kitchensink/src/App.js
+++ b/packages/react-scripts/fixtures/kitchensink/src/App.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { Component, createElement } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
-class BuiltEmitter extends Component {
+class BuiltEmitter extends React.Component {
   static propTypes = {
     feature: PropTypes.func.isRequired,
   };
@@ -18,7 +18,7 @@ class BuiltEmitter extends Component {
 
     // Class components must call this.props.onReady when they're ready for the test.
     // We will assume functional components are ready immediately after mounting.
-    if (!Component.isPrototypeOf(feature)) {
+    if (!React.Component.isPrototypeOf(feature)) {
       this.handleReady();
     }
   }
@@ -34,7 +34,7 @@ class BuiltEmitter extends Component {
     } = this;
     return (
       <div>
-        {createElement(feature, {
+        {React.createElement(feature, {
           onReady: handleReady,
         })}
       </div>
@@ -42,7 +42,7 @@ class BuiltEmitter extends Component {
   }
 }
 
-class App extends Component {
+class App extends React.Component {
   constructor(props) {
     super(props);
 

--- a/packages/react-scripts/template/src/App.js
+++ b/packages/react-scripts/template/src/App.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 
-class App extends Component {
+class App extends React.Component {
   render() {
     return (
       <div className="App">

--- a/test/fixtures/mjs-support/src/App.js
+++ b/test/fixtures/mjs-support/src/App.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ApolloClient, { gql } from 'apollo-boost';
 import { ApolloProvider, Query } from 'react-apollo';
 
@@ -14,7 +14,7 @@ const client = new ApolloClient({
   uri: 'https://graphql-pokemon.now.sh/graphql',
 });
 
-class Pokemon extends Component {
+class Pokemon extends React.Component {
   render() {
     const { name } = this.props.pokemon;
     return (
@@ -25,7 +25,7 @@ class Pokemon extends Component {
   }
 }
 
-class Data extends Component {
+class Data extends React.Component {
   state = {};
   componentDidCatch() {
     this.setState({ hasError: true });
@@ -50,7 +50,7 @@ class Data extends Component {
   }
 }
 
-class App extends Component {
+class App extends React.Component {
   render() {
     return (
       <ApolloProvider client={client}>

--- a/test/fixtures/webpack-message-formatting/src/AppAliasUnknownExport.js
+++ b/test/fixtures/webpack-message-formatting/src/AppAliasUnknownExport.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { bar as bar2 } from './AppUnknownExport';
 
-class App extends Component {
+class App extends React.Component {
   componentDidMount() {
     bar2();
   }

--- a/test/fixtures/webpack-message-formatting/src/AppBabel.js
+++ b/test/fixtures/webpack-message-formatting/src/AppBabel.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-class App extends Component {
+class App extends React.Component {
   render() {
     return (
       <div>

--- a/test/fixtures/webpack-message-formatting/src/AppCss.js
+++ b/test/fixtures/webpack-message-formatting/src/AppCss.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import './AppCss.css';
 
-class App extends Component {
+class App extends React.Component {
   render() {
     return <div className="App" />;
   }

--- a/test/fixtures/webpack-message-formatting/src/AppIncorrectCase.js
+++ b/test/fixtures/webpack-message-formatting/src/AppIncorrectCase.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import five from './export5';
 
-class App extends Component {
+class App extends React.Component {
   render() {
     return <div className="App">{five}</div>;
   }

--- a/test/fixtures/webpack-message-formatting/src/AppLintError.js
+++ b/test/fixtures/webpack-message-formatting/src/AppLintError.js
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 function foo() {
   const a = b;
 }
 
-class App extends Component {
+class App extends React.Component {
   render() {
     return <div />;
   }

--- a/test/fixtures/webpack-message-formatting/src/AppLintWarning.js
+++ b/test/fixtures/webpack-message-formatting/src/AppLintWarning.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 function foo() {}
 
-class App extends Component {
+class App extends React.Component {
   render() {
     return <div />;
   }

--- a/test/fixtures/webpack-message-formatting/src/AppMissingPackage.js
+++ b/test/fixtures/webpack-message-formatting/src/AppMissingPackage.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { bar } from 'unknown-package';
 
-class App extends Component {
+class App extends React.Component {
   componentDidMount() {
     bar();
   }

--- a/test/fixtures/webpack-message-formatting/src/AppNoDefault.js
+++ b/test/fixtures/webpack-message-formatting/src/AppNoDefault.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import myImport from './ExportNoDefault';
 
-class App extends Component {
+class App extends React.Component {
   render() {
     return <div className="App">{myImport}</div>;
   }

--- a/test/fixtures/webpack-message-formatting/src/AppOutOfScopeImport.js
+++ b/test/fixtures/webpack-message-formatting/src/AppOutOfScopeImport.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import myImport from '../OutOfScopeImport';
 
-class App extends Component {
+class App extends React.Component {
   render() {
     return <div className="App">{myImport}</div>;
   }

--- a/test/fixtures/webpack-message-formatting/src/AppSass.js
+++ b/test/fixtures/webpack-message-formatting/src/AppSass.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import './AppSass.scss';
 
-class App extends Component {
+class App extends React.Component {
   render() {
     return <div className="App" />;
   }

--- a/test/fixtures/webpack-message-formatting/src/AppUnknownExport.js
+++ b/test/fixtures/webpack-message-formatting/src/AppUnknownExport.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { bar } from './AppUnknownExport';
 
-class App extends Component {
+class App extends React.Component {
   componentDidMount() {
     bar();
   }

--- a/test/fixtures/webpack-message-formatting/src/AppUnknownFile.js
+++ b/test/fixtures/webpack-message-formatting/src/AppUnknownFile.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import DefaultExport from './ThisFileSouldNotExist';
 
-class App extends Component {
+class App extends React.Component {
   render() {
     return <div className="App" />;
   }


### PR DESCRIPTION
The first time you see React code [in the tutorial](https://reactjs.org/tutorial/tutorial.html#what-is-react) it uses this "namespaced format" of referring to `Component`. Also, the word `Component` is wildly nondescript whereas `React.Component` reads very nicely. 

