### PR TITLE
Fix CI builds

### DIFF
--- a/test/fixtures/relative-paths/package.json
+++ b/test/fixtures/relative-paths/package.json
@@ -1,4 +1,7 @@
 {
-  "dependencies": {},
+  "dependencies": {
+    "react": "latest",
+    "react-dom": "latest"
+  },
   "homepage": "."
 }


### PR DESCRIPTION
We were missing dependencies in the `relative-paths` test fixture that yarn PnP decided to start complaining about. I imagine they must have fixed a bug that started catching our bug 😛.