### PR TITLE
Docs: replace the command line to install relay/macro

### DIFF
--- a/docusaurus/docs/adding-relay.md
+++ b/docusaurus/docs/adding-relay.md
@@ -14,7 +14,7 @@ npm install --save babel-plugin-relay
 Alternatively you may use `yarn`:
 
 ```sh
-yarn upgrade babel-plugin-relay
+yarn add babel-plugin-relay
 ```
 
 Then, wherever you use the `graphql` template tag, import the macro:


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
replace in the documentation

``` yarn upgrade babel-plugin-relay@dev ```

by

``` yarn add babel-plugin-relay@dev ```

because its more meaningful that we are installing the package than upgrade it