### PR TITLE
Add webpack target option to configuration

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -41,6 +41,15 @@ const cssModuleRegex = /\.module\.css$/;
 const sassRegex = /\.(scss|sass)$/;
 const sassModuleRegex = /\.module\.(scss|sass)$/;
 
+// webpack build target
+const webpackTarget = process.env.WEBPACK_TARGET || 'web';
+const isNode = [
+  'node',
+  'electron-main',
+  'electron-render',
+  'node-webkit',
+].includes(webpackTarget);
+
 // common function to get style loaders
 const getStyleLoaders = (cssOptions, preProcessor) => {
   const loaders = [
@@ -410,14 +419,20 @@ module.exports = {
 
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.
-  node: {
-    dgram: 'empty',
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty',
-    child_process: 'empty',
-  },
+  // Disable mocks on node enabled target.
+  node: isNode
+    ? {}
+    : {
+        dgram: 'empty',
+        fs: 'empty',
+        net: 'empty',
+        tls: 'empty',
+        child_process: 'empty',
+      },
   // Turn off performance processing because we utilize
   // our own hints via the FileSizeReporter
   performance: false,
+  // Set the webpack build target.
+  // https://webpack.js.org/configuration/target/
+  target: webpackTarget,
 };

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -46,7 +46,7 @@ const webpackTarget = process.env.WEBPACK_TARGET || 'web';
 const isNode = [
   'node',
   'electron-main',
-  'electron-render',
+  'electron-renderer',
   'node-webkit',
 ].includes(webpackTarget);
 

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -59,6 +59,15 @@ const cssModuleRegex = /\.module\.css$/;
 const sassRegex = /\.(scss|sass)$/;
 const sassModuleRegex = /\.module\.(scss|sass)$/;
 
+// webpack build target
+const webpackTarget = process.env.WEBPACK_TARGET || 'web';
+const isNode = [
+  'node',
+  'electron-main',
+  'electron-render',
+  'node-webkit',
+].includes(webpackTarget);
+
 // common function to get style loaders
 const getStyleLoaders = (cssOptions, preProcessor) => {
   const loaders = [
@@ -476,7 +485,8 @@ module.exports = {
     }),
     // Inlines the webpack runtime script. This script is too small to warrant
     // a network request.
-    shouldInlineRuntimeChunk && new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime~.+[.]js/]),
+    shouldInlineRuntimeChunk &&
+      new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime~.+[.]js/]),
     // Makes some environment variables available in index.html.
     // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
     // <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
@@ -528,14 +538,20 @@ module.exports = {
   ].filter(Boolean),
   // Some libraries import Node modules but don't use them in the browser.
   // Tell Webpack to provide empty mocks for them so importing them works.
-  node: {
-    dgram: 'empty',
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty',
-    child_process: 'empty',
-  },
+  // Disable mocks on node enabled target.
+  node: isNode
+    ? {}
+    : {
+        dgram: 'empty',
+        fs: 'empty',
+        net: 'empty',
+        tls: 'empty',
+        child_process: 'empty',
+      },
   // Turn off performance processing because we utilize
   // our own hints via the FileSizeReporter
   performance: false,
+  // Set the webpack build target.
+  // https://webpack.js.org/configuration/target/
+  target: webpackTarget,
 };


### PR DESCRIPTION
This pull request adds an environment variable `WEBPACK_TARGET` to change webpack target to something other than `web` (See https://webpack.js.org/configuration/target/). If no target is set, it will use default target `web`.

The purpose of this change is to support Electron.js and Node-webkit without ejecting or unnecessary fork.