### PR TITLE
Allow maxWorkers/runInBand

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -73,6 +73,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'coverageThreshold',
     'extraGlobals',
     'globalSetup',
+    'maxWorkers',
+    'runInBand',
     'globalTeardown',
     'moduleNameMapper',
     'resetMocks',


### PR DESCRIPTION
Would fix #7275 

I can't see any reason how allowing these options would interfere with create-react-app's easy-to-use-out-of-the-box ideology. Sensible defaults (whatever jest provides), and allow users to customize them to their needs if need be. Solves a CI issue for me and I would really prefer to not eject.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
