### PR TITLE
Update eslint-plugin-import

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -41,7 +41,7 @@
     "eslint-config-react-app": "^3.0.7",
     "eslint-loader": "2.1.1",
     "eslint-plugin-flowtype": "2.50.1",
-    "eslint-plugin-import": "2.14.0",
+    "eslint-plugin-import": "2.16.0",
     "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-react": "7.12.4",
     "file-loader": "2.0.0",


### PR DESCRIPTION
Update eslint-plugin-import from 2.14.0 to 2.16.0
It contains new rule 'no-named-export', fixes for 'no-extraneous-dependencies' and 'dynamic-import-chunkname' 
https://github.com/benmosher/eslint-plugin-import/blob/master/CHANGELOG.md