### PR TITLE
%PUBLIC_URL% in development

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -22,20 +22,20 @@ const forkTsCheckerWebpackPlugin = require('./ForkTsCheckerWebpackPlugin');
 
 const isInteractive = process.stdout.isTTY;
 
-function prepareUrls(protocol, host, port) {
+function prepareUrls(protocol, host, port, pathname = '/') {
   const formatUrl = hostname =>
     url.format({
       protocol,
       hostname,
       port,
-      pathname: '/',
+      pathname,
     });
   const prettyPrintUrl = hostname =>
     url.format({
       protocol,
       hostname,
       port: chalk.bold(port),
-      pathname: '/',
+      pathname,
     });
 
   const isUnspecifiedHost = host === '0.0.0.0' || host === '::';

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -68,9 +68,8 @@ module.exports = function(webpackEnv) {
   // `publicUrl` is just like `publicPath`, but we will provide it to our app
   // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
   // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
-  const publicUrl = isEnvProduction
-    ? publicPath.slice(0, -1)
-    : isEnvDevelopment && '';
+  const publicUrl = publicPath.slice(0, -1);
+
   // Get environment variables to inject into our app.
   const env = getClientEnvironment(publicUrl);
 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -59,9 +59,8 @@ module.exports = function(webpackEnv) {
   // Webpack uses `publicPath` to determine where the app is being served from.
   // It requires a trailing slash, or the file assets will get an incorrect path.
   // In development, we always serve from the root. This makes config easier.
-  const publicPath = isEnvProduction
-    ? paths.servedPath
-    : isEnvDevelopment && '/';
+  const publicPath = paths.servedPath;
+
   // Some apps do not use client-side routing with pushState.
   // For these, "homepage" can be set to "." to enable relative asset paths.
   const shouldUseRelativeAssetPaths = publicPath === './';

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -68,6 +68,10 @@ module.exports = function(proxy, allowedHost) {
     hot: true,
     // It is important to tell WebpackDevServer to use the same "root" path
     // as we specified in the config. In development, we always serve from /.
+
+    // ❌ /whatever/static/js/bundle.js doesn't work
+    // ✅ /static/js/bundle.js still does
+    // 🤔 Changing this to /whatever prevents %PUBLIC_URL% from being replaced!?
     publicPath: '/',
     // WebpackDevServer is noisy by default so we emit custom message instead
     // by listening to the compiler events with `compiler.hooks[...].tap` calls above.

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -68,10 +68,6 @@ module.exports = function(proxy, allowedHost) {
     hot: true,
     // It is important to tell WebpackDevServer to use the same "root" path
     // as we specified in the config. In development, we always serve from /.
-
-    // ❌ /whatever/static/js/bundle.js doesn't work
-    // ✅ /static/js/bundle.js still does
-    // 🤔 Changing this to /whatever prevents %PUBLIC_URL% from being replaced!?
     publicPath: paths.servedPath.slice(0, -1),
     // WebpackDevServer is noisy by default so we emit custom message instead
     // by listening to the compiler events with `compiler.hooks[...].tap` calls above.

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -72,7 +72,7 @@ module.exports = function(proxy, allowedHost) {
     // ❌ /whatever/static/js/bundle.js doesn't work
     // ✅ /static/js/bundle.js still does
     // 🤔 Changing this to /whatever prevents %PUBLIC_URL% from being replaced!?
-    publicPath: '/',
+    publicPath: paths.servedPath.slice(0, -1),
     // WebpackDevServer is noisy by default so we emit custom message instead
     // by listening to the compiler events with `compiler.hooks[...].tap` calls above.
     quiet: true,

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.8",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebook/create-react-app",
+  "homepage": "http://localhost:3000/whatever",
   "license": "MIT",
   "engines": {
     "node": ">=8.10"

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -3,7 +3,6 @@
   "version": "2.1.8",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebook/create-react-app",
-  "homepage": "http://localhost:3000/whatever",
   "license": "MIT",
   "engines": {
     "node": ">=8.10"

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -91,11 +91,17 @@ checkBrowsers(paths.appPath, isInteractive)
       // We have not found a port.
       return;
     }
+
     const config = configFactory('development');
     const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
     const appName = require(paths.appPackageJson).name;
     const useTypeScript = fs.existsSync(paths.appTsConfig);
-    const urls = prepareUrls(protocol, HOST, port);
+    const urls = prepareUrls(
+      protocol,
+      HOST,
+      port,
+      paths.servedPath.slice(0, -1)
+    );
     const devSocket = {
       warnings: warnings =>
         devServer.sockWrite(devServer.sockets, 'warnings', warnings),


### PR DESCRIPTION
In response to #6135 (and possibly replacing #4158), I'm attempting to enable support for `homepage` in development as well.

This way, development matches production URLs, which is _especially_ necessary when using CRA as part of a larger app, or behind a proxy.

I've been able to record a video of this working:
> https://gfycat.com/AcclaimedEssentialAlabamamapturtle

I could use some help on how I could further test this, & to what degree.
