### PR TITLE
Prevent the use of react-native internals with react-native-web

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -284,7 +284,7 @@ module.exports = function(webpackEnv) {
       alias: {
         // Support React Native Web
         // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
-        'react-native': 'react-native-web',
+        'react-native$': 'react-native-web',
       },
       plugins: [
         // Adds support for installing with Plug'n'Play, leading to faster installs and adding


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

It's currently difficult to create more advanced aliases on top of `react-native-web`. We do the same in the `expo-cli` [here](https://github.com/expo/expo-cli/blob/370248895c35ae2ec27da7bfd1b2b0c377f9bd0c/packages/webpack-config/webpack/webpack.common.js#L185-L194). It'd be nice to emulate this without directly switching off of `react-scripts`. Here is an example that would work given this PR is merged: [Code sandbox](https://codesandbox.io/s/1qy180n2x3). You could then use Unimodules in code sandbox, or with `react-scripts` with minimal friction.

It's also bad practice to use `react-native` internals. The majority (if not all) of them don't work because the internal structure of `react-native-web` is optimized for `babel-plugin-react-native-web`.

CC: @necolas
