### PR TITLE
Avoid IDE folders

### DIFF
--- a/packages/react-scripts/template-typescript/gitignore
+++ b/packages/react-scripts/template-typescript/gitignore
@@ -5,6 +5,10 @@
 /.pnp
 .pnp.js
 
+# ide
+.idea
+.vscode
+
 # testing
 /coverage
 

--- a/packages/react-scripts/template/gitignore
+++ b/packages/react-scripts/template/gitignore
@@ -5,6 +5,10 @@
 /.pnp
 .pnp.js
 
+# ide
+.idea
+.vscode
+
 # testing
 /coverage
 


### PR DESCRIPTION
I made a search in the PR's and nothing came up, so hence my PR.

As most used IDE's for development are Jetbrains IDEA / Webstorm etc which use `.idea` and Visual Studio Code which uses `.vscode`.

I want to add these to the templates of the gitignore files, so they are ignored by default.
