### PR TITLE
Allow .json type checking

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -623,7 +623,6 @@ module.exports = function(webpackEnv) {
           tsconfig: paths.appTsConfig,
           reportFiles: [
             '**',
-            '!**/*.json',
             '!**/__tests__/**',
             '!**/?(*.)(spec|test).*',
             '!**/src/setupProxy.*',


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Closes #5619.

This adds back support for type checking of `.json` files. We had to disable previously due to a [bug in TypeScript](https://github.com/Microsoft/TypeScript/issues/28202) which was fixed a while back.

Here is an example:
![image](https://user-images.githubusercontent.com/6355370/54092432-3efdba00-4349-11e9-9994-f10457532d05.png)
