### PR TITLE
Disable copy to clipboard in cra --info

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -135,13 +135,11 @@ if (program.info) {
         npmGlobalPackages: ['create-react-app'],
       },
       {
-        clipboard: true,
         duplicates: true,
         showNotFound: true,
       }
     )
-    .then(console.log)
-    .then(() => console.log(chalk.green('Copied To Clipboard!\n')));
+    .then(console.log);
 }
 
 if (typeof projectName === 'undefined') {

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -135,6 +135,7 @@ if (program.info) {
         npmGlobalPackages: ['create-react-app'],
       },
       {
+        clipboard: false,
         duplicates: true,
         showNotFound: true,
       }


### PR DESCRIPTION
Fixes an issue where npx create-react-app --info throws an exception on Windows. The exception was caused by envinfo's copy to clipboard functionality; envinfo is distributed pre-bundled, but the dependency it uses for copying to the clipboard makes use of a binary on Windows that can't be found once the bundle is made. Disabling copy to clipboard fixes the issue. Closes #5757.

Verified by running create-react-app --info, everything works just fine.