### PR TITLE
react-dev-utils/getCSSModuleLocalIdent - add less support

### DIFF
--- a/packages/react-dev-utils/getCSSModuleLocalIdent.js
+++ b/packages/react-dev-utils/getCSSModuleLocalIdent.js
@@ -15,9 +15,9 @@ module.exports = function getLocalIdent(
   localName,
   options
 ) {
-  // Use the filename or folder name, based on some uses the index.js / index.module.(css|scss|sass) project style
+  // Use the filename or folder name, based on some uses the index.js / index.module.(css|scss|sass|less) project style
   const fileNameOrFolder = context.resourcePath.match(
-    /index\.module\.(css|scss|sass)$/
+    /index\.module\.(css|scss|sass|less)$/
   )
     ? '[folder]'
     : '[name]';


### PR DESCRIPTION
sorry for my poor English
I want use  folder name when using less, this file is in 'react-dev-utils/getCSSModuleLocalIdent'

