### PR TITLE
Simplified TypeScript steps

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -10,9 +10,8 @@ Recent versions of [TypeScript](https://www.typescriptlang.org/) work with Creat
 To add TypeScript to a Create React App project, follow these steps:
 
 1. Run `npm install --save typescript @types/react @types/react-dom @types/jest` (or `yarn add typescript @types/react @types/react-dom @types/jest`).
-2. Rename the `.js` files you want to convert: use `.tsx` if they use JSX or `.ts` if not (e.g. `git mv src/index.js src/index.tsx`).
-3. Create a [`tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) at the root project directory with `{}` in it. Alternatively, rename `index.js` to `index.tsx`.
-4. Restart your development server (if applicable). This will set sensible defaults and the required values in your [`tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
+2. Rename `src/index.js` to `src/index.tsx` or create an empty [`tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) at the root project directory.
+3. Restart your development server (if applicable). This will set sensible defaults and the required values in your [`tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
 
 Type errors will show up in the same console as the build one.
 


### PR DESCRIPTION
We don't need to tell users to rename multiple files at this step, only one.
And it's not needed to add `{}` to tsconfig anymore since #5532.

_PS: At the docs, we recommend installing `typescript @types/react @types/react-dom @types/jest`, but when not looking at the docs (just renaming the file) it only recommends adding `typescript`. Maybe we should add those there too?_