### PR TITLE
Add default values to `file_ext` note

### DIFF
--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -34,7 +34,7 @@ This will allow you to do imports like
 
 > **Note:** You must prefix imports from `node_modules` with `~` as displayed above.
 
-> **Note:** If you're using Flow, override the [module.file_ext](https://flow.org/en/docs/config/options/#toc-module-file-ext-string) setting in your `.flowconfig` so it'll recognize`.sass` or `.scss` files. You will also need to include the `module.file_ext` default settings for `.js`, `.jsx`, `.mjs` and `.json` files.
+> **Note:** If you're using Flow, override the [module.file_ext](https://flow.org/en/docs/config/options/#toc-module-file-ext-string) setting in your `.flowconfig` so it'll recognize `.sass` or `.scss` files. You will also need to include the `module.file_ext` default settings for `.js`, `.jsx`, `.mjs` and `.json` files.
 >
 > ```
 > [options]

--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -34,7 +34,7 @@ This will allow you to do imports like
 
 > **Note:** You must prefix imports from `node_modules` with `~` as displayed above.
 
-> **Note:** If you're using Flow, add the following to your `.flowconfig` so it'll recognize the `.sass` or `.scss` imports.
+> **Note:** If you're using Flow, overwrite the [module.file_ext](https://flow.org/en/docs/config/options/#toc-module-file-ext-string) setting in your `.flowconfig` so it'll recognize the `.sass` or `.scss` imports.
 >
 > ```
 > [options]

--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -34,7 +34,7 @@ This will allow you to do imports like
 
 > **Note:** You must prefix imports from `node_modules` with `~` as displayed above.
 
-> **Note:** If you're using Flow, overwrite the [module.file_ext](https://flow.org/en/docs/config/options/#toc-module-file-ext-string) setting in your `.flowconfig` so it'll recognize the `.sass` or `.scss` imports.
+> **Note:** If you're using Flow, override the [module.file_ext](https://flow.org/en/docs/config/options/#toc-module-file-ext-string) setting in your `.flowconfig` so it'll recognize`.sass` or `.scss` files. You will also need to include the `module.file_ext` default settings for `.js`, `.jsx`, `.mjs` and `.json` files.
 >
 > ```
 > [options]

--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -38,6 +38,10 @@ This will allow you to do imports like
 >
 > ```
 > [options]
+> module.file_ext=.js
+> module.file_ext=.jsx
+> module.file_ext=.mjs
+> module.file_ext=.json
 > module.file_ext=.sass
 > module.file_ext=.scss
 > ```


### PR DESCRIPTION
The docs currently indicate that to enabling sass/scss support alongside flow can be done by adding the following to your `.flowconfig`.

> [options]
> module.file_ext=.sass
> module.file_ext=.scss

Making that change is insufficient because defining values for `module.file_ext` overwrite the default values, and will prevent flow from reading from `.js` files, which prevents flow from functioning as expected.

You also need to add the following values, in order to prevent overwriting the defaults.

> module.file_ext=.js
> module.file_ext=.jsx
> module.file_ext=.mjs
> module.file_ext=.json

I would be open documenting this in another way that is less verbose, but I think that there should be some indication that adding those values will overwrite the defaults.