### PR TITLE
Fix broken link in router docs

### DIFF
--- a/docusaurus/docs/adding-a-router.md
+++ b/docusaurus/docs/adding-a-router.md
@@ -19,4 +19,4 @@ yarn add react-router-dom
 
 To try it, delete all the code in `src/App.js` and replace it with any of the examples on its website. The [Basic Example](https://reacttraining.com/react-router/web/example/basic) is a good place to get started.
 
-Note that [you may need to configure your production server to support client-side routing](/docs/deployments#serving-apps-with-client-side-routing) before deploying your app.
+Note that [you may need to configure your production server to support client-side routing](/docs/deployment#serving-apps-with-client-side-routing) before deploying your app.


### PR DESCRIPTION
The correct link should be https://facebook.github.io/create-react-app/docs/deployment#serving-apps-with-client-side-routing.

Frankly, I didn't test this, but it should be a pretty safe change. Highly encourage the project to integration Netlify preview builds for Docusaurus PRs so that maintainers can easily verify the doc changes.