### PR TITLE
fix(windows7 & eject.js): add babel.config.js when windows7 detected

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -115,10 +115,10 @@ module.exports = {
   // These properties only exist before ejecting:
   ownPath: resolveOwn('.'),
   ownNodeModules: resolveOwn('node_modules'), // This is empty on npm 3
+  babelConfigPath: resolveOwn('scripts/utils/babel.config.js'),
   appTypeDeclarations: resolveApp('src/react-app-env.d.ts'),
   ownTypeDeclarations: resolveOwn('lib/react-app.d.ts'),
 };
-
 const ownPackageJson = require('../package.json');
 const reactScriptsPath = resolveApp(`node_modules/${ownPackageJson.name}`);
 const reactScriptsLinked =

--- a/packages/react-scripts/scripts/eject.js
+++ b/packages/react-scripts/scripts/eject.js
@@ -215,9 +215,22 @@ inquirer
 
     // Add Babel config
     console.log(`  Adding ${cyan('Babel')} preset`);
-    appPackage.babel = {
-      presets: ['react-app'],
-    };
+    // Resolves https://github.com/facebook/create-react-app/issues/6038
+    if (process.platform === 'win32') {
+      const winVersion = os.release().split('.')[0];
+      if (winVersion < 7) {
+        console.log(
+          `  Detected Windows7: Adding ${cyan('Babel')}.config.js file`
+        );
+        fs.copyFileSync(paths.babelConfigPath, 'babel.config.js', {
+          dereference: true,
+        });
+      }
+    } else {
+      appPackage.babel = {
+        presets: ['react-app'],
+      };
+    }
 
     // Add ESlint config
     console.log(`  Adding ${cyan('ESLint')} configuration`);

--- a/packages/react-scripts/scripts/utils/babel.config.js
+++ b/packages/react-scripts/scripts/utils/babel.config.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = function(api) {
+  api.cache(true);
+  const presets = ['react-app'];
+
+  return {
+    presets,
+  };
+};


### PR DESCRIPTION
Fixes #6038 

Verified fix correctly detects windows7 and triggers file copy of babel.config.js into the root directory of the cra.  Ran the same code on a Mac OS, and it correctly wrote the default babel configuration setup into the package.json file.
