### PR TITLE
Fix link to page about running tests

### DIFF
--- a/docusaurus/docs/getting-started.md
+++ b/docusaurus/docs/getting-started.md
@@ -108,7 +108,7 @@ The page will automatically reload if you make changes to the code. You will see
 
 Runs the test watcher in an interactive mode. By default, runs tests related to files changed since the last commit.
 
-[Read more about testing](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests).
+[Read more about testing](https://facebook.github.io/create-react-app/docs/running-tests).
 
 ### `npm run build` or `yarn build`
 


### PR DESCRIPTION
This commit fixes the link to read more about running tests, which previously linked to the source of a different page in Github with a non-existent anchor rather than to the published docs.
