### PR TITLE
Interpolate variables into template before minification

### DIFF
--- a/packages/react-dev-utils/InterpolateHtmlPlugin.js
+++ b/packages/react-dev-utils/InterpolateHtmlPlugin.js
@@ -26,7 +26,7 @@ class InterpolateHtmlPlugin {
     compiler.hooks.compilation.tap('InterpolateHtmlPlugin', compilation => {
       this.htmlWebpackPlugin
         .getHooks(compilation)
-        .beforeEmit.tap('InterpolateHtmlPlugin', data => {
+        .afterTemplateExecution.tap('InterpolateHtmlPlugin', data => {
           // Run HTML through a series of user-specified string replacements.
           Object.keys(this.replacements).forEach(key => {
             const value = this.replacements[key];


### PR DESCRIPTION
Fixes https://github.com/facebook/create-react-app/issues/6448

We ran into a problem where a code snippet in our index.html was removed regardless of the `NODE_ENV` set:

```
 <script>
 if ("%NODE_ENV%" === "production") {
  // Production only configuration
}
 </script>
```

The problem was that the interpolation was only registered after the minification already ran. So from the minifier's point of view `"%NODE_ENV%" === "production"` is always false and the code block can therefore be eliminated.

I tested this out by using a local copy of `react-scripts` & `react-dev-tools` and rebuilding our project. I think the only potential bug this change could introduce would be if any steps between the template generation and the emit would actually themselves generate interpolated variables. Those would not be converted by the PR as it is. It may be possible to run the interpolation for both hooks if this turns out to be a problem.