### PR TITLE
Adjusted deployment documentation for ZEIT Now

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -458,7 +458,7 @@ You can deploy your application by running the following command in the root of 
 now
 ```
 
-**Alternatively**, you can also use their integration [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab).
+**Alternatively**, you can also use their integration for [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab).
 
 That’s all!
 

--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -464,7 +464,7 @@ That’s all!
 
 Your site will now deploy, and you will receive a link similar to the following: https://react.now-examples.now.sh
 
-Out of the box, you are already provided with the necessary routes for rewriting requests (except for custom static files) directly to your `index.html` file and the appropiate default caching headers. This behaviour can be overwritten [like this](https://zeit.co/docs/v2/advanced/routes/).
+Out of the box, you are preconfigured for client-side routing compatibility and appropriate default caching headers. This behaviour can be overwritten [like this](https://zeit.co/docs/v2/advanced/routes/).
 
 ## [Render](https://render.com)
 

--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -436,27 +436,35 @@ To support `pushState`, make sure to create a `public/_redirects` file with the 
 
 When you build the project, Create React App will place the `public` folder contents into the build output.
 
-## [Now](https://zeit.co/now)
+## [ZEIT Now](https://zeit.co)
 
-[Now](https://zeit.co/docs) offers a simple, single-command deployment. You can use `now` to deploy your app for free.
+[ZEIT Now](https://zeit.co) is a cloud platform for websites and serverless APIs, that you can use to deploy your Create React App projects to your personal domain (or a free `.now.sh` suffixed URL).
 
-The first step is to install Now. You can do this by installing [the Now Desktop app](https://zeit.co/download), which also installs Now CLI and keeps it up-to-date, or by [installing Now CLI](https://zeit.co/download#now-cli) directly with npm:
+This guide will show you how to get started in a few quick steps:
+
+### Step 1: Installing Now CLI
+
+To install their command-line interface with [npm](https://www.npmjs.com/package/now), run the following command:
 
 ```shell
 npm i -g now
 ```
 
-To deploy your built project directly with Now CLI in your terminal, without any configuration:
+### Step 2: Deploying
 
-1. Build your app by running `npm run build`.
+You can deploy your application by running the following command in the root of the project directory:
 
-2. Move into the build directory by running `cd build`.
+```shell
+now
+```
 
-3. Run `now --name your-project-name` from within the build directory. You will be given a **now.sh** URL as a response as your build is deployed, similar to the following: https://my-cra-project-4rx7b16z3.now.sh/
+**Alternatively**, you can also use their integration [GitHub](https://zeit.co/github) or [GitLab](https://zeit.co/gitlab).
 
-Click or paste the deployment URL into your browser when the build is complete and you will see your deployed app.
+That’s all!
 
-For more information on deploying React applications with Now, including automatically building your application fresh in the cloud, setting up routes to rewrite all paths to the index.html file, and setting up caching headers for speed, see [the ZEIT Guide for Deploying a React app with Create React App](https://zeit.co/guides/deploying-react-with-now-cra/).
+Your site will now deploy, and you will receive a link similar to the following: https://react.now-examples.now.sh
+
+Out of the box, you are already provided with the necessary routes for rewriting requests (except for custom static files) directly to your `index.html` file and the appropiate default caching headers. This behaviour can be overwritten [like this](https://zeit.co/docs/v2/advanced/routes/).
 
 ## [Render](https://render.com)
 


### PR DESCRIPTION
Now that ZEIT has launched [zero config deployments](https://twitter.com/zeithq/status/1159145442896166912), deploying a Create React App site is now much easier:

![image](https://user-images.githubusercontent.com/6170607/62698856-76e35900-b9de-11e9-8577-d3197064d578.png)
