### PR TITLE
Add Service-Worker header to checkValidServiceWorker

### DIFF
--- a/packages/react-scripts/template-typescript/src/serviceWorker.ts
+++ b/packages/react-scripts/template-typescript/src/serviceWorker.ts
@@ -108,7 +108,9 @@ function registerValidSW(swUrl: string, config?: Config) {
 
 function checkValidServiceWorker(swUrl: string, config?: Config) {
   // Check if the service worker can be found. If it can't reload the page.
-  fetch(swUrl)
+  fetch(swUrl, {
+    headers: { 'Service-Worker': 'script' }
+  })
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
       const contentType = response.headers.get('content-type');

--- a/packages/react-scripts/template/src/serviceWorker.js
+++ b/packages/react-scripts/template/src/serviceWorker.js
@@ -100,7 +100,9 @@ function registerValidSW(swUrl, config) {
 
 function checkValidServiceWorker(swUrl, config) {
   // Check if the service worker can be found. If it can't reload the page.
-  fetch(swUrl)
+  fetch(swUrl, {
+    headers: { 'Service-Worker': 'script' }
+  })
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
       const contentType = response.headers.get('content-type');


### PR DESCRIPTION
This PR adds the http header `Service-Worker: script` to the `checkValidServiceWorker` request in both serviceWorker templates, to match the [spec](https://w3c.github.io/ServiceWorker/) on how to request a service worker.

---

See https://w3c.github.io/ServiceWorker/#update-algorithm:

> To perform the fetch given request, run the following steps:
> 1. Append `Service-Worker`/`script` to request’s header list.

And https://w3c.github.io/ServiceWorker/#service-worker-script-request:

> An HTTP request to fetch a service worker's script resource will include the following header:
> - `Service-Worker`
>   Indicates this request is a service worker's script resource request.

