### PR TITLE
continue  #2729 and only add react-scripts lint

### DIFF
--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -55,6 +55,22 @@ switch (script) {
     process.exit(result.status);
     break;
   }
+  case 'lint': {
+    const eslintConfigPath = require.resolve('eslint-config-react-app');
+    spawn(
+      'node',
+      [
+        require.resolve('eslint/bin/eslint'),
+        '--config',
+        eslintConfigPath,
+        'src/**/*.{js,jsx,.mjs}',
+      ],
+      { stdio: 'inherit' }
+    ).on('error', err => {
+      console.log('Error running ESLint: ' + err);
+      process.exit(results.status);
+    });
+  }
   default:
     console.log('Unknown script "' + script + '".');
     console.log('Perhaps you need to update react-scripts?');


### PR DESCRIPTION
Continuing on the work done in PR #2729 raising this PR to only add the lint target to `react-scripts`, hopefully this should move the needle on #1217 & #2625
