### PR TITLE
Show logo for mobile views in create-react-app.dev

### DIFF
--- a/docusaurus/website/static/css/custom.css
+++ b/docusaurus/website/static/css/custom.css
@@ -32,6 +32,9 @@
 .headerTitleWithLogo {
   white-space: nowrap;
 }
+.projectLogo {
+  display: block;
+}
 
 @media only screen and (min-device-width: 360px) and (max-device-width: 736px) {
 }

--- a/docusaurus/website/static/css/custom.css
+++ b/docusaurus/website/static/css/custom.css
@@ -32,6 +32,7 @@
 .headerTitleWithLogo {
   white-space: nowrap;
 }
+
 .projectLogo {
   display: block;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
This PR fixes issue #7517 
Create react is not being displayed in create-react-app.dev page because docusaurus by default hides the logo for mobile view. Fix here involves displaying the the logo for all the resolutions. [https://github.com/facebook/docusaurus/blob/bd72aacfe85c2e239d6d92486850b5a229cda836/packages/docusaurus-1.x/lib/static/css/main.css#L592](Info)
<img width="379" alt="Screen Shot 2019-08-13 at 1 53 41 PM" src="https://user-images.githubusercontent.com/20091277/62927144-8f36e780-bdd3-11e9-9b90-b19d3b2b736f.png">

