### PR TITLE
Disable no-dupe-class-members rule for TypeScript

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -71,6 +71,8 @@ module.exports = {
     rules: {
       // TypeScript's `noFallthroughCasesInSwitch` option is more robust (#6906)
       'default-case': 'off',
+      // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)
+      'no-dupe-class-members': 'off',
 
       // Add TypeScript specific rules (and turn off ESLint equivalents)
       '@typescript-eslint/no-angle-bracket-type-assertion': 'warn',


### PR DESCRIPTION
Fixes #6986.