### PR TITLE
Add ENTRY_POINT env.

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -18,6 +18,7 @@ const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 
 const envPublicUrl = process.env.PUBLIC_URL;
+const envEntryPoint = process.env.ENTRY_POINT || 'src/index';
 
 function ensureSlash(inputPath, needsSlash) {
   const hasSlash = inputPath.endsWith('/');
@@ -102,7 +103,7 @@ module.exports = {
   appBuild: resolveApp('build'),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),
-  appIndexJs: resolveModule(resolveApp, 'src/index'),
+  appIndexJs: resolveModule(resolveApp, envEntryPoint),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
   appTsConfig: resolveApp('tsconfig.json'),


### PR DESCRIPTION
Related issues:

1. https://github.com/facebook/create-react-app/issues/1084
2. https://github.com/facebook/create-react-app/issues/3941
3. https://github.com/facebook/create-react-app/issues/3052

With this change, you can build different bundles via:

```
ENTRY_POINT=src/admin react-scripts build
ENTRY_POINT=src/shop react-scripts build
ENTRY_POINT=src/blog react-scripts build
```