### PR TITLE
docs(svg): add tip for title props accessibility

### DIFF
--- a/docusaurus/docs/adding-images-fonts-and-files.md
+++ b/docusaurus/docs/adding-images-fonts-and-files.md
@@ -59,3 +59,5 @@ const App = () => (
 ```
 
 This is handy if you don't want to load SVG as a separate file. Don't forget the curly braces in the import! The `ReactComponent` import name is special and tells Create React App that you want a React component that renders an SVG, rather than its filename.
+
+> **Tip:** The imported SVG React Component accepts a `title` prop along with other props that a `svg` element accepts. Use this prop to add an accessbile title to your svg component.


### PR DESCRIPTION
With https://github.com/facebook/create-react-app/pull/7118 being merged, we can now pass a title prop to the SVG ReactComponent to make
our SVG component easily accessible. So we should add it to docs
