### PR TITLE
Upgrade Babel from 7.4.3 to 7.5.5

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -28,7 +28,7 @@
   },
   "types": "./lib/react-app.d.ts",
   "dependencies": {
-    "@babel/core": "7.4.3",
+    "@babel/core": "7.5.5",
     "@svgr/webpack": "4.3.1",
     "@typescript-eslint/eslint-plugin": "1.10.2",
     "@typescript-eslint/parser": "1.10.2",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Fixes #7402 

Upgrades Babel from `7.4.3` to `7.5.5`. The previously used version of Babel uses `lodash < 4.17.13` which is triggering this known security vulnerability from Github. More information on the vulnerability can be found here: [CVE-2019-10744](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/).

This is the Github security notification:

<img width="543" alt="61550331-2badda00-aa20-11e9-9086-95317ff28e14" src="https://user-images.githubusercontent.com/2514127/61599333-f65ae500-abf5-11e9-8ad0-83ccc9c883b1.png">

There are no breaking changes from the previous version of Babel to the one proposed in this PR. Please let me know what I can do to help get this merged. 

Thanks!