### PR TITLE
Warn when using react-scripts-ts

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -228,7 +228,7 @@ function createApp(
         `You are using Node ${
           process.version
         } so the project will be bootstrapped with an old unsupported version of tools.\n\n` +
-          `Please update to Node 10 or higher for a better, fully supported experience.\n`
+          `Please update to Node 8.10 or higher for a better, fully supported experience.\n`
       )
     );
     // Fall back to latest supported react-scripts on Node 4

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -517,23 +517,32 @@ function getInstallPackage(version, originalDirectory) {
     }
   }
 
-  if (packageToInstall.startsWith('react-scripts-ts')) {
-    return inquirer
-      .prompt({
-        type: 'confirm',
-        name: 'useScriptsTs',
-        message: chalk.yellow(
-          'The react-scripts-ts package is deprecated. TypeScript is now supported natively in Create React App. You can use the --typescript option instead when generating your app to include TypeScript support. Would you like to continue using react-scripts-ts?'
-        ),
-        default: false,
-      })
-      .then(answer => {
-        if (!answer.useScriptsTs) {
-          process.exit(0);
-        }
+  const scriptsToWarn = [
+    {
+      name: 'react-scripts-ts',
+      message: chalk.yellow(
+        'The react-scripts-ts package is deprecated. TypeScript is now supported natively in Create React App. You can use the --typescript option instead when generating your app to include TypeScript support. Would you like to continue using react-scripts-ts?'
+      ),
+    },
+  ];
 
-        return packageToInstall;
-      });
+  for (const script of scriptsToWarn) {
+    if (packageToInstall.startsWith(script.name)) {
+      return inquirer
+        .prompt({
+          type: 'confirm',
+          name: 'useScript',
+          message: script.message,
+          default: false,
+        })
+        .then(answer => {
+          if (!answer.useScript) {
+            process.exit(0);
+          }
+
+          return packageToInstall;
+        });
+    }
   }
 
   return Promise.resolve(packageToInstall);

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -222,13 +222,13 @@ function createApp(
     process.exit(1);
   }
 
-  if (!semver.satisfies(process.version, '>=6.0.0')) {
+  if (!semver.satisfies(process.version, '>=8.10.0')) {
     console.log(
       chalk.yellow(
         `You are using Node ${
           process.version
         } so the project will be bootstrapped with an old unsupported version of tools.\n\n` +
-          `Please update to Node 6 or higher for a better, fully supported experience.\n`
+          `Please update to Node 10 or higher for a better, fully supported experience.\n`
       )
     );
     // Fall back to latest supported react-scripts on Node 4
@@ -244,7 +244,7 @@ function createApp(
             `You are using npm ${
               npmInfo.npmVersion
             } so the project will be bootstrapped with an old unsupported version of tools.\n\n` +
-              `Please update to npm 3 or higher for a better, fully supported experience.\n`
+              `Please update to npm 5 or higher for a better, fully supported experience.\n`
           )
         );
       }
@@ -447,7 +447,7 @@ function run(
           console.log(
             chalk.yellow(
               `\nNote: the project was bootstrapped with an old unsupported version of tools.\n` +
-                `Please update to Node >=6 and npm >=3 to get supported tools in new projects.\n`
+                `Please update to Node >=8.10 and npm >=5 to get supported tools in new projects.\n`
             )
           );
         }
@@ -648,7 +648,7 @@ function checkNpmVersion() {
     npmVersion = execSync('npm --version')
       .toString()
       .trim();
-    hasMinNpm = semver.gte(npmVersion, '3.0.0');
+    hasMinNpm = semver.gte(npmVersion, '5.0.0');
   } catch (err) {
     // ignore
   }

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -28,6 +28,7 @@
     "envinfo": "7.1.0",
     "fs-extra": "7.0.1",
     "hyperquest": "2.1.3",
+    "inquirer": "6.2.2",
     "semver": "5.6.0",
     "tar-pack": "3.4.1",
     "tmp": "0.0.33",


### PR DESCRIPTION
Closes #6598.

We now warn when using the `--scripts-version=react-scripts-ts` option in the CLI.