### PR TITLE
docs: Simplify installing Storybook with npx

### DIFF
--- a/docusaurus/docs/developing-components-in-isolation.md
+++ b/docusaurus/docs/developing-components-in-isolation.md
@@ -22,16 +22,10 @@ You can also deploy your Storybook or style guide as a static app. This way, eve
 
 Storybook is a development environment for React UI components. It allows you to browse a component library, view the different states of each component, and interactively develop and test components.
 
-First, install the following npm package globally:
+Run the following command inside your app’s directory:
 
 ```sh
-npm install -g @storybook/cli
-```
-
-Then, run the following command inside your app’s directory:
-
-```sh
-sb init
+npx -p @storybook/cli sb init
 ```
 
 After that, follow the instructions on the screen.


### PR DESCRIPTION
Reduce the two-step install process to just one (per the latest storybook docs)

Change (i) `npm install -g @storybook/cli` and (ii) `sb init` to `npx -p @storybook/cli sb init`

| Old commands                        | New command                     |
| ----------------------------------- | ------------------------------- |
| (i) `npm install -g @storybook/cli` | `npx -p @storybook/cli sb init` |
| (ii) `sb init`                      |                                 |

Refs: https://storybook.js.org/basics/quick-start-guide/

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
