### PR TITLE
Use a careted version range for fork-ts-checker-webpack-plugin

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -59,7 +59,7 @@
     "escape-string-regexp": "1.0.5",
     "filesize": "3.6.1",
     "find-up": "3.0.0",
-    "fork-ts-checker-webpack-plugin": "1.1.1",
+    "fork-ts-checker-webpack-plugin": "^1.1.1",
     "global-modules": "2.0.0",
     "globby": "8.0.2",
     "gzip-size": "5.0.0",


### PR DESCRIPTION
I'm using an ejected CRA and want to be able to keep `fork-ts-checker-webpack-plugin` up to date independently of `react-dev-utils`.