### PR TITLE
docs: update Flow documentation

### DIFF
--- a/docusaurus/docs/adding-flow.md
+++ b/docusaurus/docs/adding-flow.md
@@ -14,7 +14,8 @@ To add Flow to a Create React App project, follow these steps:
 3. Run `npm run flow init` (or `yarn flow init`) to create a [`.flowconfig` file](https://flow.org/en/docs/config/) in the root directory.
 4. Add `// @flow` to any files you want to type check (for example, to `src/App.js`).
 
-Now you can run `npm run flow` (or `yarn flow`) to check the files for type errors. You can optionally enable an extension for your IDE, such as [Flow Language Support](https://github.com/flowtype/flow-for-vscode) for Visual Studio Code, or leverage the Language Server Protocol standard (e.g. [vim LSP](https://github.com/prabirshrestha/vim-lsp/wiki/Servers-Flow)) to get hints while you type.
+Now you can run `npm run flow` (or `yarn flow`) to check the files for type errors.  
+You can optionally enable an extension for your IDE, such as [Flow Language Support](https://github.com/flowtype/flow-for-vscode) for Visual Studio Code, or leverage the Language Server Protocol standard (e.g. [vim LSP](https://github.com/prabirshrestha/vim-lsp/wiki/Servers-Flow)) to get hints while you type.
 
 If you'd like to use [absolute imports](/docs/importing-a-component#absolute-imports) with Flow,
 make sure to add the following line to your `.flowconfig` to make Flow aware of it:

--- a/docusaurus/docs/adding-flow.md
+++ b/docusaurus/docs/adding-flow.md
@@ -16,7 +16,7 @@ To add Flow to a Create React App project, follow these steps:
 
 Now you can run `npm run flow` (or `yarn flow`) to check the files for type errors. You can optionally enable an extension for your IDE, such as [Flow Language Support](https://github.com/flowtype/flow-for-vscode) for Visual Studio Code, or leverage the Language Server Protocol standard (e.g. [vim LSP](https://github.com/prabirshrestha/vim-lsp/wiki/Servers-Flow)) to get hints while you type.
 
-If you'd like to use [absolute imports](https://create-react-app.dev/docs/importing-a-component#absolute-imports) with Flow,
+If you'd like to use [absolute imports](/docs/importing-a-component#absolute-imports) with Flow,
 make sure to add the following line to your `.flowconfig` to make Flow aware of it:
 
 ```diff

--- a/docusaurus/docs/adding-flow.md
+++ b/docusaurus/docs/adding-flow.md
@@ -14,8 +14,14 @@ To add Flow to a Create React App project, follow these steps:
 3. Run `npm run flow init` (or `yarn flow init`) to create a [`.flowconfig` file](https://flow.org/en/docs/config/) in the root directory.
 4. Add `// @flow` to any files you want to type check (for example, to `src/App.js`).
 
-Now you can run `npm run flow` (or `yarn flow`) to check the files for type errors.
-You can optionally use an IDE like [Nuclide](https://nuclide.io/docs/languages/flow/) for a better integrated experience.
-In the future we plan to integrate it into Create React App even more closely.
+Now you can run `npm run flow` (or `yarn flow`) to check the files for type errors. You can optionally enable an extension for your IDE, such as [Flow Language Support](https://github.com/flowtype/flow-for-vscode) for Visual Studio Code, or leverage the Language Server Protocol standard (e.g. [vim LSP](https://github.com/prabirshrestha/vim-lsp/wiki/Servers-Flow)) to get hints while you type.
+
+If you'd like to use [absolute imports](https://create-react-app.dev/docs/importing-a-component#absolute-imports) with Flow,
+make sure to add the following line to your `.flowconfig` to make Flow aware of it:
+
+```diff
+  [options]
++ module.name_mapper='^\(.*\)$' -> '<PROJECT_ROOT>/src/\1'
+```
 
 To learn more about Flow, check out [its documentation](https://flow.org/).


### PR DESCRIPTION
Nuclide is discontinued, so I provided some alternatives.

Also, I let the users know they need to tweak their `.flowconfig` to make the absolute imports work with Flow.