### PR TITLE
removed redundant statements

### DIFF
--- a/packages/babel-preset-react-app/README.md
+++ b/packages/babel-preset-react-app/README.md
@@ -34,7 +34,7 @@ This preset uses the `useBuiltIns` option with [transform-object-rest-spread](ht
 
 ## Usage with Flow
 
-Flow is enabled by default. Make sure you have a `.flowconfig` file at the root directory. You can also use the `flow` option on `.babelrc`:
+Make sure you have a `.flowconfig` file at the root directory. You can also use the `flow` option on `.babelrc`:
 
 ```
 {
@@ -44,7 +44,7 @@ Flow is enabled by default. Make sure you have a `.flowconfig` file at the root 
 
 ## Usage with TypeScript
 
-TypeScript is enabled by default. Make sure you have a `tsconfig.json` file at the root directory. You can also use the `typescript` option on `.babelrc`:
+Make sure you have a `tsconfig.json` file at the root directory. You can also use the `typescript` option on `.babelrc`:
 
 ```
 {


### PR DESCRIPTION
The enabled by default statement made sense when the developer was supposed to disable flow in order to use ts. Both those statements in there create some confusion about it in my opinion.
