### PR TITLE
Add Algolia search bar to Docusaurus

### DIFF
--- a/docusaurus/website/siteConfig.js
+++ b/docusaurus/website/siteConfig.js
@@ -82,6 +82,11 @@ const siteConfig = {
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
   repoUrl: 'https://github.com/facebook/create-react-app',
+
+  algolia: {
+    apiKey: '3be60f4f8ffc24c75da84857d6323791',
+    indexName: 'create-react-app',
+  }
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
Resolves part of: https://github.com/facebook/create-react-app/issues/5238

Adds search bar per [Docusaurus instructions](https://docusaurus.io/docs/en/search). 

IS:
![search-bar](https://user-images.githubusercontent.com/1372946/47406439-22027a80-d70b-11e8-82f1-179e58bd1602.gif)

// Some info from Algolia

- You can check your configuration in our github repo (https://github.com/algolia/docsearch-configs/blob/master/configs/create-react-app.json). 
- Analytics available from the Algolia dashboard by selecting the application DOCSEARCH. Please select the analytics tabs. (Note: Individuals may need to email Algolia to get this access if want analytics...I have it now.) 
