### PR TITLE
Update to workbox-webpack-plugin v4

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -70,7 +70,7 @@
     "webpack": "4.29.6",
     "webpack-dev-server": "3.2.1",
     "webpack-manifest-plugin": "2.0.4",
-    "workbox-webpack-plugin": "3.6.3"
+    "workbox-webpack-plugin": "4.1.1"
   },
   "devDependencies": {
     "react": "^16.8.4",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -70,7 +70,7 @@
     "webpack": "4.29.6",
     "webpack-dev-server": "3.2.1",
     "webpack-manifest-plugin": "2.0.4",
-    "workbox-webpack-plugin": "4.1.1"
+    "workbox-webpack-plugin": "4.2.0"
   },
   "devDependencies": {
     "react": "^16.8.4",


### PR DESCRIPTION
**DESCRIPTION:**
- Resolves #6659: Updated the `workbox-webpack-plugin` from v3 to latest v4 and also tested some of the new configuration options such as `skipWaiting` and `cleanupOutdatedCaches` after ejecting the app.

- Resolves #6243: The new version automatically solves the issue where a registered service worker still tries to load an old resource, after workbox has cleaned up its old cache after an update.

**TESTS COMPLETED:**
- Change the app code to `serviceWorker.register()` and run `build`, then check if workbox caches the relevant files and if the service worker installs correctly and triggers the `onSuccess` callback.

- Add flag `skipWaiting: true` to the `webpack.config.js`, then update the app code and perhaps also the version number in `package.json`, then repeat the test above and check if the new service worker takes over the application and triggers the `onUpdate` callback. **Older outdated workbox caches should be deleted** at the point (from logs **visible on the dev console** in localhost)

- Add flag `cleanupOutdatedCaches: false`, repeat the test above and check if the new service worker takes over the application. Older outdated workbox cache should not deleted now (this option is **only available in versions 4.x.x** and above).
