### PR TITLE
Update url-loader to 2.0.1

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -75,7 +75,7 @@
     "style-loader": "0.23.1",
     "terser-webpack-plugin": "1.2.3",
     "ts-pnp": "1.1.2",
-    "url-loader": "1.1.2",
+    "url-loader": "2.0.1",
     "webpack": "4.35.0",
     "webpack-dev-server": "3.2.1",
     "webpack-manifest-plugin": "2.0.4",


### PR DESCRIPTION
This closes #7359 by making IMAGE_INLINE_SIZE_LIMIT=0 actually disable image inlining.

We use url-loader's `limit` option to set the line at which images will be inlined, and we basically expose this option to our end users via the IMAGE_INLINE_SIZE_LIMIT environment variable. Most people using it want to disable inlining images all together (the major motivator for adding it at all was I think for strict CSP), and our documentation said setting the value to zero would do that. However, it did the opposite: url-loader treated zero as "no limit".

The update to 2.x fixes this; zero means nothing gets inlined. The other changes from the version bump shouldn't affect us:
- minimum node version is 8.9.x, we already require 8.10.x
- the limit was "greater than", is now "greater than or equal to"

Validated this change manually, checking whether the image was inlined at different vales of IMAGE_INLINE_SIZE_LIMIT, everything worked like a charm.