### PR TITLE
Add additional information for postcss errors (#6282)

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -157,9 +157,7 @@ function build(previousFileSizes) {
         // Add additional information for postcss errors
         if (err.hasOwnProperty('postcssNode')) {
           errMessage +=
-            '\n' +
-            path.basename(err['postcssNode'].source.input.file) +
-            '\nCompileError: Begins at selector ' +
+            '\nCompileError: Begins at CSS selector ' +
             err['postcssNode'].selector +
             ' (' +
             err['postcssNode'].source.start.line +

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -156,12 +156,15 @@ function build(previousFileSizes) {
 
         // Add additional information for postcss errors
         if (err.hasOwnProperty('postcssNode')) {
-          const source = err['postcssNode'].source;
-          errMessage += '\n' + path.basename(source.input.file) +
+          errMessage +=
+            '\n' +
+            path.basename(err['postcssNode'].source.input.file) +
             '\nCompileError: Begins at selector ' +
-            err['postcssNode'].selector +' (' +
-            err['postcssNode'].source.start.line + ':' +
-            source.start.column +
+            err['postcssNode'].selector +
+            ' (' +
+            err['postcssNode'].source.start.line +
+            ':' +
+            err['postcssNode'].source.start.column +
             ')';
         }
 

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -151,8 +151,22 @@ function build(previousFileSizes) {
         if (!err.message) {
           return reject(err);
         }
+
+        let errMessage = err.message;
+
+        // Add additional information for postcss errors
+        if (err.hasOwnProperty('postcssNode')) {
+          const source = err['postcssNode'].source;
+          errMessage += '\n' + path.basename(source.input.file) +
+            '\nCompileError: Begins at selector ' +
+            err['postcssNode'].selector +' (' +
+            err['postcssNode'].source.start.line + ':' +
+            source.start.column +
+            ')';
+        }
+
         messages = formatWebpackMessages({
-          errors: [err.message],
+          errors: [errMessage],
           warnings: [],
         });
       } else {

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -158,12 +158,7 @@ function build(previousFileSizes) {
         if (err.hasOwnProperty('postcssNode')) {
           errMessage +=
             '\nCompileError: Begins at CSS selector ' +
-            err['postcssNode'].selector +
-            ' (' +
-            err['postcssNode'].source.start.line +
-            ':' +
-            err['postcssNode'].source.start.column +
-            ')';
+            err['postcssNode'].selector;
         }
 
         messages = formatWebpackMessages({


### PR DESCRIPTION
Fixes #6282: If build compiler error has postcssNode property, add additional information to the error message. Default compiler CSS error messages are opaque. To verify:

```
npx create-react-app css-test
cd css-test
echo "label[for=*] { margin-right: 12px; }" > ./src/App.css
yarn build
```

Outputs error:
![screen shot 2019-02-06 at 2 51 13 pm](https://user-images.githubusercontent.com/1865690/52369549-f6d43a80-2a1e-11e9-8de7-c3e9fbecb10e.png)

Replace css-test/node_modules/react-scripts/build.js lines:
```
messages = formatWebpackMessages({
  errors: [err.message],
  warnings: [],
});
```

With :
```
        let errMessage = err.message;

        // Add additional information for postcss errors
        if (err.hasOwnProperty('postcssNode')) {
          errMessage += '\n' + path.basename(
            err['postcssNode'].source.input.file
          ) + '\nCompileError: Begins at selector ' +
            err['postcssNode'].selector +' (' +
            err['postcssNode'].source.start.line + ':' +
            err['postcssNode'].source.start.column +
            ')';
        }

        messages = formatWebpackMessages({
          errors: [errMessage],
          warnings: [],
        });
```
Run `yarn build` to view new compiler error output:
![screen shot 2019-02-06 at 2 52 06 pm](https://user-images.githubusercontent.com/1865690/52369793-6fd39200-2a1f-11e9-8b25-255bed897fa1.png)