### PR TITLE
Add TailwindCSS PostCSS Plugin

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -61,6 +61,7 @@ module.exports = {
   appNodeModules: resolveApp('node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
+  tailwindConfig: resolveApp('tailwind.js'),
 };
 
 let checkForMonorepo = true;
@@ -82,6 +83,7 @@ module.exports = {
   appNodeModules: resolveApp('node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
+  tailwindConfig: resolveApp('tailwind.js'),
   // These properties only exist before ejecting:
   ownPath: resolveOwn('.'),
   ownNodeModules: resolveOwn('node_modules'), // This is empty on npm 3
@@ -107,6 +109,7 @@ if (useTemplate) {
     appNodeModules: resolveOwn('node_modules'),
     publicUrl: getPublicUrl(resolveOwn('package.json')),
     servedPath: getServedPath(resolveOwn('package.json')),
+    tailwindConfig: resolveApp('template/tailwind.js'),
     // These properties only exist before ejecting:
     ownPath: resolveOwn('.'),
     ownNodeModules: resolveOwn('node_modules'),
@@ -119,6 +122,9 @@ module.exports.srcPaths = [module.exports.appSrc];
 module.exports.useYarn = fs.existsSync(
   path.join(module.exports.appPath, 'yarn.lock')
 );
+
+// detect if Tailwind CSS should be used
+module.exports.useTailwind = fs.existsSync(module.exports.tailwindConfig);
 
 if (checkForMonorepo) {
   // if app is in a monorepo (lerna or yarn workspace), treat other packages in

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -38,12 +38,16 @@ const postCSSLoaderOptions = {
   // Necessary for external CSS imports to work
   // https://github.com/facebook/create-react-app/issues/2677
   ident: 'postcss',
-  plugins: () => [
-    require('postcss-flexbugs-fixes'),
-    autoprefixer({
-      flexbox: 'no-2009',
-    }),
-  ],
+  plugins: () =>
+    [
+      require('postcss-flexbugs-fixes'),
+      paths.useTailwind
+        ? require('tailwindcss')(paths.tailwindConfig)
+        : undefined,
+      autoprefixer({
+        flexbox: 'no-2009',
+      }),
+    ].filter(Boolean),
 };
 
 // style files regexes

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -63,12 +63,16 @@ const postCSSLoaderOptions = {
   // Necessary for external CSS imports to work
   // https://github.com/facebook/create-react-app/issues/2677
   ident: 'postcss',
-  plugins: () => [
-    require('postcss-flexbugs-fixes'),
-    autoprefixer({
-      flexbox: 'no-2009',
-    }),
-  ],
+  plugins: () =>
+    [
+      require('postcss-flexbugs-fixes'),
+      paths.useTailwind
+        ? require('tailwindcss')(paths.tailwindConfig)
+        : undefined,
+      autoprefixer({
+        flexbox: 'no-2009',
+      }),
+    ].filter(Boolean),
   sourceMap: shouldUseSourceMap,
 };
 

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -62,6 +62,7 @@
     "style-loader": "0.19.1",
     "svgr": "1.8.1",
     "sw-precache-webpack-plugin": "0.11.4",
+    "tailwindcss": "^0.7.2",
     "thread-loader": "1.1.2",
     "uglifyjs-webpack-plugin": "1.1.6",
     "url-loader": "0.6.2",
@@ -72,8 +73,7 @@
   },
   "devDependencies": {
     "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "tailwindcss": "^0.7.2"
+    "react-dom": "^16.0.0"
   },
   "optionalDependencies": {
     "fsevents": "1.2.0"

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -72,7 +72,8 @@
   },
   "devDependencies": {
     "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react-dom": "^16.0.0",
+    "tailwindcss": "^0.7.2"
   },
   "optionalDependencies": {
     "fsevents": "1.2.0"


### PR DESCRIPTION
Add Tailwind as a PostCSS plugin in CRA build chain

1. Tailwind configuration file loaded from `{PROJECT_ROOT}/tailwind.js` as recommend https://tailwindcss.com/docs/installation#2-create-a-tailwind-config-file

Fixes : #5843 