### PR TITLE
Add helpful message to the footer

### DIFF
--- a/packages/react-error-overlay/src/containers/RuntimeErrorContainer.js
+++ b/packages/react-error-overlay/src/containers/RuntimeErrorContainer.js
@@ -79,7 +79,7 @@ class RuntimeErrorContainer extends PureComponent<Props, State> {
         />
         <Footer
           line1="This screen is visible only in development. It will not appear if the app crashes in production."
-          line2="Open your browser’s developer console to further inspect this error."
+          line2="Open your browser’s developer console to further inspect this error.  Click the 'X' or hit ESC to dismiss this message."
         />
       </ErrorOverlay>
     );


### PR DESCRIPTION
Perhaps saving another person digging through Google to find [they've missed the little 'X'](https://stackoverflow.com/questions/46589819/disable-error-overlay-in-development-mode?rq=1) that's been there all along.