### PR TITLE
Change cssmodule classname hash to use repo relative paths instead of…

### DIFF
--- a/packages/react-dev-utils/getCSSModuleLocalIdent.js
+++ b/packages/react-dev-utils/getCSSModuleLocalIdent.js
@@ -8,6 +8,7 @@
 'use strict';
 
 const loaderUtils = require('loader-utils');
+const path = require('path');
 
 module.exports = function getLocalIdent(
   context,
@@ -23,7 +24,7 @@ module.exports = function getLocalIdent(
     : '[name]';
   // Create a hash based on a the file location and class name. Will be unique across a project, and close to globally unique.
   const hash = loaderUtils.getHashDigest(
-    context.resourcePath.replace(context.rootContext, '') + localName,
+    path.posix.relative(context.rootContext, context.resourcePath) + localName,
     'md5',
     'base64',
     5

--- a/packages/react-dev-utils/getCSSModuleLocalIdent.js
+++ b/packages/react-dev-utils/getCSSModuleLocalIdent.js
@@ -23,7 +23,7 @@ module.exports = function getLocalIdent(
     : '[name]';
   // Create a hash based on a the file location and class name. Will be unique across a project, and close to globally unique.
   const hash = loaderUtils.getHashDigest(
-    context.resourcePath + localName,
+    context.resourcePath.replace(context.rootContext, '') + localName,
     'md5',
     'base64',
     5


### PR DESCRIPTION
Fixes #6875.

I tested this using two clones of a project using CRA and css modules.  The clones have different paths.  Before this PR, the classname hashes would be different, after the change the classnames are the same.  

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
