### PR TITLE
Add temporary workaround for Babel dependency issues in installs test suite

### DIFF
--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -184,6 +184,10 @@ CI=true yarn test
 # Eject...
 echo yes | npm run eject
 
+# Temporary workaround for https://github.com/facebook/create-react-app/issues/6099
+rm yarn.lock
+yarn add @babel/plugin-transform-react-jsx-source @babel/plugin-syntax-jsx @babel/plugin-transform-react-jsx @babel/plugin-transform-react-jsx-self
+
 # Ensure env file still exists
 exists src/react-app-env.d.ts
 


### PR DESCRIPTION
This is a temporary fix to get our test suites passing so we can finish work on the 3.0 release. We still need to find and fix the root cause of this issue: #6679. This workaround should be removed once that's fixed.