### PR TITLE
instructed saving typescript deps in dev

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -20,11 +20,11 @@ yarn create react-app my-app --typescript
 To add [TypeScript](https://www.typescriptlang.org/) to a Create React App project, first install it:
 
 ```sh
-npm install --save typescript @types/node @types/react @types/react-dom @types/jest
+npm install --save-dev typescript @types/node @types/react @types/react-dom @types/jest
 
 # or
 
-yarn add typescript @types/node @types/react @types/react-dom @types/jest
+yarn add --dev typescript @types/node @types/react @types/react-dom @types/jest
 ```
 
 Next, rename any file to be a TypeScript file (e.g. `src/index.js` to `src/index.tsx`) and **restart your development server**!


### PR DESCRIPTION
Type definitions should be in the dev Dependencies and not in the dependencies as a general good practice.
This PR includes small modifications to provided commands to instruct readers to do so.
Tested by running the commands locally
