### PR TITLE
Port number in statement not correct

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -18,7 +18,7 @@ serve -s build
 The last command shown above will serve your static site on the port **5000**. Like many of [serve](https://github.com/zeit/serve)’s internal settings, the port can be adjusted using the `-l` or `--listen` flags:
 
 ```sh
-serve -s build -l 4000
+serve -s build -l 5000
 ```
 
 Run this command to get a full list of the options available:


### PR DESCRIPTION
The statement says: serve your static site on the port **5000**.  but the command was 
```sh
serve -s build -l 4000
```
which serves it on port 4000

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
