### PR TITLE
Docs: update localStorage mock in “Running Tests”

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -239,6 +239,7 @@ For example:
 const localStorageMock = {
   getItem: jest.fn(),
   setItem: jest.fn(),
+  removeItem: jest.fn(),
   clear: jest.fn(),
 };
 global.localStorage = localStorageMock;


### PR DESCRIPTION
On a project running [redux-persist](https://github.com/rt2zz/redux-persist), declaring the current `localStorage` mock would yield warnings in tests, making them harder to visually grep:

![image](https://user-images.githubusercontent.com/2587348/49158354-3c3f0200-f322-11e8-825d-2a68e0760af1.png)

Redux Persists checks for three methods to detect if `localStorage` is defined: `getItem`, `setItem` and `removeItem` ([see relevant code](https://github.com/rt2zz/redux-persist/blob/208c6b112ead87b3701dfacaae2cdbe78377775a/src/integration/getStoredStateMigrateV4.js#L31-L43)).

I suggest adding a `removeItem` mock to the docs as it fixes the warnings in tests.
