### PR TITLE
Add empty mock for http2

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -656,6 +656,7 @@ module.exports = function(webpackEnv) {
       dgram: 'empty',
       dns: 'mock',
       fs: 'empty',
+      http2: 'empty',
       net: 'empty',
       tls: 'empty',
       child_process: 'empty',


### PR DESCRIPTION
Following suit with #2600, this PR adds `http2` as an empty module in webpack configs. ~~I don't see `http` to the list, which suggests that this empty mock should probably be replaced with a browser-side implementation sometime in the future (I can add a TODO if needed).~~

See: https://github.com/grpc/grpc-node/issues/610 (Even though it turns out the module in question seems to not be meant for the client side, I believe the lack of this mock masked the real issue)