### PR TITLE
[optimize-react] Optimize preset-env integration

### DIFF
--- a/packages/babel-plugin-optimize-react/__tests__/__snapshots__/hooks-test.js.snap
+++ b/packages/babel-plugin-optimize-react/__tests__/__snapshots__/hooks-test.js.snap
@@ -7,10 +7,10 @@ const {
   useState
 } = React;
 export function MyComponent() {
-  const _ref_0 = useState(0);
+  const _ref_ = useState(0);
 
-  const setCounter = _ref_0[1];
-  const counter = _ref_0[0];
+  const setCounter = _ref_[1];
+  const counter = _ref_[0];
   return __reactCreateElement__(\\"div\\", null, counter);
 }"
 `;
@@ -20,10 +20,10 @@ exports[`React hook transforms should support destructuring hooks from imports #
 const __reactCreateElement__ = React.createElement;
 const useState = React.useState;
 export function MyComponent() {
-  const _ref_0 = useState(0);
+  const _ref_ = useState(0);
 
-  const setCounter = _ref_0[1];
-  const counter = _ref_0[0];
+  const setCounter = _ref_[1];
+  const counter = _ref_[0];
   return __reactCreateElement__(\\"div\\", null, counter);
 }"
 `;
@@ -33,10 +33,10 @@ exports[`React hook transforms should support destructuring hooks from imports #
 const __reactCreateElement__ = React.createElement;
 const foo = React.useState;
 export function MyComponent() {
-  const _ref_0 = foo(0);
+  const _ref_ = foo(0);
 
-  const setCounter = _ref_0[1];
-  const counter = _ref_0[0];
+  const setCounter = _ref_[1];
+  const counter = _ref_[0];
   return __reactCreateElement__(\\"div\\", null, counter);
 }"
 `;
@@ -48,10 +48,10 @@ const {
   useState: foo
 } = React;
 export function MyComponent() {
-  const _ref_0 = foo(0);
+  const _ref_ = foo(0);
 
-  const setCounter = _ref_0[1];
-  const counter = _ref_0[0];
+  const setCounter = _ref_[1];
+  const counter = _ref_[0];
   return __reactCreateElement__(\\"div\\", null, counter);
 }"
 `;
@@ -63,10 +63,10 @@ const {
   useState
 } = React;
 export function MyComponent() {
-  const _ref_0 = useState(0);
+  const _ref_ = useState(0);
 
-  const setCounter = _ref_0[1];
-  const counter = _ref_0[0];
+  const setCounter = _ref_[1];
+  const counter = _ref_[0];
   return __reactCreateElement__(\\"div\\", null, counter);
 }"
 `;
@@ -79,10 +79,10 @@ const {
   useState
 } = React;
 export function MyComponent() {
-  const _ref_0 = useState(0);
+  const _ref_ = useState(0);
 
-  const setCounter = _ref_0[1];
-  const counter = _ref_0[0];
+  const setCounter = _ref_[1];
+  const counter = _ref_[0];
   return __reactCreateElement__(\\"div\\", null, counter);
 }"
 `;
@@ -99,23 +99,14 @@ var _react = _interopRequireDefault(require(\\"react\\"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError(\\"Invalid attempt to destructure non-iterable instance\\"); }
-
-function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i[\\"return\\"] != null) _i[\\"return\\"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
 var __reactCreateElement__ = _react.default.createElement;
 var useState = _react.default.useState;
 
 function MyComponent() {
-  var _useState = useState(0),
-      _useState2 = _slicedToArray(_useState, 2),
-      counter = _useState2[0],
-      setCounter = _useState2[1];
+  var _ref_ = useState(0);
 
+  var setCounter = _ref_[1];
+  var counter = _ref_[0];
   return __reactCreateElement__(\\"div\\", null, counter);
 }"
 `;

--- a/packages/babel-plugin-optimize-react/__tests__/__snapshots__/hooks-test.js.snap
+++ b/packages/babel-plugin-optimize-react/__tests__/__snapshots__/hooks-test.js.snap
@@ -87,6 +87,39 @@ export function MyComponent() {
 }"
 `;
 
+exports[`React hook transforms should support destructuring hooks while using transform-destructuring 1`] = `
+"\\"use strict\\";
+
+Object.defineProperty(exports, \\"__esModule\\", {
+  value: true
+});
+exports.MyComponent = MyComponent;
+
+var _react = _interopRequireDefault(require(\\"react\\"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError(\\"Invalid attempt to destructure non-iterable instance\\"); }
+
+function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i[\\"return\\"] != null) _i[\\"return\\"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+var __reactCreateElement__ = _react.default.createElement;
+var useState = _react.default.useState;
+
+function MyComponent() {
+  var _useState = useState(0),
+      _useState2 = _slicedToArray(_useState, 2),
+      counter = _useState2[0],
+      setCounter = _useState2[1];
+
+  return __reactCreateElement__(\\"div\\", null, counter);
+}"
+`;
+
 exports[`React hook transforms should support hook CJS require with no default 1`] = `
 "const {
   useState

--- a/packages/babel-plugin-optimize-react/__tests__/hooks-test.js
+++ b/packages/babel-plugin-optimize-react/__tests__/hooks-test.js
@@ -3,8 +3,10 @@
 const plugin = require('../index.js');
 const babel = require('@babel/core');
 
-function transform(code) {
+function transform(code, options = {}) {
+  const { presets } = options;
   return babel.transform(code, {
+    presets,
     plugins: [plugin],
   }).code;
 }
@@ -155,6 +157,22 @@ describe('React hook transforms', () => {
       export const Portal = memo(() => null);
     `;
     const output = transform(test);
+    expect(output).toMatchSnapshot();
+  });
+
+  it.only('should support destructuring hooks while using transform-destructuring', () => {
+    const test = `
+      import React, {useState} from "react";
+
+      export function MyComponent() {
+        const [counter, setCounter] = useState(0);
+
+        return React.createElement("div", null, counter);
+      }
+    `;
+    const output = transform(test, {
+      presets: [['@babel/preset-env', { targets: { ie: '11' } }]],
+    });
     expect(output).toMatchSnapshot();
   });
 });

--- a/packages/babel-plugin-optimize-react/__tests__/hooks-test.js
+++ b/packages/babel-plugin-optimize-react/__tests__/hooks-test.js
@@ -160,7 +160,7 @@ describe('React hook transforms', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it.only('should support destructuring hooks while using transform-destructuring', () => {
+  it('should support destructuring hooks while using transform-destructuring', () => {
     const test = `
       import React, {useState} from "react";
 

--- a/packages/babel-plugin-optimize-react/index.js
+++ b/packages/babel-plugin-optimize-react/index.js
@@ -309,10 +309,10 @@ module.exports = function(babel) {
         for (let i = 0; i < node.declarations.length; i++) {
           const parentPath = declarationPath.get('declarations')[i];
           const path = parentPath.get('init');
-          const calleePath = path.get('callee');
           if (
+            t.isCallExpression(path) &&
             isUsingDestructuredArray(path) &&
-            isReferencingReactHook(calleePath)
+            isReferencingReactHook(path.get('callee'))
           ) {
             const id = parentPath.get('id');
             const elements = id.get('elements');

--- a/packages/babel-plugin-optimize-react/package.json
+++ b/packages/babel-plugin-optimize-react/package.json
@@ -15,6 +15,7 @@
     "@babel/core": "^7.1.0"
   },
   "devDependencies": {
+    "@babel/preset-env": "7.2.3",
     "jest": "^23.6.0",
     "prettier": "^1.15.3"
   },


### PR DESCRIPTION
Fixes unoptimized destructuring when used with `@babel/preset-env`

Before:
```js
"use strict";

Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.MyComponent = MyComponent;

var _react = _interopRequireDefault(require("react"));

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }

function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _nonIterableRest(); }

function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance"); }

function _iterableToArrayLimit(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }

function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }

var __reactCreateElement__ = _react["default"].createElement;
var useState = _react["default"].useState;

function MyComponent() {
  var _useState = useState(0),
      _useState2 = _slicedToArray(_useState, 2),
      counter = _useState2[0],
      setCounter = _useState2[1];

  return __reactCreateElement__("div", null, counter);
}
```

After:
```js
""use strict";

Object.defineProperty(exports, "__esModule", {
  value: true
});
exports.MyComponent = MyComponent;

var _react = _interopRequireDefault(require("react"));

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

var __reactCreateElement__ = _react.default.createElement;
var useState = _react.default.useState;

function MyComponent() {
  var _ref_ = useState(0);

  var setCounter = _ref_[1];
  var counter = _ref_[0];
  return __reactCreateElement__("div", null, counter);
}
```

The problem is how babel runs plugins. While it does run plugins before presets it only does so per node. Since plugins are applied while traversing down (guess) and `transform-destructuring` runs on `VariableDeclaration` `transform-destructuring` is applied before `optimize-react` (which runs on `CallExpression` which is a child in the targetted ASTs). By moving `optimize-react` to the same level as `transform-destructuring` we can guarantee for this plugin that the plugin is applied before the preset. 

This change includes using `scope.generateUidIdentifier` instead of handcrafting an identifier from state. Even if the fix is rejected this refactoring should be considered since it is technically possible to create variable collisions with the previous approach.
