### PR TITLE
Fix @typescript-eslint typescript peer dependency warning

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -61,7 +61,7 @@
     "jest-watch-typeahead": "0.3.0",
     "mini-css-extract-plugin": "0.5.0",
     "optimize-css-assets-webpack-plugin": "5.0.1",
-    "pnp-webpack-plugin": "1.2.1",
+    "pnp-webpack-plugin": "1.5.0",
     "postcss-flexbugs-fixes": "4.1.0",
     "postcss-loader": "3.0.0",
     "postcss-normalize": "7.0.1",


### PR DESCRIPTION
Fixes #6834.

Bump `@typescript-eslint` packages to a newer version that have removed the `typescript` peer dependency.