### PR TITLE
Add Node DNS module to empty mocks

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -646,6 +646,7 @@ module.exports = function(webpackEnv) {
     node: {
       module: 'empty',
       dgram: 'empty',
+      dns: 'empty',
       fs: 'empty',
       net: 'empty',
       tls: 'empty',

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -646,7 +646,7 @@ module.exports = function(webpackEnv) {
     node: {
       module: 'empty',
       dgram: 'empty',
-      dns: 'empty',
+      dns: 'mock',
       fs: 'empty',
       net: 'empty',
       tls: 'empty',


### PR DESCRIPTION
DNS is required by some popular node.js modules; presently a require statement for DNS will throw an error if it is not wrapped in a try catch block.

Closes #6277.