### PR TITLE
Fix for #6322

### DIFF
--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -42,6 +42,12 @@ If you set `SASS_PATH=node_modules:src`, this will allow you to do imports like
 @import 'nprogress/nprogress'; // importing a css file from the nprogress node module
 ```
 
+> **Note:** For windows operating system, use below syntax
+>
+> ```
+> SASS_PATH=./node_modules;./src
+> ```
+
 > **Tip:** You can opt into using this feature with [CSS modules](adding-a-css-modules-stylesheet.md) too!
 
 > **Note:** If you're using Flow, override the [module.file_ext](https://flow.org/en/docs/config/options/#toc-module-file-ext-string) setting in your `.flowconfig` so it'll recognize `.sass` or `.scss` files. You will also need to include the `module.file_ext` default settings for `.js`, `.jsx`, `.mjs` and `.json` files.


### PR DESCRIPTION
## Documentation changes
- Mentioned a note for windows operating system to use syntax like `SASS_PATH=./node_modules;./src`

## Issue Link
https://github.com/facebook/create-react-app/issues/6322

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
