### PR TITLE
Check if config callbacks are defined before using them

### DIFF
--- a/packages/react-scripts/template/src/serviceWorker.js
+++ b/packages/react-scripts/template/src/serviceWorker.js
@@ -68,7 +68,7 @@ function registerValidSW(swUrl, config) {
               console.log('New content is available; please refresh.');
 
               // Execute callback
-              if (config.onUpdate) {
+              if (config && config.onUpdate) {
                 config.onUpdate(registration);
               }
             } else {
@@ -78,7 +78,7 @@ function registerValidSW(swUrl, config) {
               console.log('Content is cached for offline use.');
 
               // Execute callback
-              if (config.onSuccess) {
+              if (config && config.onSuccess) {
                 config.onSuccess(registration);
               }
             }


### PR DESCRIPTION
This resolves bug introduced and reported in #3867:

Before invoking callbacks `onUpdate` and `onSuccess`, there should be check to make sure that config object has been passed to service worker at all.