### PR TITLE
Typescript init: suggest `jsx: "react"` in tsconfig 

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -125,9 +125,8 @@ function verifyTypeScriptSetup() {
     isolatedModules: { value: true, reason: 'implementation limitation' },
     noEmit: { value: true },
     jsx: {
-      parsedValue: ts.JsxEmit.Preserve,
-      value: 'preserve',
-      reason: 'JSX is compiled by Babel',
+      parsedValue: ts.JsxEmit.React,
+      suggested: 'react',
     },
     paths: { value: undefined, reason: 'aliased imports are not supported' },
   };


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Transpilation is done by Babel, which ignores the tsconfig, so this setting (or any tsconfig setting) doesn't affect compilation, only type checking.

Setting it to `react` raises a type error if react is not imported, and gives a quick fix to import react. The linter rule does not give a quick fix.

![image](https://user-images.githubusercontent.com/19603573/62417666-ec37de00-b61a-11e9-84c1-daa931a423fe.png)

I've set it to _suggest_ the value `react` instead of forcing it, because people might need to set it to something else in their project for whatever reason.

Verified that it works by cloning create-react-app from master, installing the local versions, and using it to compile a personal project. Setting `"jsx": "react"` does not affect the build size or content.

![image](https://user-images.githubusercontent.com/19603573/62417690-c232eb80-b61b-11e9-8a75-ab49ec393cd6.png)
