### PR TITLE
change NODE_ENV and PUBLIC_URL into readonly

### DIFF
--- a/packages/react-scripts/lib/react-app.d.ts
+++ b/packages/react-scripts/lib/react-app.d.ts
@@ -4,8 +4,8 @@
 
 declare namespace NodeJS {
   interface ProcessEnv {
-    NODE_ENV: 'development' | 'production' | 'test';
-    PUBLIC_URL: string;
+    readonly NODE_ENV: 'development' | 'production' | 'test';
+    readonly PUBLIC_URL: string;
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

after change it 

```ts
process.env.NODE_ENV = 'development'
```

will throw

```
Cannot assign to 'NODE_ENV' because it is a read-only property.ts(2540)
```