### PR TITLE
The variable dotenvFiles is never reassigned - use const instead

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -23,7 +23,7 @@ if (!NODE_ENV) {
 }
 
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
-var dotenvFiles = [
+const dotenvFiles = [
   `${paths.dotenv}.${NODE_ENV}.local`,
   `${paths.dotenv}.${NODE_ENV}`,
   // Don't include `.env.local` for `test` environment


### PR DESCRIPTION
The variable `dotenvFiles` is never reassigned - use const instead.

The rest of the file already makes use of const - so this change makes it more consistent.