### PR TITLE
Fix unnecessary parameter assignment in service worker registration

### DIFF
--- a/packages/react-scripts/template/src/serviceWorker.js
+++ b/packages/react-scripts/template/src/serviceWorker.js
@@ -56,7 +56,7 @@ function registerValidSW(swUrl, config) {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
-      registration.onupdatefound = () => {
+      registration.addEventListener('updatefound', () => {
         const installingWorker = registration.installing;
         installingWorker.onstatechange = () => {
           if (installingWorker.state === 'installed') {
@@ -84,7 +84,7 @@ function registerValidSW(swUrl, config) {
             }
           }
         };
-      };
+      });
     })
     .catch(error => {
       console.error('Error during service worker registration:', error);


### PR DESCRIPTION
This fixes linter errors such as eslint's `no-param-reassign`.