### PR TITLE
Bump eslint-plugin-react version and update webpack config

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -211,6 +211,7 @@ module.exports = {
     // 'react/no-deprecated': 'warn',
     'react/no-direct-mutation-state': 'warn',
     'react/no-is-mounted': 'warn',
+    'react/no-typos': 'error',
     'react/react-in-jsx-scope': 'error',
     'react/require-render-return': 'error',
     'react/style-prop-object': 'warn',

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -46,6 +46,12 @@ module.exports = {
     },
   },
 
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+
   rules: {
     // http://eslint.org/docs/rules/
     'array-callback-return': 'warn',

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -314,7 +314,7 @@ module.exports = function(webpackEnv) {
                 // @remove-on-eject-begin
                 baseConfig: {
                   extends: [require.resolve('eslint-config-react-app')],
-                  settings: { react: { version: '999.999.999' } },
+                  settings: { react: { version: 'detect' } },
                 },
                 ignore: false,
                 useEslintrc: false,

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -314,7 +314,6 @@ module.exports = function(webpackEnv) {
                 // @remove-on-eject-begin
                 baseConfig: {
                   extends: [require.resolve('eslint-config-react-app')],
-                  settings: { react: { version: 'detect' } },
                 },
                 ignore: false,
                 useEslintrc: false,

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-flowtype": "2.50.1",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "6.1.2",
-    "eslint-plugin-react": "7.11.1",
+    "eslint-plugin-react": "7.12.3",
     "file-loader": "2.0.0",
     "fork-ts-checker-webpack-plugin-alt": "0.4.14",
     "fs-extra": "7.0.0",


### PR DESCRIPTION
Closes #6115.

We are able to use [`detect`](https://github.com/yannickcr/eslint-plugin-react/pull/1978) instead of the obscure `999.999.999` value for the react version of the eslint-loader config after bumping `eslint-plugin-react`.