### PR TITLE
Document .graphql and .gql file loading with graphql.macro

### DIFF
--- a/docusaurus/docs/loading-graphql-files.md
+++ b/docusaurus/docs/loading-graphql-files.md
@@ -4,10 +4,10 @@ title: Loading .graphql Files
 sidebar_label: Loading .graphql Files
 ---
 
-To load `.gql` and `.graphql` files, first install the [`graphl-tag.macro`](https://www.npmjs.com/package/graphql-tag.macro) package by running
+To load `.gql` and `.graphql` files, first install the [`graphl.macro`](https://www.npmjs.com/package/graphql.macro) package by running
 
 ```sh
-npm install --save graphl-tag.macro
+npm install --save graphl.macro
 ```
 
 Alternatively you may use `yarn`:
@@ -56,3 +56,16 @@ const query = {
 ```
 
 You can also use the `gql` template tag the same way you would use the non-macro version from `graphql-tag` package with the added benefit of inlined parsing results.
+
+```js
+import { gql } from 'graphql.macro';
+ 
+const query = gql`
+  query User {
+    user(id: 5) {
+      lastName
+      ...UserEntry1
+    }
+  }
+`;
+```

--- a/docusaurus/docs/loading-graphql-files.md
+++ b/docusaurus/docs/loading-graphql-files.md
@@ -4,18 +4,16 @@ title: Loading .graphql Files
 sidebar_label: Loading .graphql Files
 ---
 
-You can load `.gql` and `.graphql` files by using [`babel-plugin-macros`](https://github.com/kentcdodds/babel-plugin-macros) included with Create React App.
-
-To load the files, first install the [`graphl-tag.macro`](https://www.npmjs.com/package/graphql-tag.macro) package by running
+To load `.gql` and `.graphql` files, first install the [`graphl-tag.macro`](https://www.npmjs.com/package/graphql-tag.macro) package by running
 
 ```sh
-npm install --save-dev graphl-tag.macro
+npm install --save graphl-tag.macro
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add --dev graphql-tag.macro
+yarn add graphql-tag.macro
 ```
 
 Then, whenever you want to load `.gql` or `.graphql` files, import the `loader` from the macro package:

--- a/docusaurus/docs/loading-graphql-files.md
+++ b/docusaurus/docs/loading-graphql-files.md
@@ -1,0 +1,60 @@
+---
+id: loading-graphql-files
+title: Loading .graphql Files
+sidebar_label: Loading .graphql Files
+---
+
+You can load `.gql` and `.graphql` files by using [`babel-plugin-macros`](https://github.com/kentcdodds/babel-plugin-macros) included with Create React App.
+
+To load the files, first install the [`graphl-tag.macro`](https://www.npmjs.com/package/graphql-tag.macro) package by running
+
+```sh
+npm install --save-dev graphl-tag.macro
+```
+
+Alternatively you may use `yarn`:
+
+```sh
+yarn add --dev graphql-tag.macro
+```
+
+Then, whenever you want to load `.gql` or `.graphql` files, import the `loader` from the macro package:
+
+```js
+import { loader } from 'graphql.macro';
+
+const query = loader('./foo.graphql');
+```
+
+And your results get automatically inlined! This means that if the file above, `foo.graphql`, contains the following:
+
+```graphql
+gql`
+  query {
+    hello {
+      world
+    }
+  }
+`;
+```
+
+The previous example turns into:
+
+```javascript
+const query = {
+  'kind': 'Document',
+  'definitions': [{
+    ...
+  }],
+  'loc': {
+    ...
+    'source': {
+      'body': '\\\\n  query {\\\\n    hello {\\\\n      world\\\\n    }\\\\n  }\\\\n',
+      'name': 'GraphQL request',
+      ...
+    }
+  }
+};
+```
+
+You can also use the `gql` template tag the same way you would use the non-macro version from `graphql-tag` package with the added benefit of inlined parsing results.

--- a/docusaurus/docs/loading-graphql-files.md
+++ b/docusaurus/docs/loading-graphql-files.md
@@ -7,7 +7,7 @@ sidebar_label: Loading .graphql Files
 To load `.gql` and `.graphql` files, first install the [`graphl.macro`](https://www.npmjs.com/package/graphql.macro) package by running
 
 ```sh
-npm install --save graphl.macro
+npm install --save graphql.macro
 ```
 
 Alternatively you may use `yarn`:

--- a/docusaurus/docs/loading-graphql-files.md
+++ b/docusaurus/docs/loading-graphql-files.md
@@ -4,7 +4,7 @@ title: Loading .graphql Files
 sidebar_label: Loading .graphql Files
 ---
 
-To load `.gql` and `.graphql` files, first install the [`graphql.macro`](https://www.npmjs.com/package/graphql.macro) package by running
+To load `.gql` and `.graphql` files, first install the [`graphql.macro`](https://www.npmjs.com/package/graphql.macro) package by running:
 
 ```sh
 npm install --save graphql.macro

--- a/docusaurus/docs/loading-graphql-files.md
+++ b/docusaurus/docs/loading-graphql-files.md
@@ -4,7 +4,7 @@ title: Loading .graphql Files
 sidebar_label: Loading .graphql Files
 ---
 
-To load `.gql` and `.graphql` files, first install the [`graphl.macro`](https://www.npmjs.com/package/graphql.macro) package by running
+To load `.gql` and `.graphql` files, first install the [`graphql.macro`](https://www.npmjs.com/package/graphql.macro) package by running
 
 ```sh
 npm install --save graphql.macro

--- a/docusaurus/docs/loading-graphql-files.md
+++ b/docusaurus/docs/loading-graphql-files.md
@@ -13,7 +13,7 @@ npm install --save graphl.macro
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add graphql-tag.macro
+yarn add graphql.macro
 ```
 
 Then, whenever you want to load `.gql` or `.graphql` files, import the `loader` from the macro package:

--- a/docusaurus/website/i18n/en.json
+++ b/docusaurus/website/i18n/en.json
@@ -94,6 +94,10 @@
         "title": "Integrating with an API Backend",
         "sidebar_label": "Integrating with an API"
       },
+      "loading-graphql-files": {
+        "title": "Loading .graphql Files",
+        "sidebar_label": "Loading .graphql Files"
+      },
       "making-a-progressive-web-app": {
         "title": "Making a Progressive Web App"
       },

--- a/docusaurus/website/sidebars.json
+++ b/docusaurus/website/sidebars.json
@@ -22,6 +22,7 @@
       "adding-a-sass-stylesheet",
       "post-processing-css",
       "adding-images-fonts-and-files",
+      "loading-graphql-files",
       "using-the-public-folder",
       "code-splitting"
     ],


### PR DESCRIPTION
This PR follows up #3909 and #5076 by adding documentation for the `.graphql` loading features through `babel-plugin-macros`.

Signed-off-by: petetnt <pete.a.nykanen@gmail.com>
