### PR TITLE
fix: Replaced opn (deprecated) with open

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -10,9 +10,9 @@
 var chalk = require('chalk');
 var execSync = require('child_process').execSync;
 var spawn = require('cross-spawn');
-var opn = require('opn');
+var open = require('open');
 
-// https://github.com/sindresorhus/opn#app
+// https://github.com/sindresorhus/open#app
 var OSX_CHROME = 'google chrome';
 
 const Actions = Object.freeze({
@@ -24,7 +24,7 @@ const Actions = Object.freeze({
 function getBrowserEnv() {
   // Attempt to honor this environment variable.
   // It is specific to the operating system.
-  // See https://github.com/sindresorhus/opn#app for documentation.
+  // See https://github.com/sindresorhus/open#app for documentation.
   const value = process.env.BROWSER;
   let action;
   if (!value) {
@@ -93,11 +93,11 @@ function startBrowserProcess(browser, url) {
     browser = undefined;
   }
 
-  // Fallback to opn
+  // Fallback to open
   // (It will always open new tab)
   try {
     var options = { app: browser, wait: false };
-    opn(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
+    open(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {
     return false;

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -67,7 +67,7 @@
     "inquirer": "6.2.2",
     "is-root": "2.0.0",
     "loader-utils": "1.2.3",
-    "opn": "5.4.0",
+    "open": "^6.3.0",
     "pkg-up": "2.0.0",
     "react-error-overlay": "^5.1.6",
     "recursive-readdir": "2.2.2",


### PR DESCRIPTION
The [opn](https://npmjs.com/package/opn) package is deprecated and no longer maintained. Replaced it with [open](https://npmjs.com/package/open) to which the original package was renamed to.