### PR TITLE
Update webpack-dev-server 3.1.9 -> 3.1.10

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -68,7 +68,7 @@
     "terser-webpack-plugin": "1.1.0",
     "url-loader": "1.1.1",
     "webpack": "4.19.1",
-    "webpack-dev-server": "3.1.9",
+    "webpack-dev-server": "3.1.10",
     "webpack-manifest-plugin": "2.0.4",
     "workbox-webpack-plugin": "3.6.3"
   },


### PR DESCRIPTION
Small bug fix update https://github.com/webpack/webpack-dev-server/releases/tag/v3.1.10

Mainly interested in the new ability to pass `writeToDisk` option to `webpack-dev-middleware` 

That option could be leveraged to solve https://github.com/facebook/create-react-app/issues/1070