### PR TITLE
Ignore "jsx-a11y/aria-role" for React components

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -286,7 +286,7 @@ module.exports = {
     'jsx-a11y/aria-activedescendant-has-tabindex': 'warn',
     'jsx-a11y/aria-props': 'warn',
     'jsx-a11y/aria-proptypes': 'warn',
-    'jsx-a11y/aria-role': 'warn',
+    'jsx-a11y/aria-role': ['warn', { ignoreNonDOM: true }],
     'jsx-a11y/aria-unsupported-elements': 'warn',
     'jsx-a11y/heading-has-content': 'warn',
     'jsx-a11y/iframe-has-title': 'warn',


### PR DESCRIPTION
As described in [docs](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md), `jsx-a11y/aria-role` ESLint rule can be disabled for non-DOM elements.

I'm pretty sure that we want to check only native HTML elements as a lot of developers can struggle when we raise a warning for the `role` property in their custom React components.
