### PR TITLE
Prevent cursor events on app-logo svg

### DIFF
--- a/packages/react-scripts/template-typescript/src/App.css
+++ b/packages/react-scripts/template-typescript/src/App.css
@@ -5,6 +5,7 @@
 .App-logo {
   animation: App-logo-spin infinite 20s linear;
   height: 40vmin;
+  pointer-events: none;
 }
 
 .App-header {

--- a/packages/react-scripts/template/src/App.css
+++ b/packages/react-scripts/template/src/App.css
@@ -5,6 +5,7 @@
 .App-logo {
   animation: App-logo-spin infinite 20s linear;
   height: 40vmin;
+  pointer-events: none;
 }
 
 .App-header {


### PR DESCRIPTION
This PR fix [#6273](https://github.com/facebook/create-react-app/issues/6273).

Prevent any cursor event on React logo, any component below can be clicked now. The images below show the border of logo.

![image](https://user-images.githubusercontent.com/15300776/51766144-fa7fcd00-20c0-11e9-80d1-921e98f40837.png)

![image](https://user-images.githubusercontent.com/15300776/51766154-010e4480-20c1-11e9-9294-d734a95cddb5.png)

I think is not really necessary change the SVG logo or put it directly in the code.

