### PR TITLE
Update babel-plugin-macros 2.4.4 -> 2.4.5

### DIFF
--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -34,7 +34,7 @@
     "@babel/runtime": "7.2.0",
     "babel-loader": "8.0.5",
     "babel-plugin-dynamic-import-node": "2.2.0",
-    "babel-plugin-macros": "2.4.4",
+    "babel-plugin-macros": "2.4.5",
     "babel-plugin-transform-react-remove-prop-types": "0.4.21"
   }
 }


### PR DESCRIPTION
As part of the latest babel-plugin-macros [2.4.5 release](https://github.com/kentcdodds/babel-plugin-macros/releases/tag/v2.4.5), there was a small fix that went in that fixes a [bug](https://github.com/kentcdodds/babel-plugin-macros/pull/100) specifying the `babelMacros` entry in `package.json` no longer working. This patch version increase should remedy the issue and allow specifying babel macro configuration in the `package.json` file again (as stated in the [user docs](https://github.com/kentcdodds/babel-plugin-macros/blob/master/other/docs/user.md#config-experimental) of babel-plugin-macros)
