### PR TITLE
Correct spelling of browserslist

### DIFF
--- a/docusaurus/docs/supported-browsers-features.md
+++ b/docusaurus/docs/supported-browsers-features.md
@@ -29,7 +29,7 @@ If you use any other ES6+ features that need **runtime support** (such as `Array
 
 ## Configuring Supported Browsers
 
-By default, the generated project includes a [`browerslist`](https://github.com/browserslist/browserslist) configuration in your `package.json` file to target a broad range of browsers based on global usage (`> 0.2%`) for production builds, and modern browsers for development. This gives a good development experience, especially when using language features such as async/await, but still provides high compatibility with many browsers in production.
+By default, the generated project includes a [`browserslist`](https://github.com/browserslist/browserslist) configuration in your `package.json` file to target a broad range of browsers based on global usage (`> 0.2%`) for production builds, and modern browsers for development. This gives a good development experience, especially when using language features such as async/await, but still provides high compatibility with many browsers in production.
 
 The `browserslist` configuration controls the outputted JavaScript so that the emitted code will be compatible with the browsers specified. The `production` list will be used when creating a production build by running the `build` script, and the `development` list will be used when running the `start` script. You can use [https://browserl.ist](https://browserl.ist/?q=%3E+0.2%25%2C+not+dead%2C+not+op_mini+all) to see the browsers supported by your configured `browserslist`.
 
@@ -52,4 +52,4 @@ Here is an example `browserslist` that is specified in `package.json`:
 
 > Note that this does not include polyfills automatically for you. You will still need to polyfill language features (see above) as needed based on the browsers your are supporting.
 
-> When editing the `browerslist` config, you may notice that your changes don't get picked up right away. This is due to an [issue in babel-loader](https://github.com/babel/babel-loader/issues/690) not detecting the change in your `package.json`. An easy solution is to delete the `node_modules/.cache` folder and try again.
+> When editing the `browserslist` config, you may notice that your changes don't get picked up right away. This is due to an [issue in babel-loader](https://github.com/babel/babel-loader/issues/690) not detecting the change in your `package.json`. An easy solution is to delete the `node_modules/.cache` folder and try again.


### PR DESCRIPTION
I redid the spelling fix in https://github.com/facebook/create-react-app/pull/6935, which had to be reverted in https://github.com/facebook/create-react-app/pull/7016 because the CLA wasn't signed.

Thanks again @wbr2y for the original PR!