### PR TITLE
Use TypeScript parser to read tsconfig.json

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -51,10 +51,11 @@ function verifyTypeScriptSetup() {
   const isYarn = fs.existsSync(paths.yarnLockFile);
 
   // Ensure typescript is installed
+  let ts;
   try {
-    resolve.sync('typescript', {
+    ts = require(resolve.sync('typescript', {
       basedir: paths.appNodeModules,
-    });
+    }));
   } catch (_) {
     console.error(
       chalk.red(
@@ -87,7 +88,16 @@ function verifyTypeScriptSetup() {
   const messages = [];
   let tsconfig;
   try {
-    tsconfig = require(paths.appTsConfig);
+    const { config, error } = ts.readConfigFile(
+      paths.appTsConfig,
+      ts.sys.readFile
+    );
+
+    if (error) {
+      throw error;
+    }
+
+    tsconfig = config;
   } catch (_) {
     console.error(
       chalk.red.bold(


### PR DESCRIPTION
We have to read `tsconfig.json` using the ts parser otherwise it will fail, because it may contain things like comments and trailing comma.

One remaining annoyance is that when overriding the json it is removing all comments from the file.