### PR TITLE
Fix link to updating doc

### DIFF
--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -59,7 +59,7 @@ switch (script) {
     console.log('Unknown script "' + script + '".');
     console.log('Perhaps you need to update react-scripts?');
     console.log(
-      'See: https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#updating-to-new-releases'
+      'See: https://facebook.github.io/create-react-app/docs/updating-to-new-releases'
     );
     break;
 }


### PR DESCRIPTION
Currently, navigate to `template/README.md`, but `template/README.md`
doesn't describe updating.
So, I think that docs/updating-to-new-releases is appropriate.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
