### PR TITLE
update bash commands for HTTPS use in local env

### DIFF
--- a/docusaurus/docs/using-https-in-development.md
+++ b/docusaurus/docs/using-https-in-development.md
@@ -27,7 +27,7 @@ set HTTPS=true&&npm start
 ### Linux, macOS (Bash)
 
 ```bash
-HTTPS=true npm start
+export HTTPS=true&&npm start
 ```
 
 Note that the server will use a self-signed certificate, so your web browser will almost definitely display a warning upon accessing the page.


### PR DESCRIPTION
The environment variable HTTPS needs to be exported in order to be inherited in the environment for future commands that are called (i.e. npm start).

See [this stackexchange link](https://askubuntu.com/questions/205688/whats-the-difference-between-set-export-and-env-and-when-should-i-use-each) for an explanation

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
