### PR TITLE
Added back the crossOriginLoading 'anonymous' in config

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -184,6 +184,10 @@ module.exports = function(webpackEnv) {
         : isEnvDevelopment && 'static/js/bundle.js',
       // TODO: remove this when upgrading to webpack 5
       futureEmitAssets: true,
+      // Given Webpack supports codesplit and production bundles are using 
+      // subresource integrity, it's important to make sure the attribute
+      // set on async-loaded chunks is set to anonymous.
+      crossOriginLoading: 'anonymous',
       // There are also additional JS chunk files if you use code splitting.
       chunkFilename: isEnvProduction
         ? 'static/js/[name].[contenthash:8].chunk.js'


### PR DESCRIPTION
Not sure why this was removed, but it is necessary for production when target is web, which uses JSONP for loading on-demand chunks, by adding script tags.

This has been in the codebase previously, but seems to be removed. Check the old PR here: https://github.com/facebook/create-react-app/pull/1181

Any reason why it got removed?

> Normal script elements pass minimal information to the window.onerror for scripts which do not pass the standard CORS checks. To allow error logging for sites which use a separate domain for static media, use the crossorigin attribute. See CORS settings attributes for a more descriptive explanation of its valid arguments.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
