### PR TITLE
Update installing-a-dependency.md

### DIFF
--- a/docusaurus/docs/installing-a-dependency.md
+++ b/docusaurus/docs/installing-a-dependency.md
@@ -6,7 +6,7 @@ title: Installing a Dependency
 The generated project includes React and ReactDOM as dependencies. It also includes a set of scripts used by Create React App as a development dependency. You may install other dependencies (for example, React Router) with `npm`:
 
 ```sh
-npm install --save react-router-dom
+npm install react-router-dom
 ```
 
 Alternatively you may use `yarn`:


### PR DESCRIPTION
The "--save" option has not been needed since the release of npm 5.0.0 (released 26 May 2017)

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
