### PR TITLE
Support configuring coveragePathIgnorePatterns

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -71,6 +71,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'collectCoverageFrom',
     'coverageReporters',
     'coverageThreshold',
+    'coveragePathIgnorePatterns',
     'extraGlobals',
     'globalSetup',
     'globalTeardown',


### PR DESCRIPTION
In some situations, it's much easier to create a "blacklist" than a "whitelist" so including `coveragePathIgnorePatterns` makes a lot of sense to me. I've made this change locally and it works as expected.