### PR TITLE
Add Cluster Module to Webpack node Configuration

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -651,6 +651,7 @@ module.exports = function(webpackEnv) {
       net: 'empty',
       tls: 'empty',
       child_process: 'empty',
+      cluster: 'empty'
     },
     // Turn off performance processing because we utilize
     // our own hints via the FileSizeReporter


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
**REASONING BEHIND CHANGES:**
The core module cluster is one of the node core librariers for in browser usage as described by the webpack dependency, node-libs-browser:
![cluster](https://user-images.githubusercontent.com/43011463/49759508-ccf8d480-fc76-11e8-8f77-f2d05dd50813.png)

It shows that the cluster module has no browser implementation and therefore in the node section of webpack.config it can have the property of 'empty', as done with dgram, fs, child_process etc. For users of create-react app with node.js code that requires cluster, they currently need to use a workaround to avoid ejecting and modifying the Webpack scripts on their own. 

There are no side effects to this change, as adding cluster to the node section of the webpack config only affects users ability to run code originally written for the node.js environment in the browser, and as described above cluster has no browser or mock implementation and therefore can be marked as empty without any side effects.

**VERIFICATION THAT CHANGES WORK:**
use case (code that uses log4js-node): before this change errors occurred due to log4js-node requiring the cluster module and Webpack not being able to find a module for it.
![cluster2](https://user-images.githubusercontent.com/43011463/49759656-23fea980-fc77-11e8-85cc-4c64ea822e34.png)
After adding cluster:'empty' to the webpack config, the code starts up as expected:
![cluster3](https://user-images.githubusercontent.com/43011463/49759755-62946400-fc77-11e8-831b-4db6aaf44400.png)

