### PR TITLE
save gh-pages as dev dependency

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -287,13 +287,13 @@ Now, whenever you run `npm run build`, you will see a cheat sheet with instructi
 To publish it at [https://myusername.github.io/my-app](https://myusername.github.io/my-app), run:
 
 ```sh
-npm install --save gh-pages
+npm install gh-pages --save-dev
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add gh-pages
+yarn add gh-pages --dev
 ```
 
 Add the following scripts in your `package.json`:


### PR DESCRIPTION
gh-pages is only used at build time so it should probably get marked as a dev dependency when saving to package.json