### PR TITLE
Upgrade dotenv-expand to fix issues

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -41,7 +41,7 @@
     "case-sensitive-paths-webpack-plugin": "2.2.0",
     "css-loader": "2.1.1",
     "dotenv": "6.2.0",
-    "dotenv-expand": "4.2.0",
+    "dotenv-expand": "5.1.0",
     "eslint": "^6.1.0",
     "eslint-config-react-app": "^5.0.1",
     "eslint-loader": "2.2.1",


### PR DESCRIPTION
Hi,

This fixes issues #4002 and #5833. Fixes #7577.

Essentially if a `.env` has an override which is an empty string, it is ignored. This was fixed by https://github.com/motdotla/dotenv-expand/issues/18