### PR TITLE
Use defineProperty on global in setupTests.js

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -242,7 +242,9 @@ const localStorageMock = {
   removeItem: jest.fn(),
   clear: jest.fn(),
 };
-global.localStorage = localStorageMock;
+Object.defineProperty(global, 'localStorage', {
+  value: localStorageMock
+});
 ```
 
 > Note: Keep in mind that if you decide to "eject" before creating `src/setupTests.js`, the resulting `package.json` file won't contain any reference to it, so you should manually create the property `setupTestFrameworkScriptFile` in the configuration for Jest, something like the following:


### PR DESCRIPTION
I tried to use this code example to mock the localStorage in a unit test.  I was getting a "not a mock error", so I eventually ended up doing a `console.log(localStorageMock == global.localStorage)` directly after the line I removed in this PR, and it would return false. With this fix, it returns true and my tests are working.