### PR TITLE
Update react-dev-util globby dependency to v8.0.2

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -54,7 +54,7 @@
     "filesize": "3.6.1",
     "find-up": "3.0.0",
     "global-modules": "2.0.0",
-    "globby": "8.0.1",
+    "globby": "8.0.2",
     "gzip-size": "5.0.0",
     "immer": "1.10.0",
     "inquirer": "6.2.1",


### PR DESCRIPTION
v8.0.2 was recently released https://github.com/sindresorhus/globby/releases to fix some pathing issues with dir-glob when v2.2.0 was published to npm this morning (https://www.npmjs.com/package/dir-glob).
Forcing to the new version locally fixes the current issues we're having with other packages not using the latest version, but it would be nice to get CRA on the same version as well.