### PR TITLE
Remove unused babel-loader from babel-preset-react-app

### DIFF
--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -32,7 +32,6 @@
     "@babel/preset-react": "7.0.0",
     "@babel/preset-typescript": "7.3.3",
     "@babel/runtime": "7.4.3",
-    "babel-loader": "8.0.5",
     "babel-plugin-dynamic-import-node": "2.2.0",
     "babel-plugin-macros": "2.5.1",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24"


### PR DESCRIPTION
As far as I can tell there's no reason for the webpack `babel-loader` to be a dependency of `babel-preset-react-app`. If you happen to use `babel-preset-react-app` without Webpack you get a warning like

```
warning "babel-preset-react-app > babel-loader@8.0.5" has unmet peer dependency "webpack@>=2".
```

There was another PR #6124 but it wasn't merged for some reason.