### PR TITLE
Exit from startBrowserProcess when no browser is provided.

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -88,6 +88,15 @@ function startBrowserProcess(browser, url, args) {
     }
   }
 
+  // In cases where no browser is set, the open library fails with an ENOENT.
+  // This means that on Windows 10 with Windows Subsystem For Linux, if the user
+  // has not set the Windows paths in their PATH, this will fail.
+  // Thus, if no browser is provided, we return early to avoid an (inevitable) crash.
+  // This solves https://github.com/facebook/create-react-app/issues/7251
+  if (browser === undefined) {
+    return false;
+  }
+
   // Another special case: on OS X, check if BROWSER has been set to "open".
   // In this case, instead of passing `open` to `opn` (which won't work),
   // just ignore it (thus ensuring the intended behavior, i.e. opening the system browser):


### PR DESCRIPTION
In cases where no browser is set, the open library fails with an ENOENT.


This means that on Windows 10 with Windows Subsystem for Linux, if the user
has not added  /mnt/c/Windows/System32  to their $PATH, this will fail, as the open library fails to find the cmd.exe process.

This could possibly by fixed by modifying the open library to handle this issue, however, my reasoning is that if no browser is provided to startBrowserProcess, the call to open should fail nevertheless (however, I see that some cases are handled by setting browser to undefined, so this should perhaps be checked on OSX.

The change is easy: if no browser is provided, we return early to avoid an (inevitable) crash.

This means that npm start on WSL without /mnt/c/Windows/System32 in the PATH should behave as an npm start with the env-variable BROWSER=none. This is the same behaviour as in react-scripts 2.x

This solves #7251 

Tested on WSL running on Microsoft Windows [Version 10.0.18890.1000]
- npm link in create-react-app/packages/react-dev-utils
- npx create-react-app testapp 
- cd testapp
- npm uninstall react-dev-utils
- npm link dev-utils
- npm start

Verified that "Compiled successfully!" shows up.

