### PR TITLE
Disable default-case lint rule for TypeScript

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -69,6 +69,10 @@ module.exports = {
     // If adding a typescript-eslint version of an existing ESLint rule,
     // make sure to disable the ESLint rule here.
     rules: {
+      // TypeScript's `noFallthroughCasesInSwitch` option is more robust (#6906)
+      'default-case': 'off',
+
+      // Add TypeScript specific rules (and turn off ESLint equivalents)
       '@typescript-eslint/no-angle-bracket-type-assertion': 'warn',
       'no-array-constructor': 'off',
       '@typescript-eslint/no-array-constructor': 'warn',

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -106,6 +106,8 @@ function verifyTypeScriptSetup() {
     allowSyntheticDefaultImports: { suggested: true },
     strict: { suggested: true },
     forceConsistentCasingInFileNames: { suggested: true },
+    // TODO: Enable for v4.0 (#6936)
+    // noFallthroughCasesInSwitch: { suggested: true },
 
     // These values are required and cannot be changed by the user
     // Keep this in sync with the webpack config
@@ -181,7 +183,7 @@ function verifyTypeScriptSetup() {
         )
       );
     }
-    
+
     console.log(e && e.message ? `${e.message}` : '');
     process.exit(1);
   }


### PR DESCRIPTION
Fixes #6906.

I've created #6936 as a follow up for v4 to suggest the `noFallthroughCasesInSwitch` option in `tsconfig.json`.