### PR TITLE
Add SASS_PATH instructions to Sass stylesheet docs

### DIFF
--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -30,9 +30,19 @@ This will allow you to do imports like
 @import '~nprogress/nprogress'; // importing a css file from the nprogress node module
 ```
 
-> **Tip:** You can opt into using this feature with [CSS modules](adding-a-css-modules-stylesheet.md) too!
-
 > **Note:** You must prefix imports from `node_modules` with `~` as displayed above.
+
+`node-sass` also supports the `SASS_PATH` variable.
+
+To use imports relative to a path you specify, and from `node_modules` without adding the `~` prefix, you can add a [`.env` file](https://github.com/facebook/create-react-app/blob/master/docusaurus/docs/adding-custom-environment-variables.md#adding-development-environment-variables-in-env) at the project root with the variable `SASS_PATH=node_modules:src`. To specify more directories you can add them to `SASS_PATH` separated by a `:` like `path1:path2:path3`.
+
+If you set `SASS_PATH=node_modules:src`, this will allow you to do imports like
+```scss
+@import 'styles/colors'; // assuming a styles directory under src/, where _colors.scss partial file exists.
+@import 'nprogress/nprogress'; // importing a css file from the nprogress node module
+```
+
+> **Tip:** You can opt into using this feature with [CSS modules](adding-a-css-modules-stylesheet.md) too!
 
 > **Note:** If you're using Flow, override the [module.file_ext](https://flow.org/en/docs/config/options/#toc-module-file-ext-string) setting in your `.flowconfig` so it'll recognize `.sass` or `.scss` files. You will also need to include the `module.file_ext` default settings for `.js`, `.jsx`, `.mjs` and `.json` files.
 >


### PR DESCRIPTION
A bunch of issues popped up with people asking how to have SASS/SCSS imports the way the would expect normally.
Turns out `node-sass` supports the SASS_PATH variable that we can use. This PR adds that to the documentation.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
