### PR TITLE
Adds nonce to inline script using webpack's approach

### DIFF
--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -122,6 +122,14 @@ export function stopReportingRuntimeErrors() {
   }
 }
 
+function getNonce() {
+  if (typeof __webpack_nonce__ === 'undefined') {
+    return null;
+  }
+
+  return __webpack_nonce__; // eslint-disable-line no-undef
+}
+
 function update() {
   // Loading iframe can be either sync or async depending on the browser.
   if (isLoadingIframe) {
@@ -148,6 +156,10 @@ function update() {
       );
       script.type = 'text/javascript';
       script.innerHTML = iframeScript;
+      const nonce = getNonce();
+      if (nonce) {
+        script.setAttribute('nonce', nonce);
+      }
       iframeDocument.body.appendChild(script);
     }
   };


### PR DESCRIPTION
This is about **Content Security Policy** headers and the **react-error-overlay** inserted inline script.

When serving CSP headers with a 'nonce' source within the 'script-src' directive, any inline script in the DOM will effectively be blocked by the client, preventing the script execution. This stops the iframe from showing the actual overlay.

Several other libraries, some related to Webpack, [have overcome this issue](https://github.com/webpack-contrib/style-loader/pull/319/files#diff-04d527816b7b43741ff8bef689a31f44) by setting the 'nonce' attribute before creating the script/style tag and inserting it into the DOM.

The solution I'm proposing here allows the user to either set `__webpack_nonce__` in a Webpack entrypoint that imports **react-error-overlay** or, if the bundler used isn't Webpack, simply set `window.__webpack_nonce__` inside the DOM manually in a dev environment where it will be picked up on runtime.

Relevant info: `__webpack_nonce__` doesn't yet work with [Webpack's DLL plugin](https://github.com/webpack/webpack/issues/8775). 
