### PR TITLE
Update testMatch to also be compatible with Jest 24

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -40,7 +40,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupTestFrameworkScriptFile: setupTestsFile,
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
-      '<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}',
+      '<rootDir>/src/**/*(*.){spec,test}.{js,jsx,ts,tsx}',
     ],
     testEnvironment: 'jsdom',
     testURL: 'http://localhost',

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -40,7 +40,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     setupTestFrameworkScriptFile: setupTestsFile,
     testMatch: [
       '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',
-      '<rootDir>/src/**/*(*.){spec,test}.{js,jsx,ts,tsx}',
+      '<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}',
     ],
     testEnvironment: 'jsdom',
     testURL: 'http://localhost',


### PR DESCRIPTION
For people who try to use Jest 24, there is a different version of `micromatch` and it behaves differently.  These changes should make it behave the same before and after changing Jest versions.

Without this change, Jest 24 will come up with no files to test.

I tested with `npm run test -- --listTests` on two projects, one with the default Jest 23 and another with the new Jest 24.  In addition to numerous normally named test files had some special case files like `src/.test.js`, `src/test.js`, and `src/somethingtest.js`.  Only the first two matched and the third one didn't; both pre-, and post- this change.