### PR TITLE
Remove tell targetWindow to activate when tab is already running

### DIFF
--- a/packages/react-dev-utils/openChrome.applescript
+++ b/packages/react-dev-utils/openChrome.applescript
@@ -25,7 +25,6 @@ on run argv
     if found then
       set targetWindow's active tab index to targetTabIndex
       tell targetTab to reload
-      tell targetWindow to activate
       set index of targetWindow to 1
       return
     end if


### PR DESCRIPTION
This line makes working with nodemon or any other auto-restarter incredibly annoying as focus is taken away from the editor as soon as the server restarts.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
