### PR TITLE
Update fsevents dependency version

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -86,7 +86,7 @@
     "react-dom": "^16.8.4"
   },
   "optionalDependencies": {
-    "fsevents": "2.0.6"
+    "fsevents": "2.0.7"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Fixes the following warning when installing:
> warning react-scripts > fsevents@2.0.6: Please update: there are crash fixes

Change applied: fsevents/fsevents#279
