### PR TITLE
Add support for WebWorker with worker-plugin

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -12,6 +12,7 @@ const path = require('path');
 const webpack = require('webpack');
 const PnpWebpackPlugin = require('pnp-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const WorkerPlugin = require('worker-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
@@ -379,6 +380,8 @@ module.exports = {
       inject: true,
       template: paths.appHtml,
     }),
+    // Process WebWorkers
+    new WorkerPlugin(),
     // Makes some environment variables available in index.html.
     // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
     // <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -12,6 +12,7 @@ const path = require('path');
 const webpack = require('webpack');
 const PnpWebpackPlugin = require('pnp-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const WorkerPlugin = require('worker-plugin');
 const InlineChunkHtmlPlugin = require('react-dev-utils/InlineChunkHtmlPlugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -472,6 +473,8 @@ module.exports = {
         minifyURLs: true,
       },
     }),
+    // Process WebWorkers
+    new WorkerPlugin(),
     // Inlines the webpack runtime script. This script is too small to warrant
     // a network request.
     new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime~.+[.]js/]),

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -66,7 +66,8 @@
     "webpack": "4.19.1",
     "webpack-dev-server": "3.1.9",
     "webpack-manifest-plugin": "2.0.4",
-    "workbox-webpack-plugin": "3.6.2"
+    "workbox-webpack-plugin": "3.6.2",
+    "worker-plugin": "^1.1.1"
   },
   "devDependencies": {
     "react": "^16.3.2",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Closes #3660

I used to test a simple example of the [test](https://github.com/GoogleChromeLabs/worker-plugin/tree/master/test/fixtures/basic) [plugin](https://github.com/GoogleChromeLabs/worker-plugin/)

```
// index.js

const worker = new Worker('./worker', { type: 'module' });

worker.onmessage = ({ data }) => {
  console.log('page got data: ', data);
};

worker.postMessage('hello');
```
```
// worker.js

import { foo } from './dep';

console.log('hello from worker');

addEventListener('message', ({ data }) => {
  console.log('worker got message', data);

  if (data === 'hello') {
    postMessage(foo);
  }
});
```
```
// deep.js

export const foo = 'bar';
```