### PR TITLE
Check for TypeScript install in preflight

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -22,11 +22,13 @@ process.on('unhandledRejection', err => {
 // Ensure environment variables are read.
 require('../config/env');
 // @remove-on-eject-begin
-// Do the preflight check (only happens before eject).
+// Do the preflight checks (only happens before eject).
 const verifyPackageTree = require('./utils/verifyPackageTree');
 if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
   verifyPackageTree();
 }
+const verifyTypeScriptSetup = require('./utils/verifyTypeScriptSetup');
+verifyTypeScriptSetup();
 // @remove-on-eject-end
 
 const path = require('path');

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -27,6 +27,8 @@ const verifyPackageTree = require('./utils/verifyPackageTree');
 if (process.env.SKIP_PREFLIGHT_CHECK !== 'true') {
   verifyPackageTree();
 }
+const verifyTypeScriptSetup = require('./utils/verifyTypeScriptSetup');
+verifyTypeScriptSetup();
 // @remove-on-eject-end
 
 const fs = require('fs');

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -1,0 +1,59 @@
+// @remove-file-on-eject
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const chalk = require('chalk');
+const fs = require('fs');
+const path = require('path');
+const resolve = require('resolve');
+const paths = require('../../config/paths');
+
+function verifyTypeScriptSetup() {
+  if (!fs.existsSync(paths.appTsConfig)) {
+    return;
+  }
+
+  const isYarn = fs.existsSync(paths.yarnLockFile);
+
+  // Ensure typescript is installed
+  try {
+    resolve.sync('typescript', {
+      basedir: paths.appNodeModules,
+    });
+  } catch (_) {
+    console.error(
+      chalk.red(
+        'We detected a',
+        chalk.bold('tsconfig.json'),
+        "in your package root but couldn't find an installation of",
+        chalk.bold('typescript') + '.'
+      )
+    );
+    console.error();
+    console.error(
+      chalk.bold(
+        'Please install',
+        chalk.cyan.bold('typescript'),
+        'by running',
+        chalk.cyan.bold(
+          isYarn ? 'yarn add typescript' : 'npm install typescript'
+        ) + '.'
+      )
+    );
+    console.error(
+      'If you are not trying to use TypeScript, please remove the ' +
+        chalk.cyan('tsconfig.json') +
+        ' file from your package root.'
+    );
+    console.error();
+    process.exit(1);
+  }
+}
+
+module.exports = verifyTypeScriptSetup;


### PR DESCRIPTION
This ensures TypeScript is installed when a `tsconfig.json` is present (this is our trigger to perform type checking).