### PR TITLE
Resolve relative paths for preprocessor styles

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -121,12 +121,20 @@ module.exports = function(webpackEnv) {
       },
     ].filter(Boolean);
     if (preProcessor) {
-      loaders.push({
-        loader: require.resolve(preProcessor),
-        options: {
-          sourceMap: isEnvProduction && shouldUseSourceMap,
+      loaders.push(
+        {
+          loader: require.resolve('resolve-url-loader'),
+          options: {
+            sourceMap: isEnvProduction && shouldUseSourceMap,
+          },
         },
-      });
+        {
+          loader: require.resolve(preProcessor),
+          options: {
+            sourceMap: true,
+          },
+        }
+      );
     }
     return loaders;
   };

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -70,6 +70,7 @@
     "react-app-polyfill": "^1.0.1",
     "react-dev-utils": "^9.0.1",
     "resolve": "1.10.0",
+    "resolve-url-loader": "3.0.1",
     "sass-loader": "7.1.0",
     "semver": "6.0.0",
     "style-loader": "0.23.1",


### PR DESCRIPTION
preprocessor will output `sourceMap` by default
then check if `sourceMap` are needed on resolve-url-loader

issue demo: https://github.com/iamandrewluca/cra-scss-relative-problem

![image](https://user-images.githubusercontent.com/1881266/48613814-6b09bf80-e995-11e8-9d87-0920cac02fe9.png)


Fixes #4653 
