### PR TITLE
Remove deprecated instruction

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -190,9 +190,6 @@ yarn add @testing-library/react @testing-library/jest-dom
 Similar to `enzyme` you can create a `src/setupTests.js` file to avoid boilerplate in your test files:
 
 ```js
-// react-testing-library renders your components to document.body,
-// this will ensure they're removed after each test.
-import '@testing-library/react/cleanup-after-each';
 // this adds jest-dom's custom assertions
 import '@testing-library/jest-dom/extend-expect';
 ```


### PR DESCRIPTION
From the @testing-library docs: The module `@testing-library/react/cleanup-after-each` has been deprecated and no longer does anything (it is not needed). You no longer need to import this module and can safely remove any import or configuration which imports this module.

Previous console warning: 
<img width="473" alt="warning-from-testing-lib" src="https://user-images.githubusercontent.com/4689228/64065799-bcafcd80-cbe8-11e9-99bc-6db9b29285ae.png">

