### PR TITLE
Replace deprecated SFC with FunctionComponent in react-app.d.ts

### DIFF
--- a/packages/react-scripts/lib/react-app.d.ts
+++ b/packages/react-scripts/lib/react-app.d.ts
@@ -42,7 +42,7 @@ declare module '*.webp' {
 declare module '*.svg' {
   import * as React from 'react';
 
-  export const ReactComponent: React.SFC<React.SVGProps<SVGSVGElement>>;
+  export const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
 
   const src: string;
   export default src;


### PR DESCRIPTION
```js
/**
 * @deprecated as of recent React versions, function components can no
 * longer be considered 'stateless'.
```

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
