### PR TITLE
Updated docs re: .eslintrc

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -19,9 +19,9 @@ Some editors, including Sublime Text, Atom, and Visual Studio Code, provide plug
 
 They are not required for linting. You should see the linter output right in your terminal as well as the browser console. However, if you prefer the lint results to appear right in your editor, there are some extra steps you can do.
 
-You would need to install an ESLint plugin for your editor first. Then, add a file called `.eslintrc` to the project root:
+You would need to install an ESLint plugin for your editor first. Then, add a file called `.eslintrc.json` to the project root:
 
-```js
+```json
 {
   "extends": "react-app"
 }
@@ -29,7 +29,7 @@ You would need to install an ESLint plugin for your editor first. Then, add a fi
 
 Now your editor should report the linting warnings.
 
-Note that even if you edit your `.eslintrc` file further, these changes will **only affect the editor integration**. They won’t affect the terminal and in-browser lint output. This is because Create React App intentionally provides a minimal set of rules that find common mistakes.
+Note that even if you edit your `.eslintrc.json` file further, these changes will **only affect the editor integration**. They won’t affect the terminal and in-browser lint output. This is because Create React App intentionally provides a minimal set of rules that find common mistakes.
 
 If you want to enforce a coding style for your project, consider using [Prettier](https://github.com/jlongster/prettier) instead of ESLint style rules.
 

--- a/packages/eslint-config-react-app/README.md
+++ b/packages/eslint-config-react-app/README.md
@@ -22,15 +22,15 @@ First, install this package, ESLint and the necessary plugins.
 npm install --save-dev eslint-config-react-app babel-eslint@9.x eslint@5.x eslint-plugin-flowtype@2.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-react@7.x
 ```
 
-Then create a file named `.eslintrc` with following contents in the root folder of your project:
+Then create a file named `.eslintrc.json` with following contents in the root folder of your project:
 
-```js
+```json
 {
   "extends": "react-app"
 }
 ```
 
-That's it! You can override the settings from `eslint-config-react-app` by editing the `.eslintrc` file. Learn more about [configuring ESLint](http://eslint.org/docs/user-guide/configuring) on the ESLint website.
+That's it! You can override the settings from `eslint-config-react-app` by editing the `.eslintrc.json` file. Learn more about [configuring ESLint](http://eslint.org/docs/user-guide/configuring) on the ESLint website.
 
 ## Accessibility Checks
 
@@ -55,7 +55,7 @@ The following rules from the [eslint-plugin-jsx-a11y](https://github.com/evcohen
 - [role-supports-aria-props](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/role-supports-aria-props.md)
 - [scope](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/scope.md)
 
-If you want to enable even more accessibility rules, you can create an `.eslintrc` file in the root of your project with this content:
+If you want to enable even more accessibility rules, you can create an `.eslintrc.json` file in the root of your project with this content:
 
 ```json
 {


### PR DESCRIPTION
References to .eslintrc now have extension (using it without extension is [deprecated](https://eslint.org/docs/user-guide/configuring#configuration-file-formats))

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
