### PR TITLE
verify package tree up until current working directory

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyPackageTree.js
+++ b/packages/react-scripts/scripts/utils/verifyPackageTree.js
@@ -53,6 +53,10 @@ function verifyPackageTree() {
   while (true) {
     const previousDir = currentDir;
     currentDir = path.resolve(currentDir, '..');
+    if (currentDir === process.cwd()) {
+      // We've reached the working directory.
+      break;
+    }
     if (currentDir === previousDir) {
       // We've reached the root.
       break;


### PR DESCRIPTION
This is an attempt to address issue #4167 

I don't think the check should go beyond CRA project directory. But like mentioned in issue #4167 this was intentional. It'll be great to see what exact case that is.

I've tested the fix with my project setup.