### PR TITLE
Add --silent option to build command (#5029)

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -61,6 +61,7 @@ if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
 // Process CLI arguments
 const argv = process.argv.slice(2);
 const writeStatsJson = argv.indexOf('--stats') !== -1;
+const silent = argv.indexOf('--silent') !== -1;
 
 // We require that you explictly set browsers and do not fall back to
 // browserslist defaults.
@@ -99,27 +100,29 @@ checkBrowsers(paths.appPath, isInteractive)
         console.log(chalk.green('Compiled successfully.\n'));
       }
 
-      console.log('File sizes after gzip:\n');
-      printFileSizesAfterBuild(
-        stats,
-        previousFileSizes,
-        paths.appBuild,
-        WARN_AFTER_BUNDLE_GZIP_SIZE,
-        WARN_AFTER_CHUNK_GZIP_SIZE
-      );
-      console.log();
+      if(!silent) {
+        console.log('File sizes after gzip:\n');
+        printFileSizesAfterBuild(
+          stats,
+          previousFileSizes,
+          paths.appBuild,
+          WARN_AFTER_BUNDLE_GZIP_SIZE,
+          WARN_AFTER_CHUNK_GZIP_SIZE
+        );
+        console.log();
 
-      const appPackage = require(paths.appPackageJson);
-      const publicUrl = paths.publicUrl;
-      const publicPath = config.output.publicPath;
-      const buildFolder = path.relative(process.cwd(), paths.appBuild);
-      printHostingInstructions(
-        appPackage,
-        publicUrl,
-        publicPath,
-        buildFolder,
-        useYarn
-      );
+        const appPackage = require(paths.appPackageJson);
+        const publicUrl = paths.publicUrl;
+        const publicPath = config.output.publicPath;
+        const buildFolder = path.relative(process.cwd(), paths.appBuild);
+        printHostingInstructions(
+          appPackage,
+          publicUrl,
+          publicPath,
+          buildFolder,
+          useYarn
+        );
+      }
     },
     err => {
       console.log(chalk.red('Failed to compile.\n'));


### PR DESCRIPTION
This adds a `--silent` option to the `react-scripts build` command.

When using the `--silent` option neither *file sizes* nor *hosting instructions* will be logged.

This is useful when building remotely, as the current amount of "unnecessary" information can really clog the output.

# Test plan

1) Run `react-scripts build` and see that it prints the same information as before
````
$ yarn build
yarn run v1.6.0
$ react-scripts build
Creating an optimized production build...
Compiled successfully.

File sizes after gzip:

  207.02 KB  build\static\js\1.6875191b.chunk.js
  12.55 KB   build\static\js\main.d7e743ce.chunk.js
  2.76 KB    build\static\css\main.fba159f8.chunk.css
  2 KB       build\static\css\1.5d61c275.chunk.css
  763 B      build\static\js\runtime~main.229c360f.js

The project was built assuming it is hosted at the server root.
You can control this with the homepage field in your package.json.
For example, add this to build it for GitHub Pages:

  "homepage" : "http://myname.github.io/myapp",

The build folder is ready to be deployed.
You may serve it with a static server:

  yarn global add serve
  serve -s build

Find out more about deployment here:

  http://bit.ly/CRA-deploy

Done in 67.75s.
````

2) Run `react-scripts build --silent` and see that it doesn't print the information specified above
````
$ yarn build:silent
yarn run v1.6.0
$ react-scripts --silent
Creating an optimized production build...
Compiled successfully.

Done in 17.63s.
````