### PR TITLE
Fix TypeScript type-checking: Set "target": "esnext" in the default tsconfig.json

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -90,8 +90,8 @@ function verifyTypeScriptSetup() {
     // tsconfig.json
     // 'parsedValue' matches the output value from ts.parseJsonConfigFileContent()
     target: {
-      parsedValue: ts.ScriptTarget.ES5,
-      suggested: 'es5',
+      parsedValue: ts.ScriptTarget.Latest,
+      suggested: 'esnext',
     },
     lib: { suggested: ['dom', 'dom.iterable', 'esnext'] },
     allowJs: { suggested: true },


### PR DESCRIPTION
This fixes the issue that I just experienced while trying to figure out a TypeScript type error: https://github.com/facebook/create-react-app/issues/5771

The CRA webpack config includes polyfills for IE9+, so the TypeScript type checker should be using the type definitions for the latest JS features, including `Array.includes`, `Object.assign`, etc. The current default `tsconfig.json` limits TypeScript to only using ES5 features.

Note that the Babel compilation doesn't actually care about `tsconfig.json`, and this doesn't affect any emitted JavaScript, because CRA isn't using TypeScript to compile the JS. It only affects type-checking, because TypeScript infers the type declarations from the "target". (Type declarations can also be overriden by setting the "lib" option.)

I've confirmed that the new default `tsconfig.json` has the updated target, and that `yarn start` and `yarn build` are both running fine after this change.

UPDATE: Actually I just did [some research to find out what Babel supports](https://github.com/Timer/fork-ts-checker-webpack-plugin/pull/2#issuecomment-437657838), and I think it would be better to use ES2018 here, because [Babel definitely supports ES2018](https://github.com/babel/babel/pull/7658). And actually it's better to leave the target as "es5", and just add the "lib" option.

UPDATE 2: Haha NOOOOOOOOO, this [was already fixed but wasn't released yet](https://github.com/facebook/create-react-app/issues/5684)! Oh well!