### PR TITLE
Use 'dev' flag for http-proxy-middleware install

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -75,9 +75,9 @@ You can use this feature in conjunction with the `proxy` property in `package.js
 First, install `http-proxy-middleware` using npm or Yarn:
 
 ```sh
-$ npm install http-proxy-middleware --save
+$ npm install http-proxy-middleware --save-dev
 $ # or
-$ yarn add http-proxy-middleware
+$ yarn add http-proxy-middleware --dev
 ```
 
 Next, create `src/setupProxy.js` and place the following contents in it:


### PR DESCRIPTION
The instructions for installing http-proxy-middleware leave the package installed in the package.json "dependencies" section.  I believe this dependency belongs in "devDependencies."  It's working for me as such.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
