### PR TITLE
Added WRITE_TO_DISK environment variable. Fixes #1070

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -72,6 +72,10 @@ module.exports = function(proxy, allowedHost) {
     // WebpackDevServer is noisy by default so we emit custom message instead
     // by listening to the compiler events with `compiler.hooks[...].tap` calls above.
     quiet: true,
+    // WebpackDevServer has an option to write every build to disk. This can be
+    // useful for certain use cases such as developing browser extensions where one
+    // would need to otherwise do full builds.
+    writeToDisk: false || process.env.WRITE_TO_DISK === 'true',
     // Reportedly, this avoids CPU overload on some systems.
     // https://github.com/facebook/create-react-app/issues/293
     // src/node_modules is not ignored to support absolute imports


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
This PR will allow us to pass the [`writeToDisk`](https://github.com/webpack/webpack-dev-middleware#writetodisk) option to webpack-dev-middleware using a new environment variable `WRITE_TO_DISK`.

The new option addresses #1070 and use cases such as creating browser extensions.
