### PR TITLE
fix: eslintrc overrides key should be an array, not object

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -52,57 +52,59 @@ module.exports = {
     },
   },
 
-  overrides: {
-    files: ['**/*.ts', '**/*.tsx'],
-    parser: '@typescript-eslint/parser',
-    parserOptions: {
-      ecmaVersion: 2018,
-      sourceType: 'module',
-      ecmaFeatures: {
-        jsx: true,
+  overrides: [
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+        ecmaFeatures: {
+          jsx: true,
+        },
+
+        // typescript-eslint specific options
+        warnOnUnsupportedTypeScriptVersion: true,
       },
+      plugins: ['@typescript-eslint'],
+      // If adding a typescript-eslint version of an existing ESLint rule,
+      // make sure to disable the ESLint rule here.
+      rules: {
+        // TypeScript's `noFallthroughCasesInSwitch` option is more robust (#6906)
+        'default-case': 'off',
+        // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)
+        'no-dupe-class-members': 'off',
+        // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/477)
+        'no-undef': 'off',
 
-      // typescript-eslint specific options
-      warnOnUnsupportedTypeScriptVersion: true,
+        // Add TypeScript specific rules (and turn off ESLint equivalents)
+        '@typescript-eslint/no-angle-bracket-type-assertion': 'warn',
+        'no-array-constructor': 'off',
+        '@typescript-eslint/no-array-constructor': 'warn',
+        '@typescript-eslint/no-namespace': 'error',
+        'no-use-before-define': 'off',
+        '@typescript-eslint/no-use-before-define': [
+          'warn',
+          {
+            functions: false,
+            classes: false,
+            variables: false,
+            typedefs: false,
+          },
+        ],
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': [
+          'warn',
+          {
+            args: 'none',
+            ignoreRestSiblings: true,
+          },
+        ],
+        'no-useless-constructor': 'off',
+        '@typescript-eslint/no-useless-constructor': 'warn',
+      },
     },
-    plugins: ['@typescript-eslint'],
-    // If adding a typescript-eslint version of an existing ESLint rule,
-    // make sure to disable the ESLint rule here.
-    rules: {
-      // TypeScript's `noFallthroughCasesInSwitch` option is more robust (#6906)
-      'default-case': 'off',
-      // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/291)
-      'no-dupe-class-members': 'off',
-      // 'tsc' already handles this (https://github.com/typescript-eslint/typescript-eslint/issues/477)
-      'no-undef': 'off',
-
-      // Add TypeScript specific rules (and turn off ESLint equivalents)
-      '@typescript-eslint/no-angle-bracket-type-assertion': 'warn',
-      'no-array-constructor': 'off',
-      '@typescript-eslint/no-array-constructor': 'warn',
-      '@typescript-eslint/no-namespace': 'error',
-      'no-use-before-define': 'off',
-      '@typescript-eslint/no-use-before-define': [
-        'warn',
-        {
-          functions: false,
-          classes: false,
-          variables: false,
-          typedefs: false,
-        },
-      ],
-      'no-unused-vars': 'off',
-      '@typescript-eslint/no-unused-vars': [
-        'warn',
-        {
-          args: 'none',
-          ignoreRestSiblings: true,
-        },
-      ],
-      'no-useless-constructor': 'off',
-      '@typescript-eslint/no-useless-constructor': 'warn',
-    },
-  },
+  ],
 
   // NOTE: When adding rules here, you need to make sure they are compatible with
   // `typescript-eslint`, as some rules such as `no-array-constructor` aren't compatible.


### PR DESCRIPTION
Attempts to fix #7218 

Array format for [`overrides` key](https://github.com/facebook/create-react-app/blob/f522a0dae2/packages/eslint-config-react-app/index.js#L55) in eslint config file is now enforced to be an array in ESLint v6. Anyone who uses `eslint-config-react-app` and ESLint v6 gets a type mismatch error:

```
Error: ESLint configuration in .eslintrc.js » eslint-config-react-app is invalid:
  - Property "overrides" is the wrong type (expected array but got `{"files":["**/*.ts","**/*.tsx"],"parser":"@typescript-eslint/parser","parserOptions":{"ecmaVersion":2018,"sourceType":"module","ecmaFeatures":{"jsx":true},"warnOnUnsupportedTypeScriptVersion":true},"plugins":["@typescript-eslint"],"rules":{"default-case":"off","no-dupe-class-members":"off","@typescript-eslint/no-angle-bracket-type-assertion":"warn","no-array-constructor":"off","@typescript-eslint/no-array-constructor":"warn","@typescript-eslint/no-namespace":"error","no-unused-vars":"off","@typescript-eslint/no-unused-vars":["warn",{"args":"none","ignoreRestSiblings":true}],"no-useless-constructor":"off","@typescript-eslint/no-useless-constructor":"warn"}}`).
```


This commit fixes the error by converting the object into a one-element array containing that object. Only  3 characters are added: `[`, `]` and `,`. The large diff is due to formatting.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
