### PR TITLE
Specify roots in Jest config

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -23,6 +23,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
     : undefined;
 
   const config = {
+    roots: ['<rootDir>/src'],
+
     collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!src/**/*.d.ts'],
 
     setupFiles: [


### PR DESCRIPTION
This PR fixes #7458 by adding `roots` to Jest configuration. I wanted to add test but didn't found any for Jest configuration. Please let me know what else should I add.