### PR TITLE
Instruction to install husky, lint-staged and prettier in devDependencies

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -88,13 +88,13 @@ Prettier is an opinionated code formatter with support for JavaScript, CSS and J
 To format our code whenever we make a commit in git, we need to install the following dependencies:
 
 ```sh
-npm install --save husky lint-staged prettier
+npm install --save-dev husky lint-staged prettier
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add husky lint-staged prettier
+yarn add --dev husky lint-staged prettier
 ```
 
 - `husky` makes it easy to use githooks as if they are npm scripts.


### PR DESCRIPTION
The ideal is to install these dependencies in `devDependencies`

https://prettier.io/docs/en/install.html
https://github.com/typicode/husky#install
https://github.com/okonet/lint-staged#installation-and-setup

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
