### PR TITLE
Remove duplicate url key in siteConfig

### DIFF
--- a/docusaurus/website/siteConfig.js
+++ b/docusaurus/website/siteConfig.js
@@ -11,7 +11,6 @@
 const siteConfig = {
   title: 'Create React App', // Title for your website.
   tagline: 'Set up a modern web app by running one command.',
-  url: 'https://facebook.github.io', // Your website URL
   // For github.io type URLs, you would set the url and baseUrl like:
   url: 'https://facebook.github.io',
   baseUrl: '/create-react-app/',


### PR DESCRIPTION
`url` was duplicated in `siteConfig.js`, both were the same value, so stripping one of them.