### PR TITLE
Update webpack-dev-server to 3.2.1

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -67,7 +67,7 @@
     "terser-webpack-plugin": "1.2.2",
     "url-loader": "1.1.2",
     "webpack": "4.28.3",
-    "webpack-dev-server": "3.2.0",
+    "webpack-dev-server": "3.2.1",
     "webpack-manifest-plugin": "2.0.4",
     "workbox-webpack-plugin": "3.6.3"
   },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -67,7 +67,7 @@
     "terser-webpack-plugin": "1.2.2",
     "url-loader": "1.1.2",
     "webpack": "4.28.3",
-    "webpack-dev-server": "3.1.14",
+    "webpack-dev-server": "3.2.0",
     "webpack-manifest-plugin": "2.0.4",
     "workbox-webpack-plugin": "3.6.3"
   },


### PR DESCRIPTION
This PR is a simple request to upgrade the version of `webpack-dev-server`, which adds support for the IBM i platform and AIX. 

Currently, the install of `react-scripts` fails because of an old version of `internal-ip` that was not installable on these platforms. `webpack-dev-server` was updated in this PR: https://github.com/webpack/webpack-dev-server/pull/1668 which landed in 3.2.0
