### PR TITLE
Rename 'getting started' link to 'docs'

### DIFF
--- a/docusaurus/website/siteConfig.js
+++ b/docusaurus/website/siteConfig.js
@@ -26,7 +26,7 @@ const siteConfig = {
 
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
-    { doc: 'getting-started', label: 'Getting Started' },
+    { doc: 'getting-started', label: 'Docs' },
     { href: 'https://reactjs.org/community/support.html', label: 'Help' },
     {
       href: 'https://www.github.com/facebook/create-react-app',


### PR DESCRIPTION
@TryingToImprove pointed out that `Getting started` link might be misleading for new users who are looking for docs. I've changed `Getting started` to just `Docs` in the top of the navigation.

It's been mentioned here: https://github.com/facebook/create-react-app/issues/5753