### PR TITLE
docs: note that 2 to 3 migration may require deletion of node_modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ or
 yarn add --exact react-scripts@3.0.0
 ```
 
-You may need to delete your `node_modules` folder and re-install all your dependencies if you run into problems when migrating.
+**NOTE: You may need to delete your `node_modules` folder and reinstall your dependencies by running `yarn` (or `npm install`) if you encounter errors after upgrading.**
 
 If you previously ejected but now want to upgrade, one common solution is to find the commits where you ejected (and any subsequent commits changing the configuration), revert them, upgrade, and later optionally eject again. It’s also possible that the feature you ejected for is now supported out of the box.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ or
 yarn add --exact react-scripts@3.0.0
 ```
 
+You may need to delete your `node_modules` folder and re-install all your dependencies if you run into problems when migrating.
+
 If you previously ejected but now want to upgrade, one common solution is to find the commits where you ejected (and any subsequent commits changing the configuration), revert them, upgrade, and later optionally eject again. It’s also possible that the feature you ejected for is now supported out of the box.
 
 ## Breaking Changes


### PR DESCRIPTION
I ran into weird issues with calling functions that do not exist when upgrading from `2.1.8` to `3.0.0`, the issues were resolved by simply deleting the `node_modules` folder and doing a full install.