### PR TITLE
Unpin eslint version in react-scripts

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -37,7 +37,7 @@
     "css-loader": "1.0.0",
     "dotenv": "6.0.0",
     "dotenv-expand": "4.2.0",
-    "eslint": "5.6.0",
+    "eslint": "^5.6.0",
     "eslint-config-react-app": "^3.0.4",
     "eslint-loader": "2.1.1",
     "eslint-plugin-flowtype": "2.50.1",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
I've run into issues with eslint being the wrong exact version a few times now. Is there a reason fir it being pinned to an exact version?

I have a custom eslint config, so eslint is a peer dependency of my project. Since it's an approximate version, it resolves to `5.8.0`. `react-scripts` then throws a warning when I try to run tests.

```
The react-scripts package provided by Create React App requires a dependency:

  "eslint": "5.6.0"
```