### PR TITLE
Add a `url` and a `extraScript` parameter to `createNoopServiceWorkerMiddleware`

### DIFF
--- a/packages/react-dev-utils/README.md
+++ b/packages/react-dev-utils/README.md
@@ -287,9 +287,9 @@ getProcessForPort(3000);
 
 On macOS, tries to find a known running editor process and opens the file in it. It can also be explicitly configured by `REACT_EDITOR`, `VISUAL`, or `EDITOR` environment variables. For example, you can put `REACT_EDITOR=atom` in your `.env.local` file, and Create React App will respect that.
 
-#### `noopServiceWorkerMiddleware(): ExpressMiddleware`
+#### `noopServiceWorkerMiddleware(url: string, extraScript: string): ExpressMiddleware`
 
-Returns Express middleware that serves a `/service-worker.js` that resets any previously set service worker configuration. Useful for development.
+Returns Express middleware that serves a service worker file at `url` (defaults to `/service-worker.js`) that resets any previously set service worker configuration. `extraScript` will be appended to the end of the file. Useful for development.
 
 #### `openBrowser(url: string): boolean`
 

--- a/packages/react-dev-utils/noopServiceWorkerMiddleware.js
+++ b/packages/react-dev-utils/noopServiceWorkerMiddleware.js
@@ -7,7 +7,10 @@
 
 'use strict';
 
-module.exports = function createNoopServiceWorkerMiddleware(url = '/service-worker.js') {
+module.exports = function createNoopServiceWorkerMiddleware(
+  url = '/service-worker.js',
+  extraScript
+) {
   return function noopServiceWorkerMiddleware(req, res, next) {
     if (req.url === url) {
       res.setHeader('Content-Type', 'text/javascript');
@@ -29,6 +32,7 @@ self.addEventListener('activate', () => {
     }
   });
 });
+${extraScript}
 `
       );
     } else {

--- a/packages/react-dev-utils/noopServiceWorkerMiddleware.js
+++ b/packages/react-dev-utils/noopServiceWorkerMiddleware.js
@@ -9,7 +9,7 @@
 
 module.exports = function createNoopServiceWorkerMiddleware(
   url = '/service-worker.js',
-  extraScript
+  extraScript = ''
 ) {
   return function noopServiceWorkerMiddleware(req, res, next) {
     if (req.url === url) {

--- a/packages/react-dev-utils/noopServiceWorkerMiddleware.js
+++ b/packages/react-dev-utils/noopServiceWorkerMiddleware.js
@@ -7,9 +7,9 @@
 
 'use strict';
 
-module.exports = function createNoopServiceWorkerMiddleware() {
+module.exports = function createNoopServiceWorkerMiddleware(url = '/service-worker.js') {
   return function noopServiceWorkerMiddleware(req, res, next) {
-    if (req.url === '/service-worker.js') {
+    if (req.url === url) {
       res.setHeader('Content-Type', 'text/javascript');
       res.send(
         `// This service worker file is effectively a 'no-op' that will reset any


### PR DESCRIPTION
Sometimes an app's service worker might not be named `/service-worker.js`. It would be useful to allow developers to customize the url/filename for the no-op service worker. (Since `url` parameter will be default to `'/service-worker.js'`, there will be no change in current app's behavior.)

Also, the developers may want to includes additional code (such as a `importScripts`) in the service worker during development. A `extraScript` parameter would be very helpful in this case.