### PR TITLE
Use contenthash instead of chunkhash for better long-term caching

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -161,11 +161,11 @@ module.exports = function(webpackEnv) {
       // There will be one main bundle, and one file per asynchronous chunk.
       // In development, it does not produce real files.
       filename: isEnvProduction
-        ? 'static/js/[name].[chunkhash:8].js'
+        ? 'static/js/[name].[contenthash:8].js'
         : isEnvDevelopment && 'static/js/bundle.js',
       // There are also additional JS chunk files if you use code splitting.
       chunkFilename: isEnvProduction
-        ? 'static/js/[name].[chunkhash:8].chunk.js'
+        ? 'static/js/[name].[contenthash:8].chunk.js'
         : isEnvDevelopment && 'static/js/[name].chunk.js',
       // We inferred the "public path" (such as / or /my-project) from homepage.
       // We use "/" in development.


### PR DESCRIPTION
This changes the .js webpack file name values to use `contenthash` instead of `chunkhash` as recommended by the webpack team:

https://github.com/webpack/webpack.js.org/issues/2096
https://webpack.js.org/guides/caching/#output-filenames

This should improve long-term caching for our users by relying only on the contents of the .js file itself instead of the chunk as a whole (.js, .css, etc) to generate the filename.