### PR TITLE
emmadal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ template/src/__tests__/__snapshots__/
 lerna-debug.log
 npm-debug.log*
 yarn-debug.log*
+yarn.lock
+package-lock.json
 yarn-error.log*
 /.changelog
 .npm/

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -131,7 +131,7 @@ if (program.info) {
       {
         System: ['OS', 'CPU'],
         Binaries: ['Node', 'npm', 'Yarn'],
-        Browsers: ['Chrome', 'Edge', 'Internet Explorer', 'Firefox', 'Safari'],
+        Browsers: ['Chrome', 'Edge', 'Brave', 'Firefox', 'Safari'],
         npmPackages: ['react', 'react-dom', 'react-scripts'],
         npmGlobalPackages: ['create-react-app'],
       },
@@ -143,8 +143,8 @@ if (program.info) {
     .then(console.log);
 }
 
-if (typeof projectName === 'undefined') {
-  console.error('Please specify the project directory:');
+if (typeof projectName === 'undefined' || projectName === 'undefined') {
+  console.error('Please specify the project directory different of undefined:');
   console.log(
     `  ${chalk.cyan(program.name())} ${chalk.green('<project-directory>')}`
   );


### PR DESCRIPTION
*  I have bring some fixing in the Environment Info : Brave browser instead of Internet explorer because Internet Explorer is the a old browser and a restriction for the project name with the undefined word because is the reserved  keyword of `Javascript` and  i think that it does not to be used to create a React project.

* add yarn.lock and package-lock.json to avoid the mismatch package installation when we using yarn instead of npm
 