### PR TITLE
Using yarn vs npm with typescript docs

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -38,6 +38,8 @@ To learn more about TypeScript, check out [its documentation](https://www.typesc
 > **Note:** If your project is not created with TypeScript enabled, npx may be using a cached version of `create-react-app`.
 > Remove previously installed versions with `npm uninstall -g create-react-app` (see [#6119](https://github.com/facebook/create-react-app/issues/6119#issuecomment-451614035)).
 
+> **Note:** If you want to use your own TypeScript version, use yarn instead of npm, otherwise create react app will use internal version.  
+
 > **Note:** You are not required to make a [`tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html), one will be made for you.
 > You are allowed to edit the generated TypeScript configuration.
 


### PR DESCRIPTION
When we want to use other TypeScript version and we do:
`npm install typescript@3.5.3 -D` 
But when we use new features like const casting https://github.com/Microsoft/TypeScript/pull/29510 it does not compile.
Instead of that if we use:
`yarn add typescript@3.5.3`
Everything works

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
