### PR TITLE
Guard polyfills against window possibly being undefined

### DIFF
--- a/packages/react-app-polyfill/ie11.js
+++ b/packages/react-app-polyfill/ie11.js
@@ -11,7 +11,7 @@ if (typeof Promise === 'undefined') {
   // inconsistent state due to an error, but it gets swallowed by a Promise,
   // and the user has no idea what causes React's erratic future behavior.
   require('promise/lib/rejection-tracking').enable();
-  window.Promise = require('promise/lib/es6-extensions.js');
+  self.Promise = require('promise/lib/es6-extensions.js');
 }
 
 // Make sure we're in a Browser-like environment before importing polyfills

--- a/packages/react-app-polyfill/ie9.js
+++ b/packages/react-app-polyfill/ie9.js
@@ -12,6 +12,4 @@ require('./ie11');
 require('core-js/features/map');
 require('core-js/features/set');
 
-if (typeof window !== 'undefined') {
-  require('raf').polyfill(window);
-}
+require('raf').polyfill();

--- a/packages/react-app-polyfill/ie9.js
+++ b/packages/react-app-polyfill/ie9.js
@@ -11,4 +11,7 @@ require('./ie11');
 // React 16+ relies on Map, Set, and requestAnimationFrame
 require('core-js/features/map');
 require('core-js/features/set');
-require('raf').polyfill(window);
+
+if (typeof window !== 'undefined') {
+  require('raf').polyfill(window);
+}


### PR DESCRIPTION
Hello!

This PR is just a small one, and ensures that window is not undefined before it invokes the polyfill.




