### PR TITLE
Exclude setupProxy.js from TypeScript

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -212,6 +212,11 @@ function verifyTypeScriptSetup() {
     );
   }
 
+  if (parsedTsConfig.exclude == null) {
+    appTsConfig.exclude = ['src/setupProxy.js'];
+    messages.push(`${chalk.cyan('exclude')} should exclude setupProxy.js`);
+  }
+
   if (messages.length > 0) {
     if (firstTimeSetup) {
       console.log(


### PR DESCRIPTION
Fix #5587

_PS: Not a fan of ` == null` but used it to maintain the same code styling. I usually use `if (!`._ 