### PR TITLE
Stop hiding the column number of ESLint errors

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -41,9 +41,6 @@ function formatMessage(message) {
     /SyntaxError\s+\((\d+):(\d+)\)\s*(.+?)\n/g,
     `${friendlySyntaxErrorLabel} $3 ($1:$2)\n`
   );
-  // Remove columns from ESLint formatter output (we added these for more
-  // accurate syntax errors)
-  message = message.replace(/Line (\d+):\d+:/g, 'Line $1:');
   // Clean up export errors
   message = message.replace(
     /^.*export '(.+?)' was not found in '(.+?)'.*$/gm,

--- a/test/fixtures/webpack-message-formatting/__snapshots__/index.test.js.snap
+++ b/test/fixtures/webpack-message-formatting/__snapshots__/index.test.js.snap
@@ -62,7 +62,7 @@ Object {
 Failed to compile.
 
 ./src/App.js
-  Line 4:  'b' is not defined  no-undef
+  Line 4:13:  'b' is not defined  no-undef
 
 Search for the keywords to learn more about each error.
 
@@ -79,7 +79,7 @@ Object {
 Compiled with warnings.
 
 ./src/App.js
-  Line 3:  'foo' is defined but never used  no-unused-vars
+  Line 3:10:  'foo' is defined but never used  no-unused-vars
 
 Search for the keywords to learn more about each warning.
 To ignore, add // eslint-disable-next-line to the line before.


### PR DESCRIPTION
Currently, CRA's `npm start` output only reports the line number of ESLint errors but hides the column numbers. This makes it harder for IDE users to leverage the time-saving features provided by IDEs like VSCode to deal with build errors:
* devs can't one-click to navigate from the build error message to the exact spot in the code where the problem is.
* the code editor won't show the little red sqiggly line under the exact spot in the code where the problem is.

This PR removes one line of code (originally introduced in #5174 last year) that removes column numbers from ESLint errors.  Here's the current code. As you can see, it has no side effects-- it removes column numbers but doesn't do any other changes to the string.
https://github.com/facebook/create-react-app/blob/4397d069d903c29927526d6fe4e7ba1b5edb136d/packages/react-dev-utils/formatWebpackMessages.js#L44-L46

Here's what existing errors look like: 
```
./src/Calendar.tsx
  Line 19:  Unnecessary escape character: \.  no-useless-escape
```

Here's what errors will look like after this PR: 
```
./src/Calendar.tsx
  Line 19:21:  Unnecessary escape character: \.  no-useless-escape
```
