### PR TITLE
Fix for #6720: HMR not working in Firefox if proxy option present

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -361,10 +361,14 @@ function prepareProxy(proxy, appPublicFolder) {
     process.exit(1);
   }
 
-  // If proxy is specified, let it handle any request except for files in the public folder.
+  // If proxy is specified, let it handle any request except for
+  // files in the public folder and requests to the WebpackDevServer socket endpoint.
+  // https://github.com/facebook/create-react-app/issues/6720
   function mayProxy(pathname) {
     const maybePublicPath = path.resolve(appPublicFolder, pathname.slice(1));
-    return !fs.existsSync(maybePublicPath);
+    const isPublicFileRequest = fs.existsSync(maybePublicPath);
+    const isWdsEndpointRequest = pathname.startsWith('/sockjs-node'); // used by webpackHotDevClient
+    return !(isPublicFileRequest || isWdsEndpointRequest);
   }
 
   if (!/^http(s)?:\/\//.test(proxy)) {


### PR DESCRIPTION
Original issue: #6720 
Root cause: https://github.com/sockjs/sockjs-client/issues/474#issuecomment-482918785
This is a PR for naive idea how to fix it: https://github.com/facebook/create-react-app/issues/6720#issuecomment-484034646