### PR TITLE
Update bit.ly PWA links. #5497

### DIFF
--- a/docusaurus/docs/making-a-progressive-web-app.md
+++ b/docusaurus/docs/making-a-progressive-web-app.md
@@ -15,7 +15,7 @@ following in their [`src/index.js`](https://github.com/facebook/create-react-app
 ```js
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
-// Learn more about service workers: http://bit.ly/CRA-PWA
+// Learn more about service workers: http://bit.ly/CRA-PWA2
 serviceWorker.unregister();
 ```
 

--- a/packages/react-scripts/template/src/index.js
+++ b/packages/react-scripts/template/src/index.js
@@ -8,5 +8,5 @@ ReactDOM.render(<App />, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
-// Learn more about service workers: http://bit.ly/CRA-PWA
+// Learn more about service workers: http://bit.ly/CRA-PWA2
 serviceWorker.unregister();

--- a/packages/react-scripts/template/src/serviceWorker.js
+++ b/packages/react-scripts/template/src/serviceWorker.js
@@ -8,7 +8,7 @@
 // resources are updated in the background.
 
 // To learn more about the benefits of this model and instructions on how to
-// opt-in, read http://bit.ly/CRA-PWA
+// opt-in, read http://bit.ly/CRA-PWA2
 
 const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
@@ -43,7 +43,7 @@ export function register(config) {
         navigator.serviceWorker.ready.then(() => {
           console.log(
             'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit http://bit.ly/CRA-PWA'
+              'worker. To learn more, visit http://bit.ly/CRA-PWA2'
           );
         });
       } else {
@@ -68,7 +68,7 @@ function registerValidSW(swUrl, config) {
               // content until all client tabs are closed.
               console.log(
                 'New content is available and will be used when all ' +
-                  'tabs for this page are closed. See http://bit.ly/CRA-PWA.'
+                  'tabs for this page are closed. See http://bit.ly/CRA-PWA2.'
               );
 
               // Execute callback


### PR DESCRIPTION
This update fixes issue #5497 and points to the correct documentation page.

http://bit.ly/CRA-PWA2 => https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app

I'm happy to give over control of the bit.ly link (if that is a thing I can do)

If you'd prefer to find the original owner, and have them change it, feel free to close this PR.
