### PR TITLE
Recommend installing types in addition to typescript dependency

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -9,7 +9,7 @@ Recent versions of [TypeScript](https://www.typescriptlang.org/) work with Creat
 
 To add TypeScript to a Create React App project, follow these steps:
 
-1. Run `npm install --save typescript @types/react @types/react-dom @types/jest` (or `yarn add typescript @types/react @types/react-dom @types/jest`).
+1. Run `npm install typescript @types/react @types/react-dom @types/jest` (or `yarn add typescript @types/react @types/react-dom @types/jest`).
 2. Rename `src/index.js` to `src/index.tsx` or create an empty [`tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) at the root project directory.
 3. Restart your development server (if applicable). This will set sensible defaults and the required values in your [`tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
 

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -73,7 +73,9 @@ function verifyTypeScriptSetup() {
         chalk.cyan.bold('typescript'),
         'by running',
         chalk.cyan.bold(
-          isYarn ? 'yarn add typescript' : 'npm install typescript'
+          isYarn
+            ? 'yarn add typescript @types/react @types/react-dom @types/jest'
+            : 'npm install typescript @types/react @types/react-dom @types/jest'
         ) + '.'
       )
     );


### PR DESCRIPTION
At the docs, we recommend installing `typescript @types/react @types/react-dom @types/jest`, but when not looking at the docs (just renaming the file) it only recommends adding typescript. Maybe we should add those there too?