### PR TITLE
Add link to cra-ts migration guide

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -24,6 +24,8 @@ To learn more about TypeScript, check out [its documentation](https://www.typesc
 > **Note:** You are not required to make a [`tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html), one will be made for you.
 > You are allowed to edit the generated TypeScript configuration.
 
+> **Note:** If you are currently using [create-react-app-typescript](https://github.com/wmonk/create-react-app-typescript/), see [this blog post](https://vincenttunru.com/migrate-create-react-app-typescript-to-create-react-app/) for instructions on how to migrate to Create React App.
+
 > **Note:** We recommend using [VSCode](https://code.visualstudio.com/) for a better integrated experience.
 
 > **Note:** Constant enums and namespaces are not supported.


### PR DESCRIPTION
For users coming from create-react-app-typescript, the added link provides instructions on how to port their app to Create React App.

@Timer suggested I create a PR to add this link. Not sure if this is the best place; let me know if there's a better place for links like this :)
