### PR TITLE
fix local yarn create-react-app for local testing before publish

### DIFF
--- a/tasks/cra.js
+++ b/tasks/cra.js
@@ -113,7 +113,7 @@ const args = process.argv.slice(2);
 // Now run the CRA command
 const craScriptPath = path.join(packagesDir, 'create-react-app', 'index.js');
 cp.execSync(
-  `node ${craScriptPath} --scripts-version="${scriptsPath}" ${args.join(' ')}`,
+  `node ${craScriptPath} ${args.join(' ')} --scripts-version="${scriptsPath}"`,
   {
     cwd: rootDir,
     stdio: 'inherit',


### PR DESCRIPTION
When running "yarn create-react-app my-app" to test local scripts changes in a CRA-fork it will fail with "You have provided more than one argument for <project-directory>". This fixes the bug by moving the project dir to the front.