### PR TITLE
Analyse also dependencies bundle

### DIFF
--- a/docusaurus/docs/analyzing-the-bundle-size.md
+++ b/docusaurus/docs/analyzing-the-bundle-size.md
@@ -24,7 +24,7 @@ Then in `package.json`, add the following line to `scripts`:
 
 ```diff
    "scripts": {
-+    "analyze": "source-map-explorer build/static/js/main.*",
++    "analyze": "source-map-explorer 'build/static/js/*.js'",
      "start": "react-scripts start",
      "build": "react-scripts build",
      "test": "react-scripts test",


### PR DESCRIPTION
The current `analyze` script only analises the `/src` code. This change leverages new version of `source-map-explorer` that is able to analyse multiple bundles at once, including the  3rd party dependencies bundle which is in my opinion even more important to analyze.