### PR TITLE
Relax aria-role  linting for developer-created components

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -222,7 +222,12 @@ module.exports = {
     'jsx-a11y/aria-activedescendant-has-tabindex': 'warn',
     'jsx-a11y/aria-props': 'warn',
     'jsx-a11y/aria-proptypes': 'warn',
-    'jsx-a11y/aria-role': 'warn',
+    'jsx-a11y/aria-role': [
+      'warn',
+      {
+        ignoreNonDOM: true,
+      },
+    ],
     'jsx-a11y/aria-unsupported-elements': 'warn',
     'jsx-a11y/heading-has-content': 'warn',
     'jsx-a11y/iframe-has-title': 'warn',


### PR DESCRIPTION
> For the [ignoreNonDOM option][1], this determines if developer-created components are checked.

This allows `role` to be used as a prop name on custom components without running afoul of eslint.

[1]: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md