### PR TITLE
Make manifest.json description more generic

### DIFF
--- a/packages/react-scripts/template-typescript/public/index.html
+++ b/packages/react-scripts/template-typescript/public/index.html
@@ -9,8 +9,8 @@
     />
     <meta name="theme-color" content="#000000" />
     <!--
-      manifest.json provides metadata used when your web app is added to the
-      homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--

--- a/packages/react-scripts/template/public/index.html
+++ b/packages/react-scripts/template/public/index.html
@@ -9,8 +9,8 @@
     />
     <meta name="theme-color" content="#000000" />
     <!--
-      manifest.json provides metadata used when your web app is added to the
-      homescreen on Android. See https://developers.google.com/web/fundamentals/web-app-manifest/
+      manifest.json provides metadata used when your web app is installed on a
+      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--


### PR DESCRIPTION
The template includes a comment describing the purpose of the manifest.json file. It specifically refers to add-to-home-screen functionality on Android. There's now much better cross platform support for Web App Manifests, so I thought it'd be better to make the description more generic. The language was pulled directly from the [first sentence of Google's documentation](https://developers.google.com/web/fundamentals/web-app-manifest/). 