### PR TITLE
Fixing typo of the first yarn command.

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -14,7 +14,7 @@ npx create-react-app my-app --typescript
 
 # or
 
-yarn create react-app my-app --typescript
+yarn create-react-app my-app --typescript
 ```
 
 To add [TypeScript](https://www.typescriptlang.org/) to a Create React App project, first install it:


### PR DESCRIPTION
From `yarn create react-app --typescript`  to  `yarn create-react-app --typescript`

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
