### PR TITLE
Ignored register for `file:` protol.

### DIFF
--- a/packages/react-scripts/template/src/serviceWorker.js
+++ b/packages/react-scripts/template/src/serviceWorker.js
@@ -21,6 +21,10 @@ const isLocalhost = Boolean(
 );
 
 export function register(config) {
+  if (window.location.protocol === 'file:') {
+    // `file:` should be ignored for some none-browser environment, such as `Electron`.
+    return;
+  }
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);


### PR DESCRIPTION
I think maybe the protol `file:` should be ignored for some none-browser environment, such as `Electron`.
[serviceworker: Request scheme 'file' is unsupported](https://github.com/electron/electron/issues/13740#issuecomment-439069134)

