### PR TITLE
Fix deployInstruction: Alt+click link appends comma at end

### DIFF
--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -70,7 +70,7 @@ function printBaseMessage(buildFolder, hostingLocation) {
 }
 
 function printDeployInstructions(publicUrl, hasDeployScript, useYarn) {
-  console.log(`To publish it at ${chalk.green(publicUrl)}, run:`);
+  console.log(`To publish it at ${chalk.green(publicUrl)} , run:`);
   console.log();
 
   // If script deploy has been added to package.json, skip the instructions


### PR DESCRIPTION
At deploy instruction, the generate publicUrl link is appended with comma and while clicking the link browser opens it with comma at end in my machine. [Mac pro 2016| Chrome Version 71.0.3578.98]
For e.g: 
To publish it at http://sbimochan.github.io, run:
--
This "http://sbimochan.github.io, " gets into browser.