### PR TITLE
 [react-error-overlay] Add an Optional Runtime Option Style iFrame with a Class

### DIFF
--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -24,6 +24,7 @@ import type { ErrorLocation } from './utils/parseCompileError';
 type RuntimeReportingOptions = {|
   onError: () => void,
   filename?: string,
+  className?: string,
 |};
 
 type EditorHandler = (errorLoc: ErrorLocation) => void;
@@ -138,7 +139,13 @@ function update() {
   // We need to schedule the first render.
   isLoadingIframe = true;
   const loadingIframe = window.document.createElement('iframe');
-  applyStyles(loadingIframe, iframeStyle);
+
+  if (currentRuntimeErrorOptions && currentRuntimeErrorOptions.className) {
+    loadingIframe.className = currentRuntimeErrorOptions.className;
+  } else {
+    applyStyles(loadingIframe, iframeStyle);
+  }
+
   loadingIframe.onload = function() {
     const iframeDocument = loadingIframe.contentDocument;
     if (iframeDocument != null && iframeDocument.body != null) {


### PR DESCRIPTION
To be more [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) compliant, inline styles should be avoided. I added an alternative to using inline styles on the iframe itself so it doesn't violate CSP.

![Screenshot of change](https://user-images.githubusercontent.com/11590024/48155067-ca7a1800-e28f-11e8-93d2-85dd63b04962.png)
(Tested in Next.js)