### PR TITLE
Update analyzing-the-bundle-size.md

### DIFF
--- a/docusaurus/docs/analyzing-the-bundle-size.md
+++ b/docusaurus/docs/analyzing-the-bundle-size.md
@@ -24,7 +24,7 @@ Then in `package.json`, add the following line to `scripts`:
 
 ```diff
    "scripts": {
-+    "analyze": "source-map-explorer 'build/static/js/*.js'",
++    "analyze": "source-map-explorer build/static/js/*.js",
      "start": "react-scripts start",
      "build": "react-scripts build",
      "test": "react-scripts test",


### PR DESCRIPTION
Using the latest `source-map-explorer`, running `npm run analyze` would throw an error (`No file(s) found`). This fixes it.

