### PR TITLE
Update analyzing the bundle size documentation

### DIFF
--- a/docusaurus/docs/analyzing-the-bundle-size.md
+++ b/docusaurus/docs/analyzing-the-bundle-size.md
@@ -24,7 +24,7 @@ Then in `package.json`, add the following line to `scripts`:
 
 ```diff
    "scripts": {
-+    "analyze": "source-map-explorer 'build/static/js/*.js'",
++    "analyze": "source-map-explorer build/static/js/*.js",
      "start": "react-scripts start",
      "build": "react-scripts build",
      "test": "react-scripts test",


### PR DESCRIPTION
Found documentation to be incorrect for guiding developers on how to analyze the source map. It states that the path must be wrapped in a quotes which causes no files to be created
Bug #6715

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
