### PR TITLE
InlineChunkHtmlPlugin works with empty publicPath

### DIFF
--- a/packages/react-dev-utils/InlineChunkHtmlPlugin.js
+++ b/packages/react-dev-utils/InlineChunkHtmlPlugin.js
@@ -17,7 +17,7 @@ class InlineChunkHtmlPlugin {
     if (tag.tagName !== 'script' || !(tag.attributes && tag.attributes.src)) {
       return tag;
     }
-    const scriptName = tag.attributes.src.replace(publicPath, '');
+    const scriptName = publicPath ? tag.attributes.src.replace(publicPath, '') : tag.attributes.src;
     if (!this.tests.some(test => scriptName.match(test))) {
       return tag;
     }
@@ -29,8 +29,8 @@ class InlineChunkHtmlPlugin {
   }
 
   apply(compiler) {
-    let publicPath = compiler.options.output.publicPath;
-    if (!publicPath.endsWith('/')) {
+    let publicPath = compiler.options.output.publicPath || '';
+    if (publicPath.length > 0 && !publicPath.endsWith('/')) {
       publicPath += '/';
     }
 

--- a/packages/react-dev-utils/InlineChunkHtmlPlugin.js
+++ b/packages/react-dev-utils/InlineChunkHtmlPlugin.js
@@ -30,7 +30,7 @@ class InlineChunkHtmlPlugin {
 
   apply(compiler) {
     let publicPath = compiler.options.output.publicPath || '';
-    if (publicPath.length > 0 && !publicPath.endsWith('/')) {
+    if (publicPath && !publicPath.endsWith('/')) {
       publicPath += '/';
     }
 


### PR DESCRIPTION
The `InlineChunkHtmlPlugin` plugin didn't work when the `publicPath` variable is empty or unset (e.g. when I want to use relative URLs).

Before:

- If `publicPath` was unset or wasn't a string, webpack would throw an error
- If `publicPath` was an empty string, the plugin would fail to inline a chunk

Now: the plugin behaves as expected even with empty or unset `publicPath`.