### PR TITLE
Add SVG support dependency note

### DIFF
--- a/docusaurus/docs/adding-images-fonts-and-files.md
+++ b/docusaurus/docs/adding-images-fonts-and-files.md
@@ -44,7 +44,7 @@ An alternative way of handling static assets is described in the next section.
 
 ## Adding SVGs
 
-> Note: this feature is available with `react-scripts@2.0.0` and higher.
+> Note: this feature is available with `react-scripts@2.0.0` and higher, and `react@16.0.0` and higher.
 
 One way to add SVG files was described in the section above. You can also import SVGs directly as React components. You can use either of the two approaches. In your code it would look like this:
 


### PR DESCRIPTION
Hello!

It seems like importing SVGs as components does not work with `react` versions before 16, even with up-to-date `react-scripts`. Thought this documentation should be updated to include that note.

Thanks!

**react@^15.6.2** and **react-scripts@2.1.8**
<img width="1508" alt="Screen Shot 2019-04-09 at 4 17 44 PM" src="https://user-images.githubusercontent.com/7256628/55836076-1c46f880-5ae3-11e9-8a20-a9769047248f.png">

```js
import Logo from './logo.svg'
console.log(Logo) // output: /static/media/logo.5d5d9eef.svg
```