### PR TITLE
Update `serve` port flag and add example

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -15,7 +15,11 @@ npm install -g serve
 serve -s build
 ```
 
-The last command shown above will serve your static site on the port **5000**. Like many of [serve](https://github.com/zeit/serve)’s internal settings, the port can be adjusted using the `-p` or `--port` flags.
+The last command shown above will serve your static site on the port **5000**. Like many of [serve](https://github.com/zeit/serve)’s internal settings, the port can be adjusted using the `-l` flag:
+
+```sh
+serve -s build -l 4000
+```
 
 Run this command to get a full list of the options available:
 

--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -15,7 +15,7 @@ npm install -g serve
 serve -s build
 ```
 
-The last command shown above will serve your static site on the port **5000**. Like many of [serve](https://github.com/zeit/serve)’s internal settings, the port can be adjusted using the `-l` flag:
+The last command shown above will serve your static site on the port **5000**. Like many of [serve](https://github.com/zeit/serve)’s internal settings, the port can be adjusted using the `-l` or `--listen` flags:
 
 ```sh
 serve -s build -l 4000


### PR DESCRIPTION
Hi everyone! Thank for this awesome project! I enjoy this a lot and use it in my react projects! 


So, I needed to run front-end with `serve` library with my costume port, I made some reserch about all flags and docs about `serve` and noticed that frags which are on the CRA website are still working, but they are deprecated and `serve` lib recommends to use flag `-l` instead of `-p`, this discussion is in https://github.com/zeit/serve/issues/382 issue, and also you can see this in `serve` code: 
https://github.com/zeit/serve/blob/85d121e5008783395cc607089f23a5039547f952/bin/serve.js#L258

This pull request updates `serve` ports and adds example of using costume ports with `serve` lib