### PR TITLE
Use raw git hook name for script name

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "e2e": "tasks/e2e-simple.sh",
     "e2e:docker": "tasks/local-test.sh",
     "postinstall": "cd packages/react-error-overlay/ && yarn build:prod",
+    "precommit": "lint-staged",
     "publish": "tasks/publish.sh",
     "start": "cd packages/react-scripts && node bin/react-scripts.js start",
     "screencast": "node ./tasks/screencast.js",
@@ -37,11 +38,6 @@
     "svg-term-cli": "^2.1.1",
     "tempy": "^0.2.1",
     "wait-for-localhost": "2.0.1"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   },
   "lint-staged": {
     "*.{js,md,css}": [


### PR DESCRIPTION
Newer versions of husky (>0.14) [suggest doing it](https://github.com/typicode/husky#upgrading-from-014).