### PR TITLE
Remove unused eslint comment

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -15,7 +15,6 @@ function isLikelyASyntaxError(message) {
 }
 
 // Cleans up webpack error messages.
-// eslint-disable-next-line no-unused-vars
 function formatMessage(message) {
   let lines = message.split('\n');
 


### PR DESCRIPTION
We don't need eslint comment as we no longer have an unused variable in next line inside `packages/react-dev-utils/formatWebpackMessages.js` in `formatMessage` function as that unused variable was removed in #6502 