### PR TITLE
feat: add support of xhtml in inlineChunkHtml plugin

### DIFF
--- a/packages/react-dev-utils/InlineChunkHtmlPlugin.js
+++ b/packages/react-dev-utils/InlineChunkHtmlPlugin.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+'use strict';
+
 class InlineChunkHtmlPlugin {
   constructor(htmlWebpackPlugin, tests) {
     this.htmlWebpackPlugin = htmlWebpackPlugin;


### PR DESCRIPTION
Hi,
The InlineChunkHtmlPlugin generate a script tag inside the index.html.
So if we choose to use xhtml in the HtmlWebpackPlugin we got some troubles. The XML is bad formatted.

This PR check in the complier if there is an instance of HTMLWebpackPlugin and take the value of the `xhtml` key

cf : https://developer.mozilla.org/en-US/docs/Archive/Web/Writing_JavaScript_for_HTML