### PR TITLE
Unpin eslint-config-react-hooks dependency

### DIFF
--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -19,7 +19,7 @@
     "eslint-plugin-import": "2.x",
     "eslint-plugin-jsx-a11y": "6.x",
     "eslint-plugin-react": "7.x",
-    "eslint-plugin-react-hooks": "1.5.0"
+    "eslint-plugin-react-hooks": "1.x"
   },
   "dependencies": {
     "confusing-browser-globals": "^1.0.6"

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-import": "2.16.0",
     "eslint-plugin-jsx-a11y": "6.2.1",
     "eslint-plugin-react": "7.12.4",
-    "eslint-plugin-react-hooks": "1.5.0",
+    "eslint-plugin-react-hooks": "^1.5.0",
     "file-loader": "3.0.1",
     "fs-extra": "7.0.1",
     "html-webpack-plugin": "4.0.0-beta.5",


### PR DESCRIPTION
Use version 1.x of the plugin.