### PR TITLE
add --use-npm to `npx create-react-app my-app`

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -10,7 +10,7 @@ title: Adding TypeScript
 To start a new Create React App project with [TypeScript](https://www.typescriptlang.org/), you can run:
 
 ```sh
-npx create-react-app my-app --typescript
+npx create-react-app my-app --typescript --use-npm
 
 # or
 


### PR DESCRIPTION
this bit me. After using `npx` i expect an npm environment, but got yarn by default.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
