### PR TITLE
Fix control comment of CSS Grid prefixing

### DIFF
--- a/docusaurus/docs/post-processing-css.md
+++ b/docusaurus/docs/post-processing-css.md
@@ -40,4 +40,4 @@ If you need to disable autoprefixing for some reason, [follow this section](http
 
 [CSS Grid Layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout) prefixing is disabled by default, but it will **not** strip manual prefixing.
 If you'd like to opt-in to CSS Grid prefixing, [first familiarize yourself about its limitations](https://github.com/postcss/autoprefixer#does-autoprefixer-polyfill-grid-layout-for-ie).<br>
-To enable CSS Grid prefixing, add `/* autoprefixer grid: on */` to the top of your CSS file.
+To enable CSS Grid prefixing, add `/* autoprefixer grid: autoplace */` to the top of your CSS file.


### PR DESCRIPTION
"on" value of "autoprefixer grid" is kinda deprecated. It's better to use "autoplace" or "no-autoplace" instead.
https://github.com/postcss/autoprefixer#options

"autoplace" enables PostCss' autoplace polyfill for ie and makes prefixes, "no-autoplace" only makes prefixes
https://github.com/postcss/autoprefixer#does-autoprefixer-polyfill-grid-layout-for-ie

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
