### PR TITLE
Use correct babel transform for dynamic import in dependencies

### DIFF
--- a/packages/babel-preset-react-app/dependencies.js
+++ b/packages/babel-preset-react-app/dependencies.js
@@ -142,7 +142,7 @@ module.exports = function(api, opts) {
       require('@babel/plugin-syntax-dynamic-import').default,
       isEnvTest &&
         // Transform dynamic import to require
-        require('babel-plugin-transform-dynamic-import').default,
+        require('babel-plugin-dynamic-import-node'),
     ].filter(Boolean),
   };
 };


### PR DESCRIPTION
The `babel-plugin-transform-dynamic-import` package is not specified in babel-preset-react-app's `package.json`. It appears that it was switched out with `babel-plugin-dynamic-import-node` in `create.js` here:

https://github.com/facebook/create-react-app/commit/52fcb23b0d3b80a3d79e3863a27372e83dded1e7

This commit updates it in `dependencies.js` too.

I ran into this while working on my [SSR fork](https://github.com/facebook/create-react-app/pull/6747). The build script was failing before this commit, but is works correctly after the switch.