### PR TITLE
Generalize the adding bootstrap documentation

### DIFF
--- a/docusaurus/docs/adding-bootstrap.md
+++ b/docusaurus/docs/adding-bootstrap.md
@@ -3,7 +3,7 @@ id: adding-bootstrap
 title: Adding Bootstrap
 ---
 
-While you don’t have to use any specific library to integrate Bootstrap with React apps, it's often easier than trying to wrap the Bootstrap jQuery plugins. [React Bootstrap](https://react-bootstrap.netlify.com/) is the most popular option and feature rich option. [reactstrap](https://reactstrap.github.io/) is also a good choice for projects looking for smaller builds at the expense of less features.
+While you don’t have to use any specific library to integrate Bootstrap with React apps, it's often easier than trying to wrap the Bootstrap jQuery plugins. [React Bootstrap](https://react-bootstrap.netlify.com/) is the most popular option, that strives for complete parity with bootstrap. [reactstrap](https://reactstrap.github.io/) is also a good choice for projects looking for smaller builds at the expense of less features.
 
 Each projects respective documentation site has detailed instructions for installing and using them. Both depend on the Bootstrap css file so install that as well:
 

--- a/docusaurus/docs/adding-bootstrap.md
+++ b/docusaurus/docs/adding-bootstrap.md
@@ -5,7 +5,7 @@ title: Adding Bootstrap
 
 While you don’t have to use any specific library to integrate Bootstrap with React apps, it's often easier than trying to wrap the Bootstrap jQuery plugins. [React Bootstrap](https://react-bootstrap.netlify.com/) is the most popular option, that strives for complete parity with bootstrap. [reactstrap](https://reactstrap.github.io/) is also a good choice for projects looking for smaller builds at the expense of some features.
 
-Each projects respective documentation site has detailed instructions for installing and using them. Both depend on the Bootstrap css file so install that as well:
+Each project's respective documentation site has detailed instructions for installing and using them. Both depend on the Bootstrap css file so install that as well:
 
 ```sh
 npm install --save bootstrap

--- a/docusaurus/docs/adding-bootstrap.md
+++ b/docusaurus/docs/adding-bootstrap.md
@@ -3,35 +3,27 @@ id: adding-bootstrap
 title: Adding Bootstrap
 ---
 
-You don’t have to use [reactstrap](https://reactstrap.github.io/) together with React but it is a popular library for integrating Bootstrap with React apps. If you need it, you can integrate it with Create React App by following these steps:
+While you don’t have to use any specific library to integrate Bootstrap with React apps, it's often easier than trying to wrap the Bootstrap jQuery plugins. [React Bootstrap](https://react-bootstrap.netlify.com/) is the most popular option and feature rich option. [reactstrap](https://reactstrap.github.io/) is also a good choice for projects looking for smaller builds at the expense of less features.
 
-Install reactstrap and Bootstrap from npm. reactstrap does not include Bootstrap CSS so this needs to be installed as well:
+Each projects respective documentation site has detailed instructions for installing and using them. Both depend on the Bootstrap css file so install that as well:
 
 ```sh
-npm install --save reactstrap bootstrap@4
+npm install --save bootstrap
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add bootstrap@4 reactstrap
+yarn add bootstrap
 ```
 
 Import Bootstrap CSS and optionally Bootstrap theme CSS in the beginning of your `src/index.js` file:
 
 ```js
-import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap/dist/css/bootstrap.css'
 // Put any other imports below so that CSS from your
 // components takes precedence over default styles.
 ```
-
-Import required reactstrap components within `src/App.js` file or your custom component files:
-
-```js
-import { Button } from 'reactstrap';
-```
-
-Now you are ready to use the imported reactstrap components within your component hierarchy defined in the render method. Here is an example [`App.js`](https://gist.githubusercontent.com/zx6658/d9f128cd57ca69e583ea2b5fea074238/raw/a56701c142d0c622eb6c20a457fbc01d708cb485/App.js) redone using reactstrap.
 
 ## Using a Custom Theme
 
@@ -55,5 +47,5 @@ $body-bg: #000;
 Finally, import the newly created `.scss` file instead of the default Bootstrap `.css` in the beginning of your `src/index.js` file, for example:
 
 ```javascript
-import './custom.scss';
+import './custom.scss'
 ```

--- a/docusaurus/docs/adding-bootstrap.md
+++ b/docusaurus/docs/adding-bootstrap.md
@@ -3,7 +3,7 @@ id: adding-bootstrap
 title: Adding Bootstrap
 ---
 
-While you don’t have to use any specific library to integrate Bootstrap with React apps, it's often easier than trying to wrap the Bootstrap jQuery plugins. [React Bootstrap](https://react-bootstrap.netlify.com/) is the most popular option, that strives for complete parity with bootstrap. [reactstrap](https://reactstrap.github.io/) is also a good choice for projects looking for smaller builds at the expense of less features.
+While you don’t have to use any specific library to integrate Bootstrap with React apps, it's often easier than trying to wrap the Bootstrap jQuery plugins. [React Bootstrap](https://react-bootstrap.netlify.com/) is the most popular option, that strives for complete parity with bootstrap. [reactstrap](https://reactstrap.github.io/) is also a good choice for projects looking for smaller builds at the expense of some features.
 
 Each projects respective documentation site has detailed instructions for installing and using them. Both depend on the Bootstrap css file so install that as well:
 
@@ -20,7 +20,7 @@ yarn add bootstrap
 Import Bootstrap CSS and optionally Bootstrap theme CSS in the beginning of your `src/index.js` file:
 
 ```js
-import 'bootstrap/dist/css/bootstrap.css'
+import 'bootstrap/dist/css/bootstrap.css';
 // Put any other imports below so that CSS from your
 // components takes precedence over default styles.
 ```
@@ -47,5 +47,5 @@ $body-bg: #000;
 Finally, import the newly created `.scss` file instead of the default Bootstrap `.css` in the beginning of your `src/index.js` file, for example:
 
 ```javascript
-import './custom.scss'
+import './custom.scss';
 ```


### PR DESCRIPTION
Picking a particular react bootstrap library feels like too strong of an opinion for supplementary  CRA docs. I trimmed it down to point out the two most popular options and remove library specific documentation to focus on the bits that are more CRA specific, e.g. using sass files.