### PR TITLE
Fix error messages for child compilations

### DIFF
--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -220,7 +220,7 @@ measureFileSizesBeforeBuild(buildFolder).then(previousFileSizes => {
 });
 ```
 
-#### `formatWebpackMessages({errors: Array<string>, warnings: Array<string>}): {errors: Array<string>, warnings: Array<string>}`
+#### `formatWebpackMessages({errors: Array<string>, warnings: Array<string>, children}): {errors: Array<string>, warnings: Array<string>}`
 
 Extracts and prettifies warning and error messages from webpack [stats](https://github.com/webpack/docs/wiki/node.js-api#stats) object.
 
@@ -236,7 +236,12 @@ compiler.hooks.invalid.tap('invalid', function() {
 });
 
 compiler.hooks.done.tap('done', function(stats) {
-  var rawMessages = stats.toJson({}, true);
+  var rawMessages = stats.toJson({
+    all: false,
+    children: true,
+    warnings: true,
+    errors: true,
+  });
   var messages = formatWebpackMessages(rawMessages);
   if (!messages.errors.length && !messages.warnings.length) {
     console.log('Compiled successfully!');

--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -153,7 +153,7 @@ function createCompiler(webpack, config, appName, urls, useYarn) {
     // We only construct the warnings and errors for speed:
     // https://github.com/facebook/create-react-app/issues/4492#issuecomment-421959548
     const messages = formatWebpackMessages(
-      stats.toJson({ all: false, warnings: true, errors: true })
+      stats.toJson({ all: false, children: true, warnings: true, errors: true })
     );
     const isSuccessful = !messages.errors.length && !messages.warnings.length;
     if (isSuccessful) {

--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -109,11 +109,24 @@ function formatMessage(message, isError) {
   return message.trim();
 }
 
+function recursivelyFindMessages(json, property) {
+  let messages = json[property];
+  if (json.children) {
+    json.children.forEach(function(child) {
+      const childMessages = recursivelyFindMessages(child, property);
+      messages = messages.concat(childMessages);
+    });
+  }
+  return messages;
+}
+
 function formatWebpackMessages(json) {
-  const formattedErrors = json.errors.map(function(message) {
+  const errors = recursivelyFindMessages(json, 'errors');
+  const formattedErrors = errors.map(function(message) {
     return formatMessage(message, true);
   });
-  const formattedWarnings = json.warnings.map(function(message) {
+  const warnings = recursivelyFindMessages(json, 'warnings');
+  const formattedWarnings = warnings.map(function(message) {
     return formatMessage(message, false);
   });
   const result = { errors: formattedErrors, warnings: formattedWarnings };

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -157,7 +157,12 @@ function build(previousFileSizes) {
         });
       } else {
         messages = formatWebpackMessages(
-          stats.toJson({ all: false, warnings: true, errors: true })
+          stats.toJson({
+            all: false,
+            children: true,
+            warnings: true,
+            errors: true,
+          })
         );
       }
       if (messages.errors.length) {


### PR DESCRIPTION
While working with an app that was ejected from create-react-app some time ago, I ran into an issue where the terminal was giving me the usual "Compiled successfully! You can now view cra in the browser." message, while actually opening the app in the browser was resulting in a "Cannot find /" message.

Further investigation showed that the Webpack `compiler` object's output filesystem object was empty, as if the build was failing. In fact, the build of a child compilation for a worker *was* failing, but `react-dev-utils` was not seeing this as `formatWebpackMessages()` only looks at `jsonStats.errors`, but ignores `jsonStats.children[i].errors`.

Updating `formatWebpackMessages()` to take child compilation errors into account solved the problem, with the "Compiled successfully!" message being replaced with the error that was causing compilation to fail.

Unfortunately, I've spent a couple hours trying to put together a simple reproduction that demonstrates the error outside of my old project, but have not been able to reproduce the error. I figure I should submit this anyway in case anybody else *does* find the error, as I lost most of the day to it. If nobody else is able to reproduce (and you don't merge it anyway), I'll try and spend a couple more hours on my own reproduction.
