### PR TITLE
fixing typo when running with yarn

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -14,7 +14,7 @@ npx create-react-app my-app --typescript
 
 # or
 
-yarn create react-app my-app --typescript
+yarn create-react-app my-app --typescript
 ```
 
 > If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that `npx` always uses the latest version.


### PR DESCRIPTION
from `yarn create react-app --typescript` to `yarn create-react-app --typescript`. Added missing dash `-` after `yarn create`.
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
