### PR TITLE
Fix notations of loopback addresses

### DIFF
--- a/packages/react-scripts/template-typescript/src/serviceWorker.ts
+++ b/packages/react-scripts/template-typescript/src/serviceWorker.ts
@@ -14,7 +14,7 @@ const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
     // [::1] is the IPv6 localhost address.
     window.location.hostname === '[::1]' ||
-    // 127.0.0.1/8 is considered localhost for IPv4.
+    // 127.0.0.0/8 are considered localhost for IPv4.
     window.location.hostname.match(
       /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
     )

--- a/packages/react-scripts/template/src/serviceWorker.js
+++ b/packages/react-scripts/template/src/serviceWorker.js
@@ -14,7 +14,7 @@ const isLocalhost = Boolean(
   window.location.hostname === 'localhost' ||
     // [::1] is the IPv6 localhost address.
     window.location.hostname === '[::1]' ||
-    // 127.0.0.1/8 is considered localhost for IPv4.
+    // 127.0.0.0/8 are considered localhost for IPv4.
     window.location.hostname.match(
       /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
     )


### PR DESCRIPTION
`127.0.0.1/8` refers to only a single IPv4 address "127.0.0.1" that have the subnet mask 255.255.255.0, but doesn't to 127.0.0.2.
`127.0.0.0/8`, which is the exact definition of the loopback addresses [[1]][[2]], includes what the regex says (127.0.0.0-127.255.255.255).

[1]: https://tools.ietf.org/html/rfc1122
[2]: https://tools.ietf.org/html/rfc6890

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
