### PR TITLE
Ignore Eslint errors in src/**/node_modules (allows package development inside /src without breaking ESLint and babel-loader)

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -324,6 +324,7 @@ module.exports = function(webpackEnv) {
             },
           ],
           include: paths.appSrc,
+          exclude: /[/\\]node_modules[/\\]/,
         },
         {
           // "oneOf" will traverse all following loaders until one will
@@ -346,6 +347,7 @@ module.exports = function(webpackEnv) {
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
               include: paths.appSrc,
+              exclude: /[/\\]node_modules[/\\]/,
               loader: require.resolve('babel-loader'),
               options: {
                 customize: require.resolve(


### PR DESCRIPTION
**Exclude node_modules from source compilation (babel + advanced feature).**

This is a small change which allows package development without the whole lerna + babel toolkit : It's workspace package INSIDE src folder. Apart from the lint issue, everything else is working out-of-the-box!

---

![image](https://user-images.githubusercontent.com/368155/50104177-b0860a80-0229-11e9-8a66-8a77071f767c.png)

DevServer shows warnings
![image](https://user-images.githubusercontent.com/368155/50104287-e62af380-0229-11e9-811a-108461758445.png)

Warnings disappear with my changes
