### PR TITLE
Allow react-scripts test --no-watch

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -69,7 +69,7 @@ if (
 
 // Jest doesn't have this option so we'll remove it
 if (argv.indexOf('--no-watch') !== -1) {
-  argv.splice(argv.indexOf('--no-watch'), 1);
+  argv = argv.filter(arg => arg !== '--no-watch');
 }
 
 // @remove-on-eject-begin

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -67,6 +67,11 @@ if (
   argv.push(hasSourceControl ? '--watch' : '--watchAll');
 }
 
+// jest doesn't have this option so we'll remove it
+if (argv.indexOf('--no-watch') !== -1) {
+  argv.splice(argv.indexOf('--no-watch'), 1);
+}
+
 // @remove-on-eject-begin
 // This is not necessary after eject because we embed config into package.json.
 const createJestConfig = require('./utils/createJestConfig');

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -67,7 +67,7 @@ if (
   argv.push(hasSourceControl ? '--watch' : '--watchAll');
 }
 
-// jest doesn't have this option so we'll remove it
+// Jest doesn't have this option so we'll remove it
 if (argv.indexOf('--no-watch') !== -1) {
   argv.splice(argv.indexOf('--no-watch'), 1);
 }

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -54,12 +54,13 @@ function isInMercurialRepository() {
   }
 }
 
-// Watch unless on CI, in coverage mode, or explicitly running all tests
+// Watch unless on CI, in coverage mode, explicitly adding `--no-watch`,
+// or explicitly running all tests
 if (
   !process.env.CI &&
   argv.indexOf('--coverage') === -1 &&
-  argv.indexOf('--watchAll') === -1 &&
-  argv.indexOf('--watch=false') === -1
+  argv.indexOf('--no-watch') === -1 &&
+  argv.indexOf('--watchAll') === -1
 ) {
   // https://github.com/facebook/create-react-app/issues/5210
   const hasSourceControl = isInGitRepository() || isInMercurialRepository();

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -58,7 +58,8 @@ function isInMercurialRepository() {
 if (
   !process.env.CI &&
   argv.indexOf('--coverage') === -1 &&
-  argv.indexOf('--watchAll') === -1
+  argv.indexOf('--watchAll') === -1 &&
+  argv.indexOf('--watch=false') === -1
 ) {
   // https://github.com/facebook/create-react-app/issues/5210
   const hasSourceControl = isInGitRepository() || isInMercurialRepository();


### PR DESCRIPTION
This is a one-line pull request for https://github.com/facebook/create-react-app/issues/6284. This allows  `react-scripts test --watch=false` to allow react-scripts to run jest without watch mode.

I tested this out by `npm link`ing my local fork to a project created with `create-react-app`.

I ran the command `npm t -- --watch=false` and jest closed right after everything was ran!

See the gif, when `--watch=false` is added, it no longer adds the `--watch`:

![jest-watch-false](https://user-images.githubusercontent.com/10551026/51794442-6a658480-21a1-11e9-961d-44fa07903c08.gif)
