### PR TITLE
Install prettier et al as devDependencies, with exact version

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -88,13 +88,13 @@ Prettier is an opinionated code formatter with support for JavaScript, CSS and J
 To format our code whenever we make a commit in git, we need to install the following dependencies:
 
 ```sh
-npm install --save husky lint-staged prettier
+npm install --save-dev --save-exact husky lint-staged prettier
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add husky lint-staged prettier
+yarn add husky lint-staged prettier --dev --exact
 ```
 
 - `husky` makes it easy to use githooks as if they are npm scripts.


### PR DESCRIPTION
Adhering to [prettier install recommendations](https://prettier.io/docs/en/install.html).
