### PR TITLE
Specify sourceType

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -350,6 +350,7 @@ module.exports = function(webpackEnv) {
                 customize: require.resolve(
                   'babel-preset-react-app/webpack-overrides'
                 ),
+                sourceType: 'unambiguous',
                 // @remove-on-eject-begin
                 babelrc: false,
                 configFile: false,


### PR DESCRIPTION
Resolves #6163, transpile a mixture of CJS scripts and ES modules in `src/` by treating only files with `import` or `export` statements as an ES module.