### PR TITLE
Update Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "get-port": "^4.0.0",
     "globby": "^8.0.1",
     "husky": "1.0.0-rc.15",
-    "jest": "^23.6.0",
+    "jest": "^24.3.1",
     "lerna": "2.9.1",
     "lerna-changelog": "^0.7.0",
     "lint-staged": "^8.0.4",
@@ -36,6 +36,7 @@
     "strip-ansi": "^4.0.0",
     "svg-term-cli": "^2.1.1",
     "tempy": "^0.2.1",
+    "terser-webpack-plugin": "^1.2.3",
     "wait-for-localhost": "2.0.1"
   },
   "husky": {


### PR DESCRIPTION
60 vulnerabilities are cause by an outdated [braces](https://www.npmjs.com/package/braces) version. This brings the version of jest the current version in which the braces version is updated to fix it.
