### PR TITLE
Updating updating-to-new-releases.md for users who installed CRA globally

### DIFF
--- a/docusaurus/docs/updating-to-new-releases.md
+++ b/docusaurus/docs/updating-to-new-releases.md
@@ -11,7 +11,7 @@ Create React App is divided into two packages:
 When you run `npx create-react-app my-app` it automatically installs the latest version of Create React App.  
 > If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, please visit [Getting Started](getting-started.md) to learn about current installation steps. 
 
-Create-React-App creates the project with the latest version of `react-scripts` so you’ll get all the new features and improvements in newly created apps automatically.
+Create React App creates the project with the latest version of `react-scripts` so you’ll get all the new features and improvements in newly created apps automatically.
 
 To update an existing project to a new version of `react-scripts`, [open the changelog](https://github.com/facebook/create-react-app/blob/master/CHANGELOG.md), find the version you’re currently on (check `package.json` in this folder if you’re not sure), and apply the migration instructions for the newer versions.
 

--- a/docusaurus/docs/updating-to-new-releases.md
+++ b/docusaurus/docs/updating-to-new-releases.md
@@ -9,9 +9,9 @@ Create React App is divided into two packages:
 - `react-scripts` is a development dependency in the generated projects (including this one).
 
 When you run `npx create-react-app my-app` it automatically installs the latest version of Create React App.  
-> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that `npx` always grabs the latest version.
+> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, please visit [Getting Started](https://facebook.github.io/create-react-app/docs/getting-started) to learn about current installtion steps. 
 
-When you run `create-react-app`, it always creates the project with the latest version of `react-scripts` so you’ll get all the new features and improvements in newly created apps automatically.
+Create-React-App creates the project with the latest version of `react-scripts` so you’ll get all the new features and improvements in newly created apps automatically.
 
 To update an existing project to a new version of `react-scripts`, [open the changelog](https://github.com/facebook/create-react-app/blob/master/CHANGELOG.md), find the version you’re currently on (check `package.json` in this folder if you’re not sure), and apply the migration instructions for the newer versions.
 

--- a/docusaurus/docs/updating-to-new-releases.md
+++ b/docusaurus/docs/updating-to-new-releases.md
@@ -8,7 +8,8 @@ Create React App is divided into two packages:
 - `create-react-app` is a global command-line utility that you use to create new projects.
 - `react-scripts` is a development dependency in the generated projects (including this one).
 
-You almost never need to update `create-react-app` itself: it delegates all the setup to `react-scripts`.
+When you run `npx create-react-app my-app` it automatically installs the latest version of Create React App.  
+> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that `npx` always grabs the latest version.
 
 When you run `create-react-app`, it always creates the project with the latest version of `react-scripts` so you’ll get all the new features and improvements in newly created apps automatically.
 

--- a/docusaurus/docs/updating-to-new-releases.md
+++ b/docusaurus/docs/updating-to-new-releases.md
@@ -9,7 +9,7 @@ Create React App is divided into two packages:
 - `react-scripts` is a development dependency in the generated projects (including this one).
 
 When you run `npx create-react-app my-app` it automatically installs the latest version of Create React App.  
-> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, please visit [Getting Started](https://facebook.github.io/create-react-app/docs/getting-started) to learn about current installtion steps. 
+> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, please visit [Getting Started](getting-started.md) to learn about current installation steps. 
 
 Create-React-App creates the project with the latest version of `react-scripts` so you’ll get all the new features and improvements in newly created apps automatically.
 


### PR DESCRIPTION
I opened https://github.com/facebook/create-react-app/issues/6140 a few days ago, after experiencing two bugs which were a result of CRA global install. #6157 solves half of the problem, but programmers who already installed CRA globally, are even more likely to check "updating-to-new-releases.md".
I think part of the current version of "updating-to-new-releases.md" is a bit outdated. 
