### PR TITLE
Make react-app-polyfill work in WebWorker environment

### DIFF
--- a/packages/react-app-polyfill/ie11.js
+++ b/packages/react-app-polyfill/ie11.js
@@ -11,12 +11,16 @@ if (typeof Promise === 'undefined') {
   // inconsistent state due to an error, but it gets swallowed by a Promise,
   // and the user has no idea what causes React's erratic future behavior.
   require('promise/lib/rejection-tracking').enable();
-  window.Promise = require('promise/lib/es6-extensions.js');
+  if (typeof window !== 'undefined') {
+    window.Promise = require('promise/lib/es6-extensions.js');
+  } else if (typeof self !== 'undefined') {
+    self.Promise = require('promise/lib/es6-extensions.js');
+  }
 }
 
 // Make sure we're in a Browser-like environment before importing polyfills
 // This prevents `fetch()` from being imported in a Node test environment
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined' || typeof self !== 'undefined') {
   // fetch() polyfill for making API calls.
   require('whatwg-fetch');
 }

--- a/packages/react-app-polyfill/ie9.js
+++ b/packages/react-app-polyfill/ie9.js
@@ -11,4 +11,7 @@ require('./ie11');
 // React 16+ relies on Map, Set, and requestAnimationFrame
 require('core-js/features/map');
 require('core-js/features/set');
-require('raf').polyfill(window);
+
+if (typeof window !== 'undefined') {
+  require('raf').polyfill(window);
+}


### PR DESCRIPTION
Fixes #7627 

I like to provide this Pull Request as a proposal for my issue about using the polyfills inside a `WebWorker`.

The changes I made extend the checks for the `window` objects by a check for the `self` object. And also disable the `raf` polyfill when no window object is defined. (Since a WebWorker should not require `AnimationFrames`...)