### PR TITLE
Remove outdated docs for setting up eslint in editor

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -13,6 +13,7 @@ To configure the syntax highlighting in your favorite text editor, head to the [
 ## Displaying Lint Output in the Editor
 
 > Note: this feature is available with `react-scripts@0.2.0` and higher.<br>
+> It works out of the box for newly created projects with `react-scripts@2.0.3` and higher.<br>
 > It also only works with npm 3 or higher.
 
 Some editors, including Sublime Text, Atom, and Visual Studio Code, provide plugins for ESLint.


### PR DESCRIPTION
My first, naive approach was just to remove that section. If we should rather modify it or leave it for older versions, let me know!

closes: #6083 
