### PR TITLE
Add vscodium to the editor list

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -40,6 +40,7 @@ const COMMON_EDITORS_OSX = {
   '/Applications/Visual Studio Code.app/Contents/MacOS/Electron': 'code',
   '/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/Electron':
     'code-insiders',
+  '/Applications/VSCodium.app/Contents/MacOS/Electron': 'vscodium',
   '/Applications/AppCode.app/Contents/MacOS/appcode':
     '/Applications/AppCode.app/Contents/MacOS/appcode',
   '/Applications/CLion.app/Contents/MacOS/clion':
@@ -66,6 +67,7 @@ const COMMON_EDITORS_LINUX = {
   Brackets: 'brackets',
   code: 'code',
   'code-insiders': 'code-insiders',
+  vscodium: 'vscodium',
   emacs: 'emacs',
   gvim: 'gvim',
   'idea.sh': 'idea',
@@ -82,6 +84,7 @@ const COMMON_EDITORS_WIN = [
   'Brackets.exe',
   'Code.exe',
   'Code - Insiders.exe',
+  'VSCodium.exe',
   'atom.exe',
   'sublime_text.exe',
   'notepad++.exe',
@@ -150,6 +153,8 @@ function getArgumentsForLineNumber(
     case 'Code':
     case 'code-insiders':
     case 'Code - Insiders':
+    case 'vscodium':
+    case 'VSCodium':
       return addWorkspaceToArgumentsIfExists(
         ['-g', fileName + ':' + lineNumber + ':' + colNumber],
         workspace


### PR DESCRIPTION
This PR adds support for opening [`vscodium`](https://github.com/VSCodium/vscodium) on error views

tested on macOS 10.12.6 + VSCodium 1.32.3