### PR TITLE
Minor performance improvements

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -334,6 +334,7 @@ module.exports = function(webpackEnv) {
           use: [
             {
               options: {
+                cache: true,
                 formatter: require.resolve('react-dev-utils/eslintFormatter'),
                 eslintPath: require.resolve('eslint'),
                 resolvePluginsRelativeTo: __dirname,
@@ -673,7 +674,7 @@ module.exports = function(webpackEnv) {
           }),
           async: isEnvDevelopment,
           useTypescriptIncrementalApi: true,
-          checkSyntacticErrors: true,
+          checkSyntacticErrors: false,
           resolveModuleNameModule: process.versions.pnp
             ? `${__dirname}/pnpTs.js`
             : undefined,
@@ -688,7 +689,6 @@ module.exports = function(webpackEnv) {
             '!**/src/setupProxy.*',
             '!**/src/setupTests.*',
           ],
-          watch: paths.appSrc,
           silent: true,
           // The formatter is invoked directly in WebpackDevServerUtils during development
           formatter: isEnvProduction ? typescriptFormatter : undefined,

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -674,7 +674,7 @@ module.exports = function(webpackEnv) {
           }),
           async: isEnvDevelopment,
           useTypescriptIncrementalApi: true,
-          checkSyntacticErrors: false,
+          checkSyntacticErrors: true,
           resolveModuleNameModule: process.versions.pnp
             ? `${__dirname}/pnpTs.js`
             : undefined,


### PR DESCRIPTION
**Enable ESLint cache:**
We discovered that enabling the ESLint cache can reduce the time for full rebuild. In our project, the time for a warm start decreased from 20 seconds to 17 seconds.

**Disable syntactic errors check:**
According to [documentation](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#options), `fork-ts-checker` can check for syntactic errors. This is basically useless for us as Babel already report those errors.

**Remove useless `watch` option:**
According to [documentation](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#options), `fork-ts-checker` ignores the `watch` option when `useTypescriptIncrementalApi: true`. 
