### PR TITLE
Remove dot from the end of the link to fix it when using from GitHub

### DIFF
--- a/packages/react-scripts/template/src/serviceWorker.js
+++ b/packages/react-scripts/template/src/serviceWorker.js
@@ -8,7 +8,7 @@
 // resources are updated in the background.
 
 // To learn more about the benefits of this model and instructions on how to
-// opt-in, read http://bit.ly/CRA-PWA.
+// opt-in, read http://bit.ly/CRA-PWA
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||


### PR DESCRIPTION
When trying to access the PWD link from GitHub preview the `.` in the end is included in the link.

![image](https://user-images.githubusercontent.com/11733036/46997265-f5a59780-d127-11e8-95a9-16d29878d9ff.png)

Clicking on it leads to the following [broken path.](http://bit.ly/CRA-PWA.)
This PR fixes it for future readers that will access it from GitHub.