### PR TITLE
feat(typescript): add skip typecheck env

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -44,6 +44,10 @@ const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
 // Check if TypeScript is setup
 const useTypeScript = fs.existsSync(paths.appTsConfig);
 
+// Skip TypeScript type checking
+const typeCheckTypeScript =
+  useTypeScript && !(process.env.SKIP_TYPE_CHECK === 'true');
+
 // style files regexes
 const cssRegex = /\.css$/;
 const cssModuleRegex = /\.module\.css$/;
@@ -620,7 +624,7 @@ module.exports = function(webpackEnv) {
           ],
         }),
       // TypeScript type checking
-      useTypeScript &&
+      typeCheckTypeScript &&
         new ForkTsCheckerWebpackPlugin({
           typescript: resolve.sync('typescript', {
             basedir: paths.appNodeModules,


### PR DESCRIPTION
add SKIP_TYPE_CHECK env to disable typescript type checking fix #5784

When you are just testing new code, it makes sense to be less strict on type checking

This also make compilation with typescript much faster
