### PR TITLE
Fix jest testMatch

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -40,7 +40,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupTestFrameworkScriptFile: setupTestsFile,
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
-      '<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}',
+      '<rootDir>/src/**/?*.(spec|test).{js,jsx,ts,tsx}',
     ],
     testEnvironment: 'jsdom',
     testURL: 'http://localhost',


### PR DESCRIPTION
With the current testMatch config, if you have a file that is actually called `test.ts`, it will be loaded as if it's a test file when you run your tests.

I don't think this is the desired behavior. A file that ends with `.test.ts` is a test file, but a file named `test.ts` shouldn't be. That dot is required.

With this change, the `test.ts` file won't be runned as a test, because the dot is now required to match.