### PR TITLE
Adding Jest and Enzyme as development dependencies.

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -87,13 +87,13 @@ When you encounter bugs caused by changing components, you will gain a deeper in
 If you’d like to test components in isolation from the child components they render, we recommend using [`shallow()` rendering API](http://airbnb.io/enzyme/docs/api/shallow.html) from [Enzyme](http://airbnb.io/enzyme/). To install it, run:
 
 ```sh
-npm install --save enzyme enzyme-adapter-react-16 react-test-renderer
+npm install --save-dev enzyme enzyme-adapter-react-16 react-test-renderer
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add enzyme enzyme-adapter-react-16 react-test-renderer
+yarn add --dev enzyme enzyme-adapter-react-16 react-test-renderer
 ```
 
 As of Enzyme 3, you will need to install Enzyme along with an Adapter corresponding to the version of React you are using. (The examples above use the adapter for React 16.)
@@ -156,13 +156,13 @@ expect(wrapper).toContainReact(welcome);
 To enable this, install `jest-enzyme`:
 
 ```sh
-npm install --save jest-enzyme
+npm install --save-dev jest-enzyme
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add jest-enzyme
+yarn add --dev jest-enzyme
 ```
 
 Import it in [`src/setupTests.js`](#initializing-test-environment) to make its matchers available in every test:
@@ -178,13 +178,13 @@ As an alternative or companion to `enzyme`, you may consider using `react-testin
 To install `react-testing-library` and `jest-dom`, you can run:
 
 ```sh
-npm install --save react-testing-library jest-dom
+npm install --save-dev react-testing-library jest-dom
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add react-testing-library jest-dom
+yarn add --dev react-testing-library jest-dom
 ```
 
 Similar to `enzyme` you can create a `src/setupTests.js` file to avoid boilerplate in your test files:


### PR DESCRIPTION
Dependencies serve many different purposes. Some dependencies are needed to build your project, others are needed when you’re running your program. 

`devDependencies` are the development dependencies. Dependencies that you need at some point in the development workflow but not while running your code (e.g. Flow, TypeScript, Jest or Enzyme).

For me it makes sense to define `devDependencies` flag to install Jest and Enzyme as development dependencies. On the [Enzyme's homepage](https://airbnb.io/enzyme/#installation) as well as the [Jest's homepage](https://jestjs.io/docs/en/getting-started.html), there are guidance for installing as development dependency btw.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
