### PR TITLE
docs: Change story book command to `sb init`

### DIFF
--- a/docusaurus/docs/developing-components-in-isolation.md
+++ b/docusaurus/docs/developing-components-in-isolation.md
@@ -31,7 +31,7 @@ npm install -g @storybook/cli
 Then, run the following command inside your app’s directory:
 
 ```sh
-getstorybook
+sb init
 ```
 
 After that, follow the instructions on the screen.


### PR DESCRIPTION
### Issue
Executing `getstorybook` works, but emits the warning:
```shell
WARNING: getstorybook is deprecated.
The official command to install Storybook from now on is:

   sb init 
```

### Fix

Change `getstorybook` to `sb init`. Works the same way. No warning.