### PR TITLE
Add netbeans to the list

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -131,6 +131,7 @@ function getArgumentsForLineNumber(
       return [fileName + ':' + lineNumber + ':' + colNumber];
     case 'wstorm':
     case 'charm':
+    case 'netbeans':
       return [fileName + ':' + lineNumber];
     case 'notepad++':
       return ['-n' + lineNumber, '-c' + colNumber, fileName];


### PR DESCRIPTION
According to the documentation, you can specify a line number using file:number syntax: http://wiki.netbeans.org/FaqCliOpen

> `netbeans Something.java:55`

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

According to the instructions at https://facebook.github.io/create-react-app/docs/advanced-configuration I need to list my editor at this list detect it, no further testing instructions have been provided

EDIT: At the moment, the Netbeans editor works when placing a shortcut inside `/usr/local/bin` to Netbeans, and then starting the devserver using `REACT_EDITOR=netbeans npm run serve`, but I cant find any documentation on how to make a test version of this package so I can actually test the integration