### PR TITLE
docs(eslint-config-react-app): babel-eslint version

### DIFF
--- a/packages/eslint-config-react-app/README.md
+++ b/packages/eslint-config-react-app/README.md
@@ -19,7 +19,7 @@ If you want to use this ESLint configuration in a project not built with Create 
 First, install this package, ESLint and the necessary plugins.
 
 ```sh
-npm install --save-dev eslint-config-react-app babel-eslint@9.x eslint@5.x eslint-plugin-flowtype@2.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-react@7.x eslint-plugin-react-hooks@1.5.0
+npm install --save-dev eslint-config-react-app babel-eslint@10.x eslint@5.x eslint-plugin-flowtype@2.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-react@7.x eslint-plugin-react-hooks@1.5.0
 ```
 
 Then create a file named `.eslintrc.json` with following contents in the root folder of your project:


### PR DESCRIPTION
Update README.md install cli to match the `babel-eslint` version in the peerDependencies of [package.json](https://github.com/facebook/create-react-app/blob/e2f43a06a60646f2db00ff0558acb6d2a3355a36/packages/eslint-config-react-app/package.json#L20).

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->