### PR TITLE
Remove unnecessary shrink-to-fit=no meta data

### DIFF
--- a/packages/react-scripts/template-typescript/public/index.html
+++ b/packages/react-scripts/template-typescript/public/index.html
@@ -3,10 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/packages/react-scripts/template/public/index.html
+++ b/packages/react-scripts/template/public/index.html
@@ -3,10 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
I was trying to understand the needs for `shrink-to-fit=no` meta data when I saw it in `index.html` file, after some testing myself and googling I came to a conclusion that it's no longer needed.

Removed recently from twbs/bootstrap/pull/28314, h5bp/html5-boilerplate#2102 and https://github.com/joshbuchea/HEAD/commit/851bb661264edbc9a968e2d74c626198523b419a

More info in @scottaohara [blogpost](https://www.scottohara.me/blog/2018/12/11/shrink-to-fit.html)

