### PR TITLE
Update to workbox-webpack-plugin v4.3.1

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -79,7 +79,7 @@
     "webpack": "4.35.0",
     "webpack-dev-server": "3.2.1",
     "webpack-manifest-plugin": "2.0.4",
-    "workbox-webpack-plugin": "4.2.0"
+    "workbox-webpack-plugin": "4.3.1"
   },
   "devDependencies": {
     "react": "^16.8.4",


### PR DESCRIPTION
## DESCRIPTION

Workbox has had a few bug fixes latest and we should bring them in.

### workbox-webpack-plugin v4.3.1 fixes:

#### What's New?
workbox-background-sync
Adds a new getAll() method to the Queue class. This can be used to get a list of all unexpired entries in a given queue without removing them. This is useful in situations where replaying the queue is not possible (the user is offline), but you want to show information about the queue to the user. [#2018]

#### What's Fixed?
Build Tools
Fixes a bug where the workbox namespace was used before it was defined, when navigationPreload: true. [#2007]
Properly passes in a custom channel name when using the broadcastUpdate option in runtimeCaching. [#2017]

workbox-background-sync
Fixes a bug in which a Request wasn't being clone()ed before re-adding it to the queue. [#2014]
Ensures that when a navigation request is stored in the queue, it's serialized with a mode of same-origin. [#2015]

workbox-broadcast-update
Fixed a bug where some private symbols were not being properly exported from workbox-core, which prevented workbox-broadcast-update from notifying on navigation requests.

More workbox release info: https://github.com/GoogleChrome/workbox/releases

## No breaking or existing behavior changes

Previously related task of updating workbox to v4 (already merged): https://github.com/facebook/create-react-app/pull/6725