### PR TITLE
fix: add `sideEffects: false` to react-error-overlay

### DIFF
--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -3,6 +3,7 @@
   "version": "5.1.0",
   "description": "An overlay for displaying stack frames.",
   "main": "lib/index.js",
+  "sideEffects": false,
   "scripts": {
     "start": "cross-env NODE_ENV=development node build.js --watch",
     "test": "cross-env NODE_ENV=test jest",


### PR DESCRIPTION
This allows us to leave the import in the code, and webpack will still tree shake it out.

Verified by grepping for `startReportingRuntimeErrors` in the resulting bundle.

Note that this is usage outside of `react-dev-utils`.

Without this change, I need to use `require` and not `import`, and stick my `require` inside of an environment check.

Docs: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free