### PR TITLE
Replace deprecated VSCode launch.json variable

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -55,7 +55,7 @@ Then add the block below to your `launch.json` file and put it inside the `.vsco
       "type": "chrome",
       "request": "launch",
       "url": "http://localhost:3000",
-      "webRoot": "${workspaceRoot}/src",
+      "webRoot": "${workspaceFolder}/src",
       "sourceMapPathOverrides": {
         "webpack:///src/*": "${webRoot}/*"
       }


### PR DESCRIPTION
Replace deprecated ${workspaceRoot} variable with ${workspaceFolder} in VSCode launch.json. See https://code.visualstudio.com/docs/editor/variables-reference#_why-isnt-workspaceroot-documented

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
