### PR TITLE
fix: make typescriptformatter support 0.5 of fork checker

### DIFF
--- a/packages/react-dev-utils/typescriptFormatter.js
+++ b/packages/react-dev-utils/typescriptFormatter.js
@@ -13,13 +13,24 @@ const chalk = require('chalk');
 const fs = require('fs');
 
 function formatter(message, useColors) {
+  const hasGetters = typeof message.getFile === 'function';
   const colors = new chalk.constructor({ enabled: useColors });
   const messageColor = message.isWarningSeverity() ? colors.yellow : colors.red;
 
-  const source =
-    message.getFile() &&
-    fs.existsSync(message.getFile()) &&
-    fs.readFileSync(message.getFile(), 'utf-8');
+  let source;
+
+  if (hasGetters) {
+    source =
+      message.getFile() &&
+      fs.existsSync(message.getFile()) &&
+      fs.readFileSync(message.getFile(), 'utf-8');
+  } else {
+    source =
+      message.file &&
+      fs.existsSync(message.file) &&
+      fs.readFileSync(message.file, 'utf-8');
+  }
+
   let frame = '';
 
   if (source) {
@@ -33,9 +44,11 @@ function formatter(message, useColors) {
       .join(os.EOL);
   }
 
+  const severity = hasGetters ? message.getSeverity() : message.severity;
+
   return [
-    messageColor.bold(`Type ${message.getSeverity().toLowerCase()}: `) +
-      message.getContent() +
+    messageColor.bold(`Type ${severity.toLowerCase()}: `) +
+      (hasGetters ? message.getContent() : message.content) +
       '  ' +
       messageColor.underline(`TS${message.code}`),
     '',


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

I use the formatter in an ejected project, and got errors after updating to the latest version of `fork-ts-checker-webpack-plugin`. The changes in this PR should make it compatible with both 0.4.x and 0.5.0.

See https://github.com/Realytics/fork-ts-checker-webpack-plugin/pull/182

I've tested by building my project using the formatter with both 0.4.15 and 0.5.0