### PR TITLE
Disable Terser function inlining

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -205,7 +205,7 @@ module.exports = function(webpackEnv) {
               // https://github.com/facebook/create-react-app/issues/5250
               // Pending futher investigation:
               // https://github.com/terser-js/terser/issues/120
-              inline: 2,
+              inline: false,
             },
             mangle: {
               safari10: true,


### PR DESCRIPTION
[There's a bug](https://github.com/pierpo/react-archer/issues/24) in a library I contribute to that is causing us a lot of trouble. There's plenty of documentation of the bug, and we can reliably reproduce it in our production app. Can you disable this behavior here to help out one of our users?
