### PR TITLE
Update local-test.sh to return test exit code

### DIFF
--- a/tasks/local-test.sh
+++ b/tasks/local-test.sh
@@ -98,8 +98,15 @@ ${apply_changes}
 node --version
 npm --version
 set +x
-${test_command} && echo -e "\n\e[1;32m✔ Job passed\e[0m" || echo -e "\n\e[1;31m✘ Job failed\e[0m"
+${test_command}
+result_code=\$?
+if [ \$result_code == 0 ]; then
+  echo -e "\n\e[1;32m✔ Job passed\e[0m"
+else
+  echo -e "\n\e[1;31m✘ Job failed\e[0m"
+fi
 $([[ ${interactive} == 'true' ]] && echo 'bash')
+exit \$result_code
 CMD
 
 docker run \


### PR DESCRIPTION
The `e2e:docker` command can run tests in a Docker container, but it always returns exit code 0 even if the tests failed. This PR resolves that and returns the exit code from the test command.