### PR TITLE
Use api.env in babel-preset-react-app

### DIFF
--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -15,6 +15,6 @@ module.exports = function(api, opts) {
   // https://github.com/babel/babel/issues/4539
   // https://github.com/facebook/create-react-app/issues/720
   // It’s also nice that we can enforce `NODE_ENV` being specified.
-  const env = process.env.BABEL_ENV || process.env.NODE_ENV;
+  const env = api.env();
   return create(api, opts, env);
 };

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -16,8 +16,10 @@
     "prod.js",
     "test.js"
   ],
+  "peerDependencies": {
+    "@babel/core": "7.2.2"
+  },
   "dependencies": {
-    "@babel/core": "7.2.2",
     "@babel/plugin-proposal-class-properties": "7.3.0",
     "@babel/plugin-proposal-decorators": "7.3.0",
     "@babel/plugin-proposal-object-rest-spread": "7.3.2",


### PR DESCRIPTION
See [docs for `api.env`](https://babeljs.io/docs/en/config-files/#apienv). There are various ways of setting the `envName` for `babel`, and this makes sure that all are taken into account.

If accessing `process.env.BABEL_ENV` and `process.env.NODE_ENV` directly is still wanted, we should use [`api.cache.using`](https://babeljs.io/docs/en/config-files/#apicache).

I also noticed `@babel/core` was in `dependencies` when it shouldn't be (since users will install `@babel/core` to use the preset with), this usually happens after running `babel-upgrade`. It should go in `peerDependencies`.