### PR TITLE
Make app directory configurable via env variable

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -14,7 +14,7 @@ const url = require('url');
 
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebook/create-react-app/issues/637
-const appDirectory = fs.realpathSync(process.cwd());
+const appDirectory = fs.realpathSync(process.env.APP_DIRECTORY || process.cwd());
 const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 
 const envPublicUrl = process.env.PUBLIC_URL;


### PR DESCRIPTION
Given this type of structure, where `cra` lives in `client`

```
├── client
│   ├── README.md
│   ├── public
│   ├── src
│   ├── test
├── docker-compose.yml
├── package.json
├── server
│   ├── src
│   └── test
└── shared
    └── src
    └── test
```
Running `APP_DIRECTORY=./client yarn start` would make the app start, build and be tested with no issues

Obvisouly this is a POC and will need documentation and tests, but before going that far I'd like to check the opinion on the approach

Thanks