### PR TITLE
Add a note about anchor tags not working with the basic proxy

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -29,7 +29,7 @@ Conveniently, this avoids [CORS issues](https://stackoverflow.com/questions/2185
 Fetch API cannot load http://localhost:4000/api/todos. No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://localhost:3000' is therefore not allowed access. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
 ```
 
-Keep in mind that `proxy` only has effect in development (with `npm start`), and it is up to you to ensure that URLs like `/api/todos` point to the right thing in production. You don’t have to use the `/api` prefix. Any unrecognized request without a `text/html` accept header will be redirected to the specified `proxy`.
+Keep in mind that `proxy` only has effect in development (with `npm start`), and it is up to you to ensure that URLs like `/api/todos` point to the right thing in production. You don’t have to use the `/api` prefix. Any unrecognized request without a `text/html` accept header will be redirected to the specified `proxy`. **Note** This means that requests initiated from anchor tags are not proxied because they include the `text/html` accept header. You must [Configure the Proxy Manually](#configuring-the-proxy-manually).
 
 The `proxy` option supports HTTP, HTTPS and WebSocket connections.<br>
 If the `proxy` option is **not** flexible enough for you, alternatively you can:


### PR DESCRIPTION
Hi there,

Hope this is helpful for other people. It's not immediately clear from the docs that when clicking on a relative link, to initiate an Oauth2 flow for example, the proxy doesn't work because of the Accept header is `text/html`.

Happy to re-word this to make it more clear. Let me know and I can fix.

Thanks!

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
