### PR TITLE
Respect app's eslintrc

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -327,7 +327,6 @@ module.exports = function(webpackEnv) {
                   extends: [require.resolve('eslint-config-react-app')],
                 },
                 ignore: false,
-                useEslintrc: false,
                 // @remove-on-eject-end
               },
               loader: require.resolve('eslint-loader'),


### PR DESCRIPTION
Allow react app to configure eslint without resorting to eject

### Test Instructions

1. npm link react-scripts globally
2. create new create-react-app
3. npm link react-scripts in new app
4. modify `eslintConfig` in `package.json` as follows:
```
    "extends": [
      "eslint:recommended",
      "react-app"
    ]
```
5. exercise the script, e.g.:
`npm run build`
6. verify output
```
./src/serviceWorker.js
  Line 44:  Unexpected console statement  no-console
  Line 72:  Unexpected console statement  no-console
  Line 85:  Unexpected console statement  no-console
  Line 97:   Unexpected console statement  no-console
  Line 123:  Unexpected console statement  no-console
```

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
