### PR TITLE
Sync version of babel-eslint in eslint-config-react-app for react-scripts V3

### DIFF
--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -13,7 +13,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "1.x",
     "@typescript-eslint/parser": "1.x",
-    "babel-eslint": "9.x",
+    "babel-eslint": "10.x",
     "eslint": "5.x",
     "eslint-plugin-flowtype": "2.x",
     "eslint-plugin-import": "2.x",


### PR DESCRIPTION
Sync the `babel-eslint` version between react-scripts (version 3) and eslint-config-react-app 
```
warning "react-scripts > eslint-config-react-app@4.0.0-next.b0cbf2ca" 
has incorrect peer dependency "babel-eslint@9.x".
```


