### PR TITLE
Change import syntax from typescript declaration

### DIFF
--- a/packages/react-scripts/config/react-app.d.ts
+++ b/packages/react-scripts/config/react-app.d.ts
@@ -28,7 +28,7 @@ declare module '*.png' {
 }
 
 declare module '*.svg' {
-  import React = require('react');
+  import * as React from 'react';
 
   export const ReactComponent: React.SFC<React.SVGProps<SVGSVGElement>>;
 


### PR DESCRIPTION
It's not a syntax babel supports inside .ts files so we better use the supported syntax here 

And it has to use `* as React` because we made `allowSyntheticDefaultImports: true` optional.