### PR TITLE
Remove `Object.assign` from `MiniCssExtractPlugin` options

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -84,10 +84,7 @@ module.exports = function(webpackEnv) {
       isEnvDevelopment && require.resolve('style-loader'),
       isEnvProduction && {
         loader: MiniCssExtractPlugin.loader,
-        options: Object.assign(
-          {},
-          shouldUseRelativeAssetPaths ? { publicPath: '../../' } : undefined
-        ),
+        options: shouldUseRelativeAssetPaths ? { publicPath: '../../' } : {},
       },
       {
         loader: require.resolve('css-loader'),
@@ -269,7 +266,9 @@ module.exports = function(webpackEnv) {
       // We placed these paths second because we want `node_modules` to "win"
       // if there are any conflicts. This matches Node resolution mechanism.
       // https://github.com/facebook/create-react-app/issues/253
-      modules: ['node_modules', paths.appNodeModules].concat(modules.additionalModulePaths || []),
+      modules: ['node_modules', paths.appNodeModules].concat(
+        modules.additionalModulePaths || []
+      ),
       // These are the reasonable defaults supported by the Node ecosystem.
       // We also include JSX as a common component filename extension to support
       // some tools, although we do not recommend using it, see:


### PR DESCRIPTION
:wave: Hello! I'm reading through react-scripts' Webpack configuration to learn a little bit more about Webpack. Thanks for the ample comments! It's super helpful.

I noticed this unneeded `Object.assign` in a `.css` loader's options, so thought I'd remove it.

* **Problem:** Using `Object.assign` in `shouldUseRelativeAssetPaths` falsey case adds a _lil bit_ of an unneeded function call
* **Solution:** Remove `Object.assign` and add `{}` to the ternary false expression
* **Testing:** _?_