### PR TITLE
Support for graceful extension of Jest config

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -73,15 +73,25 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'extraGlobals',
     'globalSetup',
     'globalTeardown',
+    'moduleNameMapper',
     'resetMocks',
     'resetModules',
     'snapshotSerializers',
+    'transform',
+    'transformIgnorePatterns',
     'watchPathIgnorePatterns',
   ];
   if (overrides) {
     supportedKeys.forEach(key => {
       if (overrides.hasOwnProperty(key)) {
-        config[key] = overrides[key];
+        if (Array.isArray(config[key]) || typeof config[key] !== 'object')  {
+          // for arrays or primitive types, directly override the config key
+          config[key] = overrides[key];  
+        } else {
+          // for object types, extend gracefully
+          config[key] = Object.assign({}, config[key], overrides[key]);  
+        } 
+        
         delete overrides[key];
       }
     });


### PR DESCRIPTION
This PR fixes what I believe to be a very necessary fix for Jest configuration. https://github.com/facebook/create-react-app/issues/6042

What it does
- It adds 3 new keys to the allowedOverrides config
- It gracefully extends any jest config option that is an object while leaving arrays and primitive types to override
- Gracefully extending the objects made the most sense because it allows the original pieces to keep working as expected while give you the ability to fix things that would render the test framework useless for a project

We need to be able to update these keys for the following reasons
- **moduleNameMapper**: I've worked on many many jobs and projects and have yet to find one that didn't take advantage of aliasing in someway. If a project is using aliasing (despite CRAs efforts to continue to block it?) it renders the test framework useless.
- **transform**: adding any additional file types or loaders to a project will render this broken. Specifically here, I know people need to use `jest-transform-graphql`
- **transformIgnorePatterns**: This is really the reason this PR was created in the first place, the above two items were just logical additions... If someone distributes ES6 / ESNext code and you are using it in your project, you can no longer use Jest. While we can promote in a perfect world that everyone ships ES5 code, first class browser support for ES6 is making this less true. Also, some codebases intentionally use ES6 code since it results in smaller end user bundles. Lastly, The dev / build system supports this while Jest does not!

My current Jest key in package.json
![image](https://user-images.githubusercontent.com/975256/50092360-e3a1ad00-01db-11e9-97a4-5e5d9d742c9d.png)

Config before change, lacking my additions
![image](https://user-images.githubusercontent.com/975256/50092329-cbca2900-01db-11e9-9f3c-65f5845ab036.png)

Config after this PR :)
![image](https://user-images.githubusercontent.com/975256/50092427-10ee5b00-01dc-11e9-8eed-5fd4a30640e1.png)

