### PR TITLE
Remove latest Node version from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: node_js
 node_js:
   - 8
   - 10
-  - node
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
We added this a while ago and it's been causing some issues. It's nice to run our tests on the latest version of Node but it shouldn't be failing our build. This creates a lot of confusion and uncertainty.

We will look into ways to add this back in the future, separate from the main build and test suite.
