### PR TITLE
Add temporary workaround for Babel dependency issues in kitchensink-eject test suite

### DIFF
--- a/tasks/e2e-kitchensink-eject.sh
+++ b/tasks/e2e-kitchensink-eject.sh
@@ -128,6 +128,10 @@ npm link "$temp_module_path/node_modules/test-integrity"
 # Eject...
 echo yes | npm run eject
 
+# Temporary workaround for https://github.com/facebook/create-react-app/issues/6099
+rm yarn.lock
+yarn add @babel/plugin-transform-react-jsx-source @babel/plugin-syntax-jsx @babel/plugin-transform-react-jsx @babel/plugin-transform-react-jsx-self
+
 # Link to test module
 npm link "$temp_module_path/node_modules/test-integrity"
 


### PR DESCRIPTION
This is (another) temporary fix to get our test suites passing so we can finish work on the 3.0 release. We still need to find and fix the root cause of this issue: #6679. This workaround should be removed once that's fixed.