### PR TITLE
Explicitly checking that EXTEND_ESLINT is true

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -348,7 +348,7 @@ module.exports = function(webpackEnv) {
                   }
 
                   // We allow overriding the config only if the env variable is set
-                  if (process.env.EXTEND_ESLINT && eslintConfig) {
+                  if (process.env.EXTEND_ESLINT === 'true' && eslintConfig) {
                     return eslintConfig;
                   } else {
                     return {


### PR DESCRIPTION
The documentation for the new EXTEND_ESLINT env variable says it applies `When set to true` but the code only checks existence of the variable.

Setting `EXTEND_ESLINT=false` still enables extending eslint since `process.env.EXTEND_ESLINT` is technically set.

This PR just checks that `process.env.EXTEND_ESLINT === 'true'`