### PR TITLE
Fixed not working websocket proxy (fix: #5280)

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -324,7 +324,10 @@ function prepareProxy(proxy, appPublicFolder) {
       // If this heuristic doesn’t work well for you, use a custom `proxy` object.
       context: function(pathname, req) {
         return (
-          req.upgrade ||
+          (!pathname.startsWith("/sockjs-node") &&
+            req.upgrade &&
+            req.headers.upgrade &&
+            req.headers.upgrade.toLowerCase() === 'websocket') ||
           req.method !== 'GET' ||
           (mayProxy(pathname) &&
             req.headers.accept &&

--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -324,6 +324,7 @@ function prepareProxy(proxy, appPublicFolder) {
       // If this heuristic doesn’t work well for you, use a custom `proxy` object.
       context: function(pathname, req) {
         return (
+          req.upgrade ||
           req.method !== 'GET' ||
           (mayProxy(pathname) &&
             req.headers.accept &&


### PR DESCRIPTION
Hello

this PR fixes that websockets, e.g. via Socket.io won't be proxied through the HTTP proxy.
For more information check out issue: #5280 there are also some users who tested it successfully.

Best regards

Max.