### PR TITLE
Add question issue template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-packages/ @amyrlam @bugzpodder @gaearon @ianschmitz @iansu @mrmckeb @petetnt @timer
+packages/ @bugzpodder @ianschmitz @iansu @mrmckeb @petetnt
 docusaurus/ @amyrlam @iansu

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: 'issue: bug'
+labels: 'issue: bug, needs triage'
 ---
 
 <!--
@@ -103,9 +103,7 @@ labels: 'issue: bug'
 
 (Write your steps here:)
 
-1.
-2.
-3.
+1. 2. 3.
 
 ### Expected behavior
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -103,7 +103,9 @@ labels: 'issue: bug, needs triage'
 
 (Write your steps here:)
 
-1. 2. 3.
+1.
+2.
+3.
 
 ### Expected behavior
 

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,7 +1,7 @@
 ---
 name: Proposal
 about: Suggest an idea for improving Create React App
-labels: 'issue: proposal'
+labels: 'issue: proposal, needs triage'
 ---
 
 ### Is your proposal related to a problem?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,13 @@
+---
+name: Question
+about: Get help with Create React App
+labels: 'needs triage'
+---
+
+If you have a general question about Create React App or about building an app with Create React App we encourage you to post on our Spectrum community instead of this issue tracker. The maintainers and other community members can provide help and answer your questions there: https://spectrum.chat/create-react-app
+
+If you're looking for general information on using React, the React docs have a list of resources: https://reactjs.org/community/support.html
+
+If you've discovered a bug or would like to propose a change please use one of the other issue templates.
+
+Thanks!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+---
+labels: 'needs triage'
+---
+
 <!--
 Thank you for sending the PR!
 


### PR DESCRIPTION
Add a new question issue template that directs users to Spectrum.

I also added a new `needs triage` label to the existing issue templates.