### PR TITLE
Update Typescript .md file that has a typo.

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -14,7 +14,7 @@ npx create-react-app my-app --typescript
 
 # or
 
-yarn create react-app my-app --typescript
+yarn create-react-app my-app --typescript
 ```
 
 To add [TypeScript](https://www.typescriptlang.org/) to a Create React App project, first install it:


### PR DESCRIPTION
yarn create react-app my-app --typescript

A 'dash' is missing in the line `yarn create react-app my-app --typescript` . It should be `yarn create-react-app my-app --typescript`

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
