### PR TITLE
Add directory details to packages/* package.json

### DIFF
--- a/packages/babel-plugin-named-asset-import/package.json
+++ b/packages/babel-plugin-named-asset-import/package.json
@@ -2,7 +2,11 @@
   "name": "babel-plugin-named-asset-import",
   "version": "0.3.1",
   "description": "Babel plugin for named asset imports in Create React App",
-  "repository": "facebookincubator/create-react-app",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/create-react-app.git",
+    "directory": "packages/babel-plugin-named-asset-import"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/facebookincubator/create-react-app/issues"

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -2,7 +2,11 @@
   "name": "babel-preset-react-app",
   "version": "7.0.2",
   "description": "Babel preset used by Create React App",
-  "repository": "facebook/create-react-app",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/create-react-app.git",
+    "directory": "packages/babel-preset-react-app"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/facebook/create-react-app/issues"

--- a/packages/confusing-browser-globals/package.json
+++ b/packages/confusing-browser-globals/package.json
@@ -7,7 +7,11 @@
   "scripts": {
     "test": "jest"
   },
-  "repository": "facebook/create-react-app",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/create-react-app.git",
+    "directory": "packages/confusing-browser-globals"
+  },
   "keywords": [
     "eslint",
     "globals"

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -5,7 +5,11 @@
     "react"
   ],
   "description": "Create React apps with no build configuration.",
-  "repository": "facebook/create-react-app",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/create-react-app.git",
+    "directory": "packages/create-react-app"
+  },
   "license": "MIT",
   "engines": {
     "node": ">=4"

--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -2,7 +2,11 @@
   "name": "eslint-config-react-app",
   "version": "3.0.8",
   "description": "ESLint configuration used by Create React App",
-  "repository": "facebook/create-react-app",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/create-react-app.git",
+    "directory": "packages/eslint-config-react-app"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/facebook/create-react-app/issues"

--- a/packages/react-app-polyfill/package.json
+++ b/packages/react-app-polyfill/package.json
@@ -2,7 +2,11 @@
   "name": "react-app-polyfill",
   "version": "0.2.2",
   "description": "Polyfills for various browsers including commonly used language features",
-  "repository": "facebook/create-react-app",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/create-react-app.git",
+    "directory": "packages/react-app-polyfill"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/facebook/create-react-app/issues"

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -2,7 +2,11 @@
   "name": "react-dev-utils",
   "version": "8.0.0",
   "description": "Webpack utilities used by Create React App",
-  "repository": "facebook/create-react-app",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/create-react-app.git",
+    "directory": "packages/react-dev-utils"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/facebook/create-react-app/issues"

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -10,7 +10,11 @@
     "build": "cross-env NODE_ENV=development node build.js",
     "build:prod": "cross-env NODE_ENV=production node build.js"
   },
-  "repository": "facebook/create-react-app",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/create-react-app.git",
+    "directory": "packages/react-error-overlay"
+  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/facebook/create-react-app/issues"

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -2,7 +2,11 @@
   "name": "react-scripts",
   "version": "2.1.8",
   "description": "Configuration and scripts for Create React App.",
-  "repository": "facebook/create-react-app",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/facebook/create-react-app.git",
+    "directory": "packages/react-scripts"
+  },
   "license": "MIT",
   "engines": {
     "node": ">=8.10"


### PR DESCRIPTION
Specifying the directory as part of the repository field in a
package.json allows third party tools to provide better support when
working with monorepos. For example, it allows them to correctly
construct a commit diff for a specific package.

This format was accepted by npm in npm/rfcs#19.
