### PR TITLE
Disable babel-loader's cacheCompression

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -429,7 +429,8 @@ module.exports = function(webpackEnv) {
                 // It enables caching results in ./node_modules/.cache/babel-loader/
                 // directory for faster rebuilds.
                 cacheDirectory: true,
-                cacheCompression: isEnvProduction,
+                // See #6846 for context on why cacheCompression is disabled
+                cacheCompression: false,
                 compact: isEnvProduction,
               },
             },
@@ -450,7 +451,8 @@ module.exports = function(webpackEnv) {
                   ],
                 ],
                 cacheDirectory: true,
-                cacheCompression: isEnvProduction,
+                // See #6846 for context on why cacheCompression is disabled
+                cacheCompression: false,
                 // @remove-on-eject-begin
                 cacheIdentifier: getCacheIdentifier(
                   isEnvProduction


### PR DESCRIPTION
Context: #6846  - I received no feedback on it, so I figure a PR is more actionable.

Changes have been tested running on a live website since I filed the issue. Build times and their memory consumption have both decreased with no further issue arising.

----

`cacheCompression` is an enabled-by-default flag in babel-loader,
which gzips the babel-loader cache.

Most projects do not actually benefit from cache compression,
especially in production where builds often happen in a CI environment
where memory is precious and disk space is not.

Furthermore, having it disabled in dev and enabled in prod means caching
won't be shared between dev and prod.

Finally, the disk space savings are not that great. Most React projects
will have a lot of small files (one file per component). babel-loader
caches each file as a unit, so the compression overhead increases when
the project is mainly lots of small files.

For these reasons, we're disabling cache compression.

Closes #6846

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
