### PR TITLE
Fix typo

### DIFF
--- a/packages/babel-preset-react-app/README.md
+++ b/packages/babel-preset-react-app/README.md
@@ -12,7 +12,7 @@ The easiest way to use this configuration is with [Create React App](https://git
 
 ## Usage Outside of Create React App
 
-If you want to use this Babel preset in a project not built with Create React App, you can install it with following steps.
+If you want to use this Babel preset in a project not built with Create React App, you can install it with the following steps.
 
 First, [install Babel](https://babeljs.io/docs/setup/).
 

--- a/packages/eslint-config-react-app/README.md
+++ b/packages/eslint-config-react-app/README.md
@@ -14,7 +14,7 @@ The easiest way to use this configuration is with [Create React App](https://git
 
 ## Usage Outside of Create React App
 
-If you want to use this ESLint configuration in a project not built with Create React App, you can install it with following steps.
+If you want to use this ESLint configuration in a project not built with Create React App, you can install it with the following steps.
 
 First, install this package, ESLint and the necessary plugins.
 

--- a/packages/react-error-overlay/README.md
+++ b/packages/react-error-overlay/README.md
@@ -5,7 +5,7 @@
 ## Development
 
 When developing within this package, make sure you run `npm start` (or `yarn start`) so that the files are compiled as you work.
-This is ran in watch mode by default.
+This is run in watch mode by default.
 
 If you would like to build this for production, run `npm run build:prod` (or `yarn build:prod`).<br>
 If you would like to build this one-off for development, you can run `NODE_ENV=development npm run build` (or `NODE_ENV=development yarn build`).

--- a/packages/react-scripts/fixtures/kitchensink/README.md
+++ b/packages/react-scripts/fixtures/kitchensink/README.md
@@ -45,7 +45,7 @@ For every test case added there is just a little chore to do:
 
 - add a test case in the appropriate integration test file, which calls and awaits `initDOM` with the previous `SwitchCase` string
 
-An usual flow for the test itself is something similar to:
+A usual flow for the test itself is something similar to:
 
 - add an `id` attribute in a target HTML tag in the feature itself
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

This PR fixes the following typo:
* following -> the following
* this is ran -> this is run
* An usual -> A usual