### PR TITLE
Remove no-watch flag in favor of watchAll=false

### DIFF
--- a/docusaurus/docs/debugging-tests.md
+++ b/docusaurus/docs/debugging-tests.md
@@ -55,7 +55,7 @@ Use the following [`launch.json`](https://code.visualstudio.com/docs/editor/debu
         "test",
         "--runInBand",
         "--no-cache",
-        "--no-watch"
+        "--watchAll=false"
       ],
       "cwd": "${workspaceRoot}",
       "protocol": "inspector",

--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -35,7 +35,7 @@ The watcher includes an interactive command-line interface with the ability to r
 
 ![Jest watch mode](https://jestjs.io/img/blog/15-watch.gif)
 
-> \*Although we recommend running your tests in watch mode during development, you can disable this behavior by passing in the `--no-watch` flag. In most CI environments, this is handled for you (see [On CI servers](#on-ci-servers)).
+> \*Although we recommend running your tests in watch mode during development, you can disable this behavior by passing in the `--watchAll=false` flag. In most CI environments, this is handled for you (see [On CI servers](#on-ci-servers)).
 
 ## Version Control Integration
 
@@ -376,7 +376,7 @@ CI=true npm run build
 
 The test command will force Jest to run in CI-mode, and tests will only run once instead of launching the watcher.
 
-For non-CI environments, you can simply pass the `--no-watch` flag to disable test-watching.
+For non-CI environments, you can simply pass the `--watchAll=false` flag to disable test-watching.
 
 The build command will check for linter warnings and fail if any are found.
 

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -54,21 +54,14 @@ function isInMercurialRepository() {
   }
 }
 
-// Watch unless on CI, explicitly adding `--no-watch`,
-// or explicitly running all tests
+// Watch unless on CI or explicitly running all tests
 if (
   !process.env.CI &&
-  argv.indexOf('--no-watch') === -1 &&
   argv.indexOf('--watchAll') === -1
 ) {
   // https://github.com/facebook/create-react-app/issues/5210
   const hasSourceControl = isInGitRepository() || isInMercurialRepository();
   argv.push(hasSourceControl ? '--watch' : '--watchAll');
-}
-
-// Jest doesn't have this option so we'll remove it
-if (argv.indexOf('--no-watch') !== -1) {
-  argv = argv.filter(arg => arg !== '--no-watch');
 }
 
 // @remove-on-eject-begin


### PR DESCRIPTION
`yarn test --watchAll=false` or `npm test -- --watchAll=false` is already sufficient for running tests in non-watch mode.   Both does the same thing as the current --no-watch flag.