### PR TITLE
Fix ESLint 6 support

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -47,7 +47,7 @@ Note that any rules set to `"error"` will stop the project from building.
 
 There are a few things to remember:
 
-1. You must extend the base config, as removing it could introduce hard-to-find issues.
+1. We highly recommend extending the base config, as removing it could introduce hard-to-find issues.
 1. When working with TypeScript, you'll need to provide an `overrides` object for rules that should _only_ target TypeScript files.
 
 In the below example:

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -340,21 +340,12 @@ module.exports = function(webpackEnv) {
                 // @remove-on-eject-begin
                 baseConfig: (() => {
                   const eslintCli = new eslint.CLIEngine();
-                  let eslintConfig;
-                  try {
-                    eslintConfig = eslintCli.getConfigForFile(paths.appIndexJs);
-                  } catch (e) {
-                    // A config couldn't be found.
-                  }
+                  const eslintConfig = eslintCli.getConfigForFile(
+                    paths.appIndexJs
+                  );
 
-                  // We allow overriding the config, only if it extends our config
-                  // (`extends` can be a string or array of strings).
-                  if (
-                    process.env.EXTEND_ESLINT &&
-                    eslintConfig &&
-                    eslintConfig.extends &&
-                    eslintConfig.extends.includes('react-app')
-                  ) {
+                  // We allow overriding the config only if the env variable is set
+                  if (process.env.EXTEND_ESLINT && eslintConfig) {
                     return eslintConfig;
                   } else {
                     return {

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -340,9 +340,12 @@ module.exports = function(webpackEnv) {
                 // @remove-on-eject-begin
                 baseConfig: (() => {
                   const eslintCli = new eslint.CLIEngine();
-                  const eslintConfig = eslintCli.getConfigForFile(
-                    paths.appIndexJs
-                  );
+                  let eslintConfig;
+                  try {
+                    eslintConfig = eslintCli.getConfigForFile(paths.appIndexJs);
+                  } catch (e) {
+                    // A config couldn't be found.
+                  }
 
                   // We allow overriding the config only if the env variable is set
                   if (process.env.EXTEND_ESLINT && eslintConfig) {


### PR DESCRIPTION
Fixes #7510.

`extends` is no longer available in ESLint 6.