### PR TITLE
TypeScript detection filtering 'node_modules'.

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -22,7 +22,7 @@ function writeJson(fileName, object) {
 }
 
 function verifyNoTypeScript() {
-  const typescriptFiles = globby('**/*.(ts|tsx)', { cwd: paths.appSrc });
+  const typescriptFiles = globby(['**/*.(ts|tsx)', '!**/node_modules'], { cwd: paths.appSrc });
   if (typescriptFiles.length > 0) {
     console.warn(
       chalk.yellow(

--- a/test/fixtures/issue-5947-not-typescript/index.test.js
+++ b/test/fixtures/issue-5947-not-typescript/index.test.js
@@ -1,0 +1,35 @@
+const testSetup = require('../__shared__/test-setup');
+const path = require('path');
+const fs = require('fs');
+
+test('Ignores node_modules when detecting TypeScript', async () => {
+  // CRA build will check for TypeScript files by
+  // globbing for src/**/*.ts however this shouldn't
+  // include any node_modules directories within src.
+  // See https://github.com/facebook/create-react-app/issues/5947
+
+  const tsConfigPath = path.join(testSetup.testDirectory, 'tsconfig.json');
+  const tsPackagePath = [
+    testSetup.testDirectory,
+    'src',
+    'node_modules',
+    'package',
+    'index.ts',
+  ];
+  const tsSrcPath = path.join(testSetup.testDirectory, 'src', 'index.ts');
+
+  // Step 1.
+  // See if src/node_modules/package/index.ts is treated
+  // as a JS project
+  fs.mkdirSync(path.join(...tsPackagePath.slice(0, 3)));
+  fs.mkdirSync(path.join(...tsPackagePath.slice(0, 4)));
+  fs.writeFileSync(path.join(...tsPackagePath));
+  await testSetup.scripts.build();
+  expect(fs.existsSync(tsConfigPath)).toBe(false);
+
+  // Step 2.
+  // Add TS and ensure tsconfig.json is generated
+  fs.writeFileSync(tsSrcPath);
+  await testSetup.scripts.build();
+  expect(fs.existsSync(tsConfigPath)).toBe(true);
+});

--- a/test/fixtures/issue-5947-not-typescript/index.test.js
+++ b/test/fixtures/issue-5947-not-typescript/index.test.js
@@ -21,6 +21,7 @@ test('Ignores node_modules when detecting TypeScript', async () => {
   // Step 1.
   // See if src/node_modules/package/index.ts is treated
   // as a JS project
+  fs.mkdirSync(path.join(...tsPackagePath.slice(0, 2)));
   fs.mkdirSync(path.join(...tsPackagePath.slice(0, 3)));
   fs.mkdirSync(path.join(...tsPackagePath.slice(0, 4)));
   fs.writeFileSync(path.join(...tsPackagePath));

--- a/test/fixtures/issue-5947-not-typescript/package.json
+++ b/test/fixtures/issue-5947-not-typescript/package.json
@@ -1,0 +1,3 @@
+{
+  "dependencies": {}
+}


### PR DESCRIPTION
See #5947.

`verifyNoTypeScript` checks whether there are any TypeScript files in the project during the build, and this PR refines that logic by adding a [Globby](https://www.npmjs.com/package/globby) negation filter so that any `node_modules` under `./src` is excluded from this logic.

Considering that `verifyNoTypeScript` has only existed since CRA 2.1 it seems _very_ unlikely that anyone would depend on checking in a `node_modules` for TypeScript support, so this is a safe change.

Steps to reproduce this bug and to show that this PR fixes it:

1. symlink `./src/anything` to a directory outside the CRA project directory called `anything`.
2. `npm init` the `anything` with its own `package.json` that depends on `big-integer`. `big-integer` is distributed on NPM with TypeScript files which will be present at `./src/anything/node_modules/big-integer/BigInteger.d.ts`.
3. Run `yarn build` and CRA ignores the TS and successfully builds.
