### PR TITLE
Updates the relay docs

### DIFF
--- a/docusaurus/docs/adding-relay.md
+++ b/docusaurus/docs/adding-relay.md
@@ -3,18 +3,18 @@ id: adding-relay
 title: Adding Relay
 ---
 
-Relay is a framework for building data-driven React applications powered by GraphQL. The current release candidate of Relay works with Create React App projects out of the box using Babel Macros. Simply set up your project as laid out in the [Relay documentation](https://facebook.github.io/relay/), then make sure you have a version of the babel plugin providing the macro.
+Relay is a framework for building data-driven React applications powered by GraphQL. The current release of Relay works with Create React App projects out of the box using Babel Macros. Simply set up your project as laid out in the [Relay documentation](https://facebook.github.io/relay/), then make sure you have a version of the babel plugin providing the macro.
 
 To add it, run:
 
 ```sh
-npm install --save babel-plugin-relay@dev
+npm install --save babel-plugin-relay
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn upgrade babel-plugin-relay@dev
+yarn upgrade babel-plugin-relay
 ```
 
 Then, wherever you use the `graphql` template tag, import the macro:


### PR DESCRIPTION
The babel macros came out in [Relay 1.7.0](https://github.com/facebook/relay/releases/tag/v1.7.0) - it's now at 4.0, so `@dev` shouldn't be needed anymore 👍 