### PR TITLE
Upgrade css-loader to 2.1.0

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -34,7 +34,7 @@
     "babel-preset-react-app": "^7.0.0",
     "bfj": "6.1.1",
     "case-sensitive-paths-webpack-plugin": "2.1.2",
-    "css-loader": "1.0.0",
+    "css-loader": "2.1.0",
     "dotenv": "6.0.0",
     "dotenv-expand": "4.2.0",
     "eslint": "5.12.0",


### PR DESCRIPTION
A simple PR to upgrade `css-loader` to version 2.1.0.
There is a bug with version 1.0.0 when importing a font with a hash at the end.

For example:
This CSS
```
@font-face {
	font-family: "My Font";
	src: url("My Font.svg#Font Name") format("svg");
}
```

generates this:
```
@font-face {
	font-family: "My Font";
	src: url("/static/media/My Font.f84c8961.svg"#Font Name) format("svg");
}
```
(which is invalid)

This issue is fixed in `css-loader` v2.0.0.
See the changelog here: https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md
In this commit: https://github.com/webpack-contrib/css-loader/issues/803