### PR TITLE
Fix —info clipboard usage, envinfo no longer supports clipboard option

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -49,6 +49,7 @@ const url = require('url');
 const hyperquest = require('hyperquest');
 const envinfo = require('envinfo');
 const os = require('os');
+const clipboard = require('clipboardy');
 
 const packageJson = require('./package.json');
 
@@ -135,12 +136,13 @@ if (program.info) {
         npmGlobalPackages: ['create-react-app'],
       },
       {
-        clipboard: false,
+        console: true,
         duplicates: true,
         showNotFound: true,
       }
     )
-    .then(console.log);
+    .then(info => clipboard.write(info))
+    .catch(e => console.log(chalk.bold('--info command failed'), e));
 }
 
 if (typeof projectName === 'undefined') {

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "chalk": "1.1.3",
+    "clipboardy": "1.2.3",
     "commander": "2.18.0",
     "cross-spawn": "4.0.2",
     "envinfo": "5.11.1",


### PR DESCRIPTION
In an effort to fix `--info` on windows, a previous PR removed the auto copy to clipboard feature. 

This adds it back using the same library envinfo previously used. 