### PR TITLE
Ensure Service Worker is registered even if register is called after load event

### DIFF
--- a/packages/react-scripts/template-typescript/src/serviceWorker.ts
+++ b/packages/react-scripts/template-typescript/src/serviceWorker.ts
@@ -39,26 +39,32 @@ export function register(config?: Config) {
       return;
     }
 
-    window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+    if (document.readyState === 'complete') {
+      doRegister(config);
+    } else {
+      window.addEventListener('load', () => doRegister(config));
+    }
+  }
+}
 
-      if (isLocalhost) {
-        // This is running on localhost. Let's check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl, config);
+function doRegister(config?: Config) {
+  const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
 
-        // Add some additional logging to localhost, pointing developers to the
-        // service worker/PWA documentation.
-        navigator.serviceWorker.ready.then(() => {
-          console.log(
-            'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit https://bit.ly/CRA-PWA'
-          );
-        });
-      } else {
-        // Is not localhost. Just register service worker
-        registerValidSW(swUrl, config);
-      }
+  if (isLocalhost) {
+    // This is running on localhost. Let's check if a service worker still exists or not.
+    checkValidServiceWorker(swUrl, config);
+
+    // Add some additional logging to localhost, pointing developers to the
+    // service worker/PWA documentation.
+    navigator.serviceWorker.ready.then(() => {
+      console.log(
+        'This web app is being served cache-first by a service ' +
+          'worker. To learn more, visit https://bit.ly/CRA-PWA'
+      );
     });
+  } else {
+    // Is not localhost. Just register service worker
+    registerValidSW(swUrl, config);
   }
 }
 

--- a/packages/react-scripts/template/src/serviceWorker.js
+++ b/packages/react-scripts/template/src/serviceWorker.js
@@ -31,26 +31,32 @@ export function register(config) {
       return;
     }
 
-    window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+    if (document.readyState === 'complete') {
+      doRegister(config);
+    } else {
+      window.addEventListener('load', () => doRegister(config));
+    }
+  }
+}
 
-      if (isLocalhost) {
-        // This is running on localhost. Let's check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl, config);
+function doRegister(config) {
+  const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
 
-        // Add some additional logging to localhost, pointing developers to the
-        // service worker/PWA documentation.
-        navigator.serviceWorker.ready.then(() => {
-          console.log(
-            'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit https://bit.ly/CRA-PWA'
-          );
-        });
-      } else {
-        // Is not localhost. Just register service worker
-        registerValidSW(swUrl, config);
-      }
+  if (isLocalhost) {
+    // This is running on localhost. Let's check if a service worker still exists or not.
+    checkValidServiceWorker(swUrl, config);
+
+    // Add some additional logging to localhost, pointing developers to the
+    // service worker/PWA documentation.
+    navigator.serviceWorker.ready.then(() => {
+      console.log(
+        'This web app is being served cache-first by a service ' +
+          'worker. To learn more, visit https://bit.ly/CRA-PWA'
+      );
     });
+  } else {
+    // Is not localhost. Just register service worker
+    registerValidSW(swUrl, config);
   }
 }
 


### PR DESCRIPTION
There should be no restriction to call serviceWorker.register only before window.load event. When it's called later on, the actual SW registration code isn't triggered.

