### PR TITLE
Print help and exit whenever help arguments are present

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -124,6 +124,10 @@ const program = new commander.Command(packageJson.name)
   })
   .parse(process.argv);
 
+if (program.rawArgs.includes('-h') || program.rawArgs.includes('--help')) {
+  program.help();
+}
+
 if (program.info) {
   console.log(chalk.bold('\nEnvironment Info:'));
   return envinfo


### PR DESCRIPTION
### Summary

**Change Type:** enhancement

Allow `help` to behave as `version` and `info` currently do; Ignore the main action, when supplied, and output their respective information.

#### Current Behavior

Supplying a project name for `create-react-app`'s main action, along with any of the help arguments (`-h` and `--help`) will result in the software ignoring those help arguments.

Example: `create-react-app hello-world --help` will produce the project and not output help information.

#### New Behavior

Whenever the `-h` or `--help` arguments are present, CRA will print out help information and exit the process.

Example: `create-react-app hello-world --help` will output the help information and exit the process.
