### PR TITLE
Updated the example for mocking the localstorage

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -238,13 +238,10 @@ For example:
 ### `src/setupTests.js`
 
 ```js
-const localStorageMock = {
-  getItem: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-  clear: jest.fn(),
-};
-global.localStorage = localStorageMock;
+Storage.prototype.getItem = jest.fn()
+Storage.prototype.setItem = jest.fn()
+Storage.prototype.removeItem = jest.fn()
+Storage.prototype.clear = jest.fn()
 ```
 
 > Note: Keep in mind that if you decide to "eject" before creating `src/setupTests.js`, the resulting `package.json` file won't contain any reference to it, so you should manually create the property `setupTestFrameworkScriptFile` in the configuration for Jest, something like the following:


### PR DESCRIPTION
The mocking example for the `localStorage` which was provided earlier was breaking after the recent `jest` update (using `CRA - v3.0`). I've updated the example to mock through the `Storage` api.

Sample code sandbox: https://codesandbox.io/s/43pn52xmz0?fontsize=14&previewwindow=tests

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
