### PR TITLE
Correct instructions for HTTPS and PowerShell

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1242,7 +1242,7 @@ set HTTPS=true&&npm start
 #### Windows (Powershell)
 
 ```Powershell
-($env:HTTPS = $true) -and (npm start)
+($env:HTTPS = "true") -and (npm start)
 ```
 
 #### Linux, macOS (Bash)


### PR DESCRIPTION
Current instructions for running using HTTPS in a PowerShell prompt are incorrect and do not work on Windows 10 v1809

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
