### PR TITLE
Temporary fix for babel-jest preflight error

### DIFF
--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "7.4.3",
     "anser": "1.4.8",
     "babel-eslint": "10.0.1",
-    "babel-jest": "24.7.1",
+    "babel-jest": "24.8.0",
     "babel-loader": "8.0.5",
     "babel-preset-react-app": "^8.0.0",
     "chalk": "^2.4.2",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/eslint-plugin": "1.6.0",
     "@typescript-eslint/parser": "1.6.0",
     "babel-eslint": "10.0.1",
-    "babel-jest": "24.7.1",
+    "babel-jest": "24.8.0",
     "babel-loader": "8.0.5",
     "babel-plugin-named-asset-import": "^0.3.2",
     "babel-preset-react-app": "^8.0.0",


### PR DESCRIPTION
Ref: #6756.

Temporary fix to bump `babel-jest` to fix preflight check error that was a result of a new version of Jest being released. Still need to address the bigger issue as part of #6756.
