### PR TITLE
Disabled Typescript no-undef rule per typescript-eslint #477

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -73,6 +73,8 @@ module.exports = {
       'default-case': 'off',
       // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)
       'no-dupe-class-members': 'off',
+      // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/477)
+      'no-undef': 'off',
 
       // Add TypeScript specific rules (and turn off ESLint equivalents)
       '@typescript-eslint/no-angle-bracket-type-assertion': 'warn',


### PR DESCRIPTION
This PR resolves #7167 by disabling the no-undef rule for typescript-eslint. As pointed out in https://github.com/typescript-eslint/typescript-eslint/issues/477, no-undef is handled by the Typescript compiler.

I have verified that errors are thrown by taking the example in the above issue and mangling the name of the namespace to "connect0" and verifying that compiler errors are thrown:
```
Failed to compile.

/Users/andyhopp/Projects/connect-react-example/src/connect-service.ts
TypeScript error in /Users/andyhopp/Projects/connect-react-example/src/connect-service.ts(6,9):
Cannot find name 'connect0'. Did you mean 'Connect'?  TS2552

    4 | 
    5 |     public initialize(ccpElement: HTMLElement, options: connect.InitCCPOptions) {
  > 6 |         connect0.core.initCCP(ccpElement, options);
      |         ^
    7 |         console.log('CCP Initialized!');
    8 |     }
    9 | }


npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! connect-react-example@0.1.0 build: `react-scripts build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the connect-react-example@0.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/andyhopp/.npm/_logs/2019-06-06T15_36_52_376Z-debug.log
```
