### PR TITLE
Add clarifying note to TypeScript docs warning about global install of CRA

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -16,6 +16,7 @@ npx create-react-app my-app --typescript
 
 yarn create react-app my-app --typescript
 ```
+
 > If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that `npx` always uses the latest version.
 
 To add [TypeScript](https://www.typescriptlang.org/) to a Create React App project, first install it:

--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -16,6 +16,7 @@ npx create-react-app my-app --typescript
 
 yarn create react-app my-app --typescript
 ```
+> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that `npx` always uses the latest version.
 
 To add [TypeScript](https://www.typescriptlang.org/) to a Create React App project, first install it:
 


### PR DESCRIPTION
Added block quote with warning about issues when CRA is installed globally.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Related to: #6816 & https://github.com/facebook/create-react-app/pull/6911

Updating blockquote to advise on use of CRA globally vs. npx when using --typescript flag.