### PR TITLE
Fix title on Safari

### DIFF
--- a/docusaurus/website/static/css/custom.css
+++ b/docusaurus/website/static/css/custom.css
@@ -23,6 +23,10 @@
   background: #282c34;
 }
 
+.headerTitleWithLogo {
+  white-space: nowrap;
+}
+
 @media only screen and (min-device-width: 360px) and (max-device-width: 736px) {
 }
 


### PR DESCRIPTION
Hello,

I see that title [wraps on Safari](https://www.dropbox.com/s/m4rgpgyckevdfze/Screenshot%202018-10-21%2002.20.11.png?dl=0) so I prepared a small PR to fix this. Here is [how it looks](https://www.dropbox.com/s/uk9l66awpm9ovp0/Screenshot%202018-10-21%2002.21.16.png?dl=0) with a fix applied.

Please check and let me know if this makes sense.

Thanks 🙏 