### PR TITLE
Add explicit check for --watchAll=false

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -57,7 +57,8 @@ function isInMercurialRepository() {
 // Watch unless on CI or explicitly running all tests
 if (
   !process.env.CI &&
-  argv.indexOf('--watchAll') === -1
+  argv.indexOf('--watchAll') === -1 &&
+  argv.indexOf('--watchAll=false') === -1
 ) {
   // https://github.com/facebook/create-react-app/issues/5210
   const hasSourceControl = isInGitRepository() || isInMercurialRepository();


### PR DESCRIPTION
Resolves #7180.

All tests are currently exiting with a `0` code, regardless of failures. This causes issues in CI environment and Git hooks.
