### PR TITLE
Verify `packageName` when installing react-scripts from git

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -408,7 +408,21 @@ function run(
         allDependencies,
         verbose,
         isOnline
-      ).then(() => packageName);
+      ).then(() => {
+        // Verify package name for git installs.
+        // Solves an issue where a custom react-scripts package may contain a
+        // name that doesn't match the repository's name.
+        try {
+          const packageJson = require(path.join(process.cwd(), 'package.json'));
+          const packageNames = Object.keys(packageJson.dependencies);
+          const packageIndex = Object.values(
+            packageJson.dependencies
+          ).findIndex(version => version.includes(packageName + '.git'));
+          return packageIndex >= 0 ? packageNames[packageIndex] : packageName;
+        } catch (e) {
+          return packageName;
+        }
+      });
     })
     .then(async packageName => {
       checkNodeVersion(packageName);


### PR DESCRIPTION
This resolves an issue where a package name may not reflect a git repository name when using a custom react scripts package (`--scripts-version`). By default, CRA uses the repository name which causes it to throw an error when a package is installed like the below:
```
  "dependencies": {
    "@test/react-scripts": "git+ssh://git@github.com:mrmckeb/create-react-app.git#react-scripts",
  }
```

To test this fix, I've created an example repository here, and tested locally with the following command, where my package is named `@test/react-scripts`.
```sh
npx git+ssh://git@github.com:mrmckeb/create-react-app.git#cra \
  test-app \
  --scripts-version=git+ssh://git@github.com:mrmckeb/create-react-app.git#react-scripts
```

This worked well. It installed correctly, using the package name I had defined.

I'm of course open to a better way of solving this! I did some research into pulling the file from a remote, but I couldn't see a reliable solution for this (I could have missed something).