### PR TITLE
Add husky, lint-staged and prettier as dev dependencies

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -310,13 +310,13 @@ Prettier is an opinionated code formatter with support for JavaScript, CSS and J
 To format our code whenever we make a commit in git, we need to install the following dependencies:
 
 ```sh
-npm install --save husky lint-staged prettier
+npm install --save-dev husky lint-staged prettier
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add husky lint-staged prettier
+yarn add --dev husky lint-staged prettier
 ```
 
 - `husky` makes it easy to use githooks as if they are npm scripts.


### PR DESCRIPTION
`husky`, `lint-staged` and `prettier` are dev dependencies, not runtime dependencies. Or do I miss something?

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
