### PR TITLE
Update to core-js@3

### DIFF
--- a/docusaurus/docs/supported-browsers-features.md
+++ b/docusaurus/docs/supported-browsers-features.md
@@ -6,7 +6,7 @@ sidebar_label: Supported Browsers and Features
 
 ## Supported Browsers
 
-By default, the generated project supports all modern browsers. Support for Internet Explorer 9, 10, and 11 requires polyfills. For a minimum set of polyfills to support older browsers, use [react-app-polyfill](https://github.com/facebook/create-react-app/blob/master/packages/react-app-polyfill/README.md). To polyfill other language features, see the [Adding Polyfills](#adding-polyfills) section below
+By default, the generated project supports all modern browsers. Support for Internet Explorer 9, 10, and 11 requires polyfills. For a set of polyfills to support older browsers, use [react-app-polyfill](https://github.com/facebook/create-react-app/blob/master/packages/react-app-polyfill/README.md).
 
 ## Supported Language Features
 
@@ -26,10 +26,6 @@ While we recommend using experimental proposals with some caution, Facebook heav
 Note that **this project includes no [polyfills](https://github.com/facebook/create-react-app/blob/master/packages/react-app-polyfill/README.md)** by default.
 
 If you use any other ES6+ features that need **runtime support** (such as `Array.from()` or `Symbol`), make sure you are [including the appropriate polyfills manually](https://github.com/facebook/create-react-app/blob/master/packages/react-app-polyfill/README.md), or that the browsers you are targeting already support them.
-
-## Adding Polyfills
-
-You can install [`@babel/polyfill`](https://babeljs.io/docs/en/babel-polyfill) as a dependency in your application, and import it at the very top of your app's entry point (`src/index.js` or `src/index.tsx`) to emulate a full ES2015+ environment. Your `browerslist` configuration will be used to only include the polyfills necessary by your target browsers.
 
 ## Configuring Supported Browsers
 

--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -83,7 +83,7 @@ module.exports = function(api, opts, env) {
           useBuiltIns: 'entry',
           // Set the corejs version we are using to avoid warnings in console
           // This will need to change once we upgrade to corejs@3
-          corejs: 2,
+          corejs: 3,
           // Do not transform modules to CJS
           modules: false,
           // Exclude transforms that make all code slower

--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -79,7 +79,7 @@ module.exports = function(api, opts, env) {
         // Latest stable ECMAScript features
         require('@babel/preset-env').default,
         {
-          // Allow importing @babel/polyfill in entrypoint and use browserlist to select polyfills
+          // Allow importing core-js in entrypoint and use browserlist to select polyfills
           useBuiltIns: 'entry',
           // Set the corejs version we are using to avoid warnings in console
           // This will need to change once we upgrade to corejs@3

--- a/packages/react-app-polyfill/README.md
+++ b/packages/react-app-polyfill/README.md
@@ -21,7 +21,7 @@ yarn add react-app-polyfill
 
 You can import the entry point for the minimal version you intend to support to ensure that the minimum langauge features are present that are required to use Create React App. For example, if you import the IE9 entry point, this will include IE10 and IE11 support.
 
-These modules ensures the following language features are present:
+These modules ensure the following language features are present:
 
 1. `Promise` (for `async` / `await` support)
 1. `window.fetch` (a Promise-based way to make web requests in the browser)

--- a/packages/react-app-polyfill/README.md
+++ b/packages/react-app-polyfill/README.md
@@ -60,7 +60,7 @@ import 'react-app-polyfill/stable';
 // ...
 ```
 
-If you are supporting Internet Explorer 9/11 you should include both the `ie9`/`ie11` and `stable` modules:
+If you are supporting Internet Explorer 9 or Internet Explorer 11 you should include both the `ie9` or `ie11` and `stable` modules:
 
 For IE9:
 

--- a/packages/react-app-polyfill/README.md
+++ b/packages/react-app-polyfill/README.md
@@ -3,18 +3,6 @@
 This package includes polyfills for various browsers.
 It includes minimum requirements and commonly used language features used by [Create React App](https://github.com/facebook/create-react-app) projects.
 
-### Features
-
-Each polyfill ensures the following language features are present:
-
-1. `Promise` (for `async` / `await` support)
-1. `window.fetch` (a Promise-based way to make web requests in the browser)
-1. `Object.assign` (a helper required for Object Spread, i.e. `{ ...a, ...b }`)
-1. `Symbol` (a built-in object used by `for...of` syntax and friends)
-1. `Array.from` (a built-in static method used by array spread, i.e. `[...arr]`)
-
-_If you need more features, you must include them manually._
-
 ### Usage
 
 First, install the package using Yarn or npm:
@@ -29,7 +17,19 @@ or
 yarn add react-app-polyfill
 ```
 
-Now, you can import the entry point for the minimal version you intend to support. For example, if you import the IE9 entry point, this will include IE10 and IE11 support.
+## Supporting Internet Explorer
+
+You can import the entry point for the minimal version you intend to support to ensure that the minimum langauge features are present that are required to use Create React App. For example, if you import the IE9 entry point, this will include IE10 and IE11 support.
+
+These modules ensures the following language features are present:
+
+1. `Promise` (for `async` / `await` support)
+1. `window.fetch` (a Promise-based way to make web requests in the browser)
+1. `Object.assign` (a helper required for Object Spread, i.e. `{ ...a, ...b }`)
+1. `Symbol` (a built-in object used by `for...of` syntax and friends)
+1. `Array.from` (a built-in static method used by array spread, i.e. `[...arr]`)
+
+_If you need more features, see the [Polyfilling other language features](#polyfilling-other-language-features) section below._
 
 #### Internet Explorer 9
 
@@ -45,6 +45,39 @@ import 'react-app-polyfill/ie9';
 ```js
 // This must be the first line in src/index.js
 import 'react-app-polyfill/ie11';
+
+// ...
+```
+
+## Polyfilling other language features
+
+You can also polyfill stable language features not available in your target browsers. If you're using this in Create React App, it will automatically use the `browserslist` you've defined to only include polyfills needed by your target browsers when importing the `stable` polyfill. **Make sure to follow the Internet Explorer steps above if you need to support Internet Explorer in your application**.
+
+```js
+// This must be the first line in src/index.js
+import 'react-app-polyfill/stable';
+
+// ...
+```
+
+If you are supporting Internet Explorer 9/11 you should include both the `ie9`/`ie11` and `stable` modules:
+
+For IE9:
+
+```js
+// These must be the first lines in src/index.js
+import 'react-app-polyfill/ie9';
+import 'react-app-polyfill/stable';
+
+// ...
+```
+
+For IE11:
+
+```js
+// These must be the first lines in src/index.js
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
 
 // ...
 ```

--- a/packages/react-app-polyfill/ie11.js
+++ b/packages/react-app-polyfill/ie11.js
@@ -26,6 +26,6 @@ if (typeof window !== 'undefined') {
 Object.assign = require('object-assign');
 
 // Support for...of (a commonly used syntax feature that requires Symbols)
-require('core-js/es6/symbol');
+require('core-js/features/symbol');
 // Support iterable spread (...Set, ...Map)
-require('core-js/fn/array/from');
+require('core-js/features/array/from');

--- a/packages/react-app-polyfill/ie9.js
+++ b/packages/react-app-polyfill/ie9.js
@@ -6,31 +6,9 @@
  */
 'use strict';
 
-if (typeof Promise === 'undefined') {
-  // Rejection tracking prevents a common issue where React gets into an
-  // inconsistent state due to an error, but it gets swallowed by a Promise,
-  // and the user has no idea what causes React's erratic future behavior.
-  require('promise/lib/rejection-tracking').enable();
-  window.Promise = require('promise/lib/es6-extensions.js');
-}
-
-// Make sure we're in a Browser-like environment before importing polyfills
-// This prevents `fetch()` from being imported in a Node test environment
-if (typeof window !== 'undefined') {
-  // fetch() polyfill for making API calls.
-  require('whatwg-fetch');
-}
-
-// Object.assign() is commonly used with React.
-// It will use the native implementation if it's present and isn't buggy.
-Object.assign = require('object-assign');
-
-// Support for...of (a commonly used syntax feature that requires Symbols)
-require('core-js/es6/symbol');
-// Support iterable spread (...Set, ...Map)
-require('core-js/fn/array/from');
+require('./ie11');
 
 // React 16+ relies on Map, Set, and requestAnimationFrame
-require('core-js/es6/map');
-require('core-js/es6/set');
+require('core-js/features/map');
+require('core-js/features/set');
 require('raf').polyfill(window);

--- a/packages/react-app-polyfill/package.json
+++ b/packages/react-app-polyfill/package.json
@@ -13,13 +13,15 @@
   "files": [
     "ie9.js",
     "ie11.js",
-    "jsdom.js"
+    "jsdom.js",
+    "stable.js"
   ],
   "dependencies": {
-    "core-js": "2.6.5",
+    "core-js": "3.0.1",
     "object-assign": "4.1.1",
     "promise": "8.0.2",
     "raf": "3.4.1",
+    "regenerator-runtime": "0.13.2",
     "whatwg-fetch": "3.0.0"
   }
 }

--- a/packages/react-app-polyfill/stable.js
+++ b/packages/react-app-polyfill/stable.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+// Polyfill stable language features.
+// It's recommended to use @babel/preset-env and browserslist
+// to only include the polyfills necessary for the target browsers.
+require('core-js/stable');
+require('regenerator-runtime/runtime');


### PR DESCRIPTION
This is a breaking change to our 3.0 alpha that deprecates the `@babel/polyfill` feature in favor of the [recommended approach from the babel team](https://babeljs.io/blog/2019/03/19/7.4.0#core-js-3-7646-https-githubcom-babel-babel-pull-7646) as part of the babel 7.4.0 release. This adds a new `react-app-polyfill/stable` module that can be imported from `src/index.js` which will include polyfills for stable language features, and integrates nicely with `@babel/preset-env` which uses `browserslist` to only include polyfills for the target browsers.

Some more relevant info on this change: https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#babel

**Outstanding questions:**
- In the [corejs@2 migration guide](https://babeljs.io/blog/2019/03/19/7.4.0#migration-from-core-js-2) it says
  - > If you are using @babel/plugin-transform-runtime, you need to use the corejs: 3 option
  - We currently have `corejs: false` so my sense is we can ignore this, but it would be helpful if someone with more knowledge of this plugin could chime in
