### PR TITLE
Use semicolons in the ProcessEnv interface

### DIFF
--- a/packages/react-scripts/lib/react-app.d.ts
+++ b/packages/react-scripts/lib/react-app.d.ts
@@ -4,8 +4,8 @@
 
 declare namespace NodeJS {
   interface ProcessEnv {
-    NODE_ENV: 'development' | 'production' | 'test'
-    PUBLIC_URL: string
+    NODE_ENV: 'development' | 'production' | 'test';
+    PUBLIC_URL: string;
   }
 }
 


### PR DESCRIPTION
Interface members should be [terminated with semicolons](https://www.typescriptlang.org/docs/handbook/interfaces.html). I've made this change to be consistent with other interfaces in the `create-react-app` project and also to fulfil a widely used TSLint rule [`semicolon`](https://palantir.github.io/tslint/rules/semicolon/).