### PR TITLE
Add custom function to generate asset manifest

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -598,6 +598,16 @@ module.exports = function(webpackEnv) {
       new ManifestPlugin({
         fileName: 'asset-manifest.json',
         publicPath: publicPath,
+        generate: (seed, files) => {
+          const manifestFiles = files.reduce(function(manifest, file) {
+            manifest[file.name] = file.path;
+            return manifest;
+          }, seed);
+
+          return {
+            files: manifestFiles,
+          };
+        },
       }),
       // Moment.js is an extremely popular library that bundles large locale files
       // by default due to how Webpack interprets its code. This is a practical


### PR DESCRIPTION
Initial work on improving asset manifest. This moves the current output of all files under a `files` key. This is a breaking change so we want to do this as part of 3.0. This will allow us to add additional information to the manifest under other top-level keys in the future. See #5513.
