### PR TITLE
Fix mini-css-extract-plugin warnings

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -81,7 +81,7 @@ module.exports = function(webpackEnv) {
   const getStyleLoaders = (cssOptions, preProcessor) => {
     const loaders = [
       isEnvDevelopment && require.resolve('style-loader'),
-      isEnvProduction && {
+      isEnvProduction && !cssOptions.modules && {
         loader: MiniCssExtractPlugin.loader,
         options: Object.assign(
           {},


### PR DESCRIPTION
Hello!

I'm proposing this change to fix `Conflicting order between` errors coming from `mini-css-extract-plugin`. It seems like these warnings are pointless when using CSS modules

https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250#issuecomment-447346852