### PR TITLE
add webp support for typescript

### DIFF
--- a/packages/react-scripts/lib/react-app.d.ts
+++ b/packages/react-scripts/lib/react-app.d.ts
@@ -43,6 +43,11 @@ declare module '*.svg' {
   export default src;
 }
 
+declare module '*.webp' {
+    const src: string;
+    export default src;
+}
+
 declare module '*.module.css' {
   const classes: { [key: string]: string };
   export default classes;

--- a/packages/react-scripts/lib/react-app.d.ts
+++ b/packages/react-scripts/lib/react-app.d.ts
@@ -34,6 +34,11 @@ declare module '*.png' {
   export default src;
 }
 
+declare module '*.webp' {
+    const src: string;
+    export default src;
+}
+
 declare module '*.svg' {
   import * as React from 'react';
 
@@ -41,11 +46,6 @@ declare module '*.svg' {
 
   const src: string;
   export default src;
-}
-
-declare module '*.webp' {
-    const src: string;
-    export default src;
 }
 
 declare module '*.module.css' {


### PR DESCRIPTION
webp file support was added in #458 but the typescript declaration for webp was missing. 

webp images couldn't be used with typescript. 

This pull request fixes this by adding a webp typescript declaration.