### PR TITLE
Document --stats flag and multi chunk analysis

### DIFF
--- a/docusaurus/docs/analyzing-the-bundle-size.md
+++ b/docusaurus/docs/analyzing-the-bundle-size.md
@@ -47,7 +47,7 @@ npm run analyze
 
 > Note: this feature is natively available with react-scripts@2.0.3 and higher.
 
-[Webpack stats data](https://webpack.js.org/api/stats/) is a JSON document containing statistics on modules which were generated during build time. This file is useful for many tools like [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/) or the [Webpack bundle analyzer web app](https://github.com/webpack/analyse).
+[Webpack stats data](https://webpack.js.org/api/stats/) is a JSON document containing statistics on modules which were generated during build time. This file is useful for many tools like [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/) or the [Webpack bundle analyzer web app](http://webpack.github.io/analyse/).
 
 To output this stats file simply pass the `--stats` flag during build time.
 
@@ -67,7 +67,7 @@ The generated stats can be found in `build/bundle-stats.json`
 
 ## Analyzing Multi-Chunk Bundle Sizes
 
-`source-map-explorer` [currently does not support analyzing bundle sizes with multiple chunks](danvk/source-map-explorer/issues/250) like projects that utilize [code splitting](code-splitting.md). To analyze multiple chunks at once we need to use [`webpack-bundle-analyzer`](https://github.com/webpack-contrib/webpack-bundle-analyzer) with the [generated stats file](analyzing-the-bundle-size.md#outputting-webpack-stats-data) instead.
+`source-map-explorer` [currently does not support analyzing bundle sizes with multiple chunks](https://github.com/danvk/source-map-explorer/issues/25) like projects that utilize [code splitting](code-splitting.md). To analyze multiple chunks at once we need to use [`webpack-bundle-analyzer`](https://github.com/webpack-contrib/webpack-bundle-analyzer) with the [generated stats file](analyzing-the-bundle-size.md#outputting-webpack-stats-data) instead.
 
 To get started with `webpack-bundle-analyzer`, follow these steps:
 

--- a/docusaurus/docs/analyzing-the-bundle-size.md
+++ b/docusaurus/docs/analyzing-the-bundle-size.md
@@ -4,20 +4,25 @@ title: Analyzing the Bundle Size
 sidebar_label: Analyzing Bundle Size
 ---
 
+Bundle size analysis is a technique/process that allows us to visually identify what is bloating our bundle file in our generated JavaScript files using visualization tools.
+
+Using these tools can help you strategize what sections to [code split](code-splitting.md) or identify extraneous files which you are not using.
+
+## Getting Started
+
 [Source map explorer](https://www.npmjs.com/package/source-map-explorer) analyzes
-JavaScript bundles using the source maps. This helps you understand where code
-bloat is coming from.
+JavaScript bundles using the source maps.
 
 To add Source map explorer to a Create React App project, follow these steps:
 
 ```sh
-npm install --save source-map-explorer
+npm install --save-dev source-map-explorer
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add source-map-explorer
+yarn add source-map-explorer -D
 ```
 
 Then in `package.json`, add the following line to `scripts`:
@@ -36,4 +41,67 @@ script.
 ```
 npm run build
 npm run analyze
+```
+
+## Outputting Webpack Stats Data
+
+> Note: this feature is natively available with react-scripts@2.0.3 and higher.
+
+[Webpack stats data](https://webpack.js.org/api/stats/) is a JSON document containing statistics on modules which were generated during build time. This file is useful for many tools like [Webpack Visualizer](https://chrisbateman.github.io/webpack-visualizer/) or the [Webpack bundle analyzer web app](https://github.com/webpack/analyse).
+
+To output this stats file simply pass the `--stats` flag during build time.
+
+```bash
+npm run build --stats
+
+# or
+
+yarn build --stats
+```
+
+The generated stats can be found in `build/bundle-stats.json`
+
+> Note:
+> Although the stats file does not contain any sensitive data we recommend deleting the bundle stats file before making any deployments.  
+> Making this apart of your deployment process can reduce the risk of publishing this file.
+
+## Analyzing Multi-Chunk Bundle Sizes
+
+`source-map-explorer` [currently does not support analyzing bundle sizes with multiple chunks](danvk/source-map-explorer/issues/250) like projects that utilize [code splitting](code-splitting.md). To analyze multiple chunks at once we need to use [`webpack-bundle-analyzer`](https://github.com/webpack-contrib/webpack-bundle-analyzer) with the [generated stats file](analyzing-the-bundle-size.md#outputting-webpack-stats-data) instead.
+
+To get started with `webpack-bundle-analyzer`, follow these steps:
+
+Install `webpack-bundle-analyzer`
+
+```bash
+npm install --save-dev webpack-bundle-analyzer
+
+# or
+
+yarn add webpack-bundle-analyzer -D
+```
+
+> Note: If you installed `source-map-explorer` we recommend removing it since `webpack-bundle-analyzer` does the same and more
+
+Update or add the `analyze` script
+
+```diff
+   "scripts": {
+-    "analyze": "source-map-explorer build/static/js/main.*",
++    "analyze": "webpack-bundle-analyzer build/bundle-stats.json",
+     "start": "react-scripts start",
+     "build": "react-scripts build",
+     "test": "react-scripts test",
+```
+
+Create a new build with the stats file then run the analyze script
+
+```bash
+npm run build -- --stats
+npm run analyze
+
+# or
+
+yarn build --stats
+yarn analyze
 ```


### PR DESCRIPTION
[Finalized page screenshot can be seen here](https://static.ozairpatel.com/2019-2vcndae8ipbgcm7houbb.png)

## Documenting `--stats`
This PR will document a feature released in `2.0.3` which is the `--stats` flag that outputs the generated [Webpack stats file](https://webpack.js.org/api/stats/) (https://github.com/facebook/create-react-app/pull/3945).

## Documenting multi chunk analysis
It also documents a method to analyze a bundle that contains multiple chunks (i.e. code split) since [`source-map-analyzer` does not support multiple files](https://github.com/danvk/source-map-explorer/issues/25) by using [`webpack-bundle-analyzer`](https://github.com/webpack-contrib/webpack-bundle-analyzer) instead.

## Page structure change
Since the page does not contain one section anymore I expanded it into a introduction on bundle analysis and named the original section "Getting Started".

## Notes
I double checked to make sure I followed consistency and styling but let me know if theres any thing I can align with the current code base :)

When posting this hidden feature to Reddit it looks like many people did not know about it either!
https://www.reddit.com/r/reactjs/comments/a6drwr/til_in_cra2_you_can_pass_stats_flag_to_generate/