### PR TITLE
Support comments in tsconfig.json

### DIFF
--- a/packages/react-scripts/config/modules.js
+++ b/packages/react-scripts/config/modules.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 const path = require('path');
 const paths = require('./paths');
 const chalk = require('react-dev-utils/chalk');
+const resolve = require('resolve');
 
 /**
  * Get the baseUrl of a compilerOptions object.
@@ -71,7 +72,10 @@ function getModules() {
   // TypeScript project and set up the config
   // based on tsconfig.json
   if (hasTsConfig) {
-    config = require(paths.appTsConfig);
+    const ts = require(resolve.sync('typescript', {
+      basedir: paths.appNodeModules,
+    }));
+    config = ts.readConfigFile(paths.appTsConfig, ts.sys.readFile).config;
     // Otherwise we'll check if there is jsconfig.json
     // for non TS projects.
   } else if (hasJsConfig) {


### PR DESCRIPTION
Since tsconfig files [allow comments](https://github.com/Microsoft/TypeScript/issues/4987), using `require` for a `tsonfig.json` with comments results in the following syntax error:

```bash
$ react-scripts start
internal/modules/cjs/loader.js:724
    throw err;
    ^

SyntaxError: /Users/jack/dev/github/test/tsconfig.json: Unexpected token / in JSON at position 157
    at JSON.parse (<anonymous>)
    at Object.Module._extensions..json (internal/modules/cjs/loader.js:721:27)
    at Module.load (internal/modules/cjs/loader.js:612:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:551:12)
    at Function.Module._load (internal/modules/cjs/loader.js:543:3)
    at Module.require (internal/modules/cjs/loader.js:650:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at getModules (/Users/jack/dev/github/test/node_modules/react-scripts/config/modules.js:74:14)
    at Object.<anonymous> (/Users/jack/dev/github/test/node_modules/react-scripts/config/modules.js:92:18)
    at Module._compile (internal/modules/cjs/loader.js:702:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:713:10)
    at Module.load (internal/modules/cjs/loader.js:612:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:551:12)
    at Function.Module._load (internal/modules/cjs/loader.js:543:3)
    at Module.require (internal/modules/cjs/loader.js:650:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/Users/jack/dev/github/test/node_modules/react-scripts/config/webpack.config.js:31:17)
    at Module._compile (internal/modules/cjs/loader.js:702:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:713:10)
    at Module.load (internal/modules/cjs/loader.js:612:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:551:12)
    at Function.Module._load (internal/modules/cjs/loader.js:543:3)
error Command failed with exit code 1.
```

This PR uses `typescript`'s `readConfigFile` which handles comments.