### PR TITLE
Add wait: false to options object for opn

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -96,7 +96,7 @@ function startBrowserProcess(browser, url) {
   // Fallback to opn
   // (It will always open new tab)
   try {
-    var options = { app: browser };
+    var options = { app: browser, wait: false };
     opn(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {


### PR DESCRIPTION
Fixes #3113.

As far as I can see, there is no downside to adding `{ wait: false }` to the option args when invoking opn, if someone can think of one then I'm happy to test that path.

Adding `wait : false` adds `cpOpts.stdio = 'ignore';` and `cpOpts.detached = true;` to the `childProcess.spawn` [option object](https://nodejs.org/api/child_process.html#child_process_options_detached). see [the relevant opn code](https://github.com/sindresorhus/opn/blob/master/index.js#L60)

Testing on Ubuntu before the change:

- With no browser open: starting react-scripts/start.js via yarn or npm then terminating the process via `<Ctrl>c` would also terminate the browser session

After:

- With no browser open: starting react-scripts/start.js via yarn or npm then terminating the process via `<Ctrl>c` does not terminate the browser session.

This fixes #3113 for me on Ubuntu and causes no regressions on macOS Mojave (where I was unable to replicate the issue due to it not using `xdg-open`) Didn't get a chance to test on Windows so would be nice if someone else could give that a go.)