### PR TITLE
Suggests that tsconfig.json is incorrect only when SyntaxError is caught

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -182,7 +182,7 @@ function verifyTypeScriptSetup() {
       );
     }
     
-    console.error(e && e.message ? `${e.message}` : '');
+    console.log(e && e.message ? `${e.message}` : '');
     process.exit(1);
   }
 

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -172,13 +172,16 @@ function verifyTypeScriptSetup() {
 
     parsedCompilerOptions = result.options;
   } catch (e) {
-    console.error(
-      chalk.red.bold(
-        'Could not parse',
-        chalk.cyan('tsconfig.json') + '.',
-        'Please make sure it contains syntactically correct JSON.'
-      )
-    );
+    if (e && e.name === 'SyntaxError') {
+      console.error(
+        chalk.red.bold(
+          'Could not parse',
+          chalk.cyan('tsconfig.json') + '.',
+          'Please make sure it contains syntactically correct JSON.'
+        )
+      );
+    }
+    
     console.error(e && e.message ? `Details: ${e.message}` : '');
     process.exit(1);
   }

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -182,7 +182,7 @@ function verifyTypeScriptSetup() {
       );
     }
     
-    console.error(e && e.message ? `Details: ${e.message}` : '');
+    console.error(e && e.message ? `${e.message}` : '');
     process.exit(1);
   }
 


### PR DESCRIPTION
Otherwise I get i.e. such output;
```
Could not parse tsconfig.json. Please make sure it contains syntactically correct JSON.
Details: tsconfig.json(19,12): error TS1328: Property value can only be string literal, numeric literal, 'true', 'false', 'null', object literal or array literal.
```

Which is misleading - especially taking into account that info about incorrect JSON is written in bold