### PR TITLE
Fix typo

### DIFF
--- a/docusaurus/docs/developing-components-in-isolation.md
+++ b/docusaurus/docs/developing-components-in-isolation.md
@@ -4,7 +4,7 @@ title: Developing Components in Isolation
 ---
 
 Usually, in an app, you have a lot of UI components, and each of them has many different states.
-For an example, a simple button component could have following states:
+For an example, a simple button component could have the following states:
 
 - In a regular state, with a text label.
 - In the disabled mode.

--- a/docusaurus/docs/integrating-with-an-api-backend.md
+++ b/docusaurus/docs/integrating-with-an-api-backend.md
@@ -20,6 +20,6 @@ You can find the companion GitHub repository [here](https://github.com/fullstack
 ## API Platform (PHP and Symfony)
 
 [API Platform](https://api-platform.com) is a framework designed to build API-driven projects.
-It allows to create hypermedia and GraphQL APIs in minutes.
+It allows creating hypermedia and GraphQL APIs in minutes.
 It is shipped with an official Progressive Web App generator as well as a dynamic administration interface, both built for Create React App.
 Check out [this tutorial](https://api-platform.com/docs/distribution).


### PR DESCRIPTION
This PR fixes the following typo: 
* `following states` -> `the following states`
* `It allows to create` -> `It allows creating`