### PR TITLE
Avoid pushing .pnp folder to git

### DIFF
--- a/packages/react-scripts/template/gitignore
+++ b/packages/react-scripts/template/gitignore
@@ -3,6 +3,7 @@
 # dependencies
 /node_modules
 /.pnp
+.pnp.js
 
 # testing
 /coverage

--- a/packages/react-scripts/template/gitignore
+++ b/packages/react-scripts/template/gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.pnp
 
 # testing
 /coverage


### PR DESCRIPTION
The same as node_modules, .pnp folder should be ignored by git

NOTE:
Not sure about .pnp.js
