### PR TITLE
Fix RegExp from navigateFallbackBlacklist (workbox)

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -623,9 +623,11 @@ module.exports = function(webpackEnv) {
           navigateFallbackBlacklist: [
             // Exclude URLs starting with /_, as they're likely an API call
             new RegExp('^/_'),
-            // Exclude URLs containing a dot, as they're likely a resource in
-            // public/ and not a SPA route
-            new RegExp('/[^/]+\\.[^/]+$'),
+            // Exclude any URLs whose last part seems to be a file extension
+            // as they're likely a resource and not a SPA route.
+            // URLs containing a "?" character won't be blacklisted as they're likely
+            // a route with query params (e.g. auth callbacks).
+            new RegExp('/[^/?]+\\.[^/]+$'),
           ],
         }),
       // TypeScript type checking


### PR DESCRIPTION
Hello,

This lovely RegExp was preventing my `index.html` to be served from ServiceWorker after an authentication callback; the request always hit the network…

Here is an example of this kind of "auth requests" callback:

`https://example.com/PWA/callback?code=a55b99fbe42a3a7663b344020d2407047f4eb206aded15c300568ca4ef1219ce&scope=openid%20profile%20organizations%20api1%20offline_access&state=12c7c99a9b75476545161b45302e2cd&session_state=_p1MWLryvh08qxT-gmvucCIFVsWh8rIwo_MUBjhjvyY.5f6ee222da987db8c21aa4a35f93ada`

The problem was that it was blacklisted by workbox because… it contains a `.` ! 😟 

I believe it would be just safer to remove it… I hope this will prevent fellow devs opting in for SW wasting a lot of time like I did to found out! 😅 

Thanks!