### PR TITLE
Unpin babel-jest

### DIFF
--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "7.4.3",
     "anser": "1.4.8",
     "babel-eslint": "10.0.1",
-    "babel-jest": "24.8.0",
+    "babel-jest": "^24.8.0",
     "babel-loader": "8.0.5",
     "babel-preset-react-app": "^8.0.0",
     "chalk": "^2.4.2",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -33,7 +33,7 @@
     "@typescript-eslint/eslint-plugin": "1.6.0",
     "@typescript-eslint/parser": "1.6.0",
     "babel-eslint": "10.0.1",
-    "babel-jest": "24.8.0",
+    "babel-jest": "^24.8.0",
     "babel-loader": "8.0.5",
     "babel-plugin-named-asset-import": "^0.3.2",
     "babel-preset-react-app": "^8.0.0",


### PR DESCRIPTION
Ref: #6756.

We decided to unpin `babel-jest` to avoid future issues when new versions of `jest` and related packages are released.