### PR TITLE
Add the possibility to keep the js class names in the production build

### DIFF
--- a/docusaurus/docs/minify-keep-class-names.md
+++ b/docusaurus/docs/minify-keep-class-names.md
@@ -1,0 +1,23 @@
+---
+id: minify-keep-class-names
+title: Minify Keep Class names
+---
+
+The production build of Create React App uses the [terser-js](https://github.com/terser-js/terser) Webpack Plugin to minify the JS / TS sources. By default the class anmes are minified and replaced. If you want to keep the JavaScript Class Names you can set the env variable `KEEP_CLASS_NAMES` before you run the production build.
+
+Example with [cross-env](https://github.com/kentcdodds/cross-env#readme):
+
+```sh
+cross-env KEEP_CLASS_NAMES='true' && react-scripts build
+```
+
+In the `package.json` this would look like:
+
+```json
+{
+    ...
+    "scripts": {
+        "build": "cross-env KEEP_CLASS_NAMES='true' react-scripts build"
+    }
+}
+```

--- a/docusaurus/website/sidebars.json
+++ b/docusaurus/website/sidebars.json
@@ -34,7 +34,8 @@
       "adding-a-router",
       "adding-custom-environment-variables",
       "making-a-progressive-web-app",
-      "production-build"
+      "production-build",
+      "minify-keep-class-names"
     ],
     "Testing": ["running-tests", "debugging-tests"],
     "Back-End Integration": [

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -41,6 +41,9 @@ const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 // makes for a smoother build process.
 const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
 
+// For keeping classNames while minifying the sources for production build
+const terserKeepClassNames = process.env.KEEP_CLASS_NAMES === 'true';
+
 // Check if TypeScript is setup
 const useTypeScript = fs.existsSync(paths.appTsConfig);
 
@@ -185,6 +188,7 @@ module.exports = function(webpackEnv) {
         // This is only used in production mode
         new TerserPlugin({
           terserOptions: {
+            keep_fnames: terserKeepClassNames,
             parse: {
               // we want terser to parse ecma 8 code. However, we don't want it
               // to apply any minfication steps that turns valid ecma 5 code


### PR DESCRIPTION
I added an environment variable to prevent the terser plugin from minifying js class names in the production build.

The variable is: `KEEP_CLASS_NAMES` - i added an example in the documentation, beneath the production-build documentation.

There is no major change, the production build will be equal to the production build before this pull request, if there is no environment variable set.