### PR TITLE
Updating jest to fix vulnerbility

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "get-port": "^4.0.0",
     "globby": "^8.0.1",
     "husky": "1.0.0-rc.15",
-    "jest": "^23.6.0",
+    "jest": "^24.3.1",
     "lerna": "2.9.1",
     "lerna-changelog": "^0.7.0",
     "lint-staged": "^8.0.4",


### PR DESCRIPTION
60 vulnerabilities are cause by an outdated [braces](https://www.npmjs.com/package/braces) version. This brings the version of jest the current version in which the braces version is updated to fix it.
