### PR TITLE
feature/ added typescript toggle and path overrides

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -8,6 +8,7 @@
 // @remove-on-eject-end
 'use strict';
 
+const argv = require('yargs').argv;
 const path = require('path');
 const fs = require('fs');
 const url = require('url');
@@ -45,6 +46,16 @@ function getServedPath(appPackageJson) {
     envPublicUrl || (publicUrl ? url.parse(publicUrl).pathname : '/');
   return ensureSlash(servedUrl, true);
 }
+
+const mergePaths = appPaths => {
+  const filePath = argv.overrides ? resolveApp(argv.overrides) : '';
+  return fs.existsSync(filePath)
+    ? Object.assign(appPaths, require(filePath))
+    : appPaths;
+};
+
+// pass in param to disabled typescript
+const disableType = argv.typescript !== undefined && !argv.typescript;
 
 const moduleFileExtensions = [
   'web.mjs',
@@ -96,7 +107,7 @@ module.exports = {
 const resolveOwn = relativePath => path.resolve(__dirname, '..', relativePath);
 
 // config before eject: we're in ./node_modules/react-scripts/config/
-module.exports = {
+module.exports = mergePaths({
   dotenv: resolveApp('.env'),
   appPath: resolveApp('.'),
   appBuild: resolveApp('build'),
@@ -117,7 +128,7 @@ module.exports = {
   ownNodeModules: resolveOwn('node_modules'), // This is empty on npm 3
   appTypeDeclarations: resolveApp('src/react-app-env.d.ts'),
   ownTypeDeclarations: resolveOwn('lib/react-app.d.ts'),
-};
+});
 
 const ownPackageJson = require('../package.json');
 const reactScriptsPath = resolveApp(`node_modules/${ownPackageJson.name}`);
@@ -130,7 +141,7 @@ if (
   !reactScriptsLinked &&
   __dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1
 ) {
-  module.exports = {
+  module.exports = mergePaths({
     dotenv: resolveOwn('template/.env'),
     appPath: resolveApp('.'),
     appBuild: resolveOwn('../../build'),
@@ -151,8 +162,9 @@ if (
     ownNodeModules: resolveOwn('node_modules'),
     appTypeDeclarations: resolveOwn('template/src/react-app-env.d.ts'),
     ownTypeDeclarations: resolveOwn('lib/react-app.d.ts'),
-  };
+  });
 }
 // @remove-on-eject-end
 
 module.exports.moduleFileExtensions = moduleFileExtensions;
+module.exports.disableType = disableType;

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -40,7 +40,7 @@ const publicUrl = '';
 const env = getClientEnvironment(publicUrl);
 
 // Check if TypeScript is setup
-const useTypeScript = fs.existsSync(paths.appTsConfig);
+const useTypeScript = !paths.disableType && fs.existsSync(paths.appTsConfig);
 
 // style files regexes
 const cssRegex = /\.css$/;

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -58,7 +58,7 @@ if (env.stringified['process.env'].NODE_ENV !== '"production"') {
 }
 
 // Check if TypeScript is setup
-const useTypeScript = fs.existsSync(paths.appTsConfig);
+const useTypeScript = !paths.disableType && fs.existsSync(paths.appTsConfig);
 
 // style files regexes
 const cssRegex = /\.css$/;
@@ -536,7 +536,7 @@ module.exports = {
       ],
     }),
     // TypeScript type checking
-    fs.existsSync(paths.appTsConfig) &&
+    useTypeScript &&
       new ForkTsCheckerWebpackPlugin({
         typescript: resolve.sync('typescript', {
           basedir: paths.appNodeModules,

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -70,7 +70,8 @@
     "webpack": "4.19.1",
     "webpack-dev-server": "3.1.9",
     "webpack-manifest-plugin": "2.0.4",
-    "workbox-webpack-plugin": "3.6.3"
+    "workbox-webpack-plugin": "3.6.3",
+    "yargs": "^12.0.2"
   },
   "devDependencies": {
     "react": "^16.3.2",


### PR DESCRIPTION
Added two simple things:

1) Added the ability to disable typescript
2) Specify custom path overrides

The reason for this is currently create-react-app is really difficult to use with any backend setup without having to have multiple project folders each with their own package.json and dependencies.

I would like to be able to harness the power and zero configuration of react-scripts, but also want to have the freedom and control to run my express server.

This simple override allows me to run my node setup using typescript and my UI using flow or without type checking at all. It also enables me to change the folder structure to allow a better client/server structure for development and build.

This may not be a desired implementation but it would be useful for me to have these features enabled so thought I would at least submit the proposal.

Thanks
