### PR TITLE
Issue-5253 - Convert Header Tag  (as suggested by @basher)

### DIFF
--- a/packages/react-scripts/template/src/App.css
+++ b/packages/react-scripts/template/src/App.css
@@ -22,6 +22,17 @@
   color: #61dafb;
 }
 
+.is-a11y {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
 @keyframes App-logo-spin {
   from {
     transform: rotate(0deg);

--- a/packages/react-scripts/template/src/App.js
+++ b/packages/react-scripts/template/src/App.js
@@ -6,7 +6,8 @@ class App extends Component {
   render() {
     return (
       <div className="App">
-        <header className="App-header">
+        <main className="App-header">
+          <h1 className="is-a11y">Create React App</h1>
           <img src={logo} className="App-logo" alt="logo" />
           <p>
             Edit <code>src/App.js</code> and save to reload.
@@ -19,7 +20,7 @@ class App extends Component {
           >
             Learn React
           </a>
-        </header>
+        </main>
       </div>
     );
   }


### PR DESCRIPTION
As suggested in the [Issue-5253](https://github.com/facebook/create-react-app/issues/5253) by @asher we're only converting the `<header>` to `<main>` and adding a `<h1>` for accessibility.

![Convert Header Tag](http://s3.emerson.link/prints/2018-10-14-100117-2zeec.png)
