### PR TITLE
Adjust typescript-eslint to not warn about typedefs when used before defined

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -79,6 +79,16 @@ module.exports = {
       'no-array-constructor': 'off',
       '@typescript-eslint/no-array-constructor': 'warn',
       '@typescript-eslint/no-namespace': 'error',
+      '@typescript-eslint/no-use-before-define': [
+        'warn',
+        {
+          functions: false,
+          classes: false,
+          variables: false,
+          typedefs: false,
+        },
+      ],
+      'no-use-before-define': 'off',
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': [
         'warn',

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -79,6 +79,7 @@ module.exports = {
       'no-array-constructor': 'off',
       '@typescript-eslint/no-array-constructor': 'warn',
       '@typescript-eslint/no-namespace': 'error',
+      'no-use-before-define': 'off',
       '@typescript-eslint/no-use-before-define': [
         'warn',
         {
@@ -88,7 +89,6 @@ module.exports = {
           typedefs: false,
         },
       ],
-      'no-use-before-define': 'off',
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': [
         'warn',


### PR DESCRIPTION
The new ESLint TS rules are a little cumbersome for typedefs. We have 100s of places where we do things like the following as we like to have our types declared at the top of our files.

```ts
export type AppProps = ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
export const mapStateToProps = (state: RootState) => ({  initialized: state.initialized });
export const mapDispatchToProps = { initialize };
```

Making the changes here in local eslint-config-react-app/index.js fixes the warnings for TS(X) files.

