### PR TITLE
Remove --single-quote from prettier examples

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -163,13 +163,13 @@ Next we add a 'lint-staged' field to the `package.json`, for example:
   },
 + "lint-staged": {
 +   "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-+     "prettier --single-quote --write",
++     "prettier --write",
 +     "git add"
 +   ]
 + },
   "scripts": {
 ```
 
-Now, whenever you make a commit, Prettier will format the changed files automatically. You can also run `./node_modules/.bin/prettier --single-quote --write "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}"` to format your entire project for the first time.
+Now, whenever you make a commit, Prettier will format the changed files automatically. You can also run `./node_modules/.bin/prettier --write "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}"` to format your entire project for the first time.
 
 Next you might want to integrate Prettier in your favorite editor. Read the section on [Editor Integration](https://prettier.io/docs/en/editors.html) on the Prettier GitHub page.


### PR DESCRIPTION
Passing options directly to the cli is not great practice, since default editor integrations won't pick it up and many people are just going to copy paste this snippet. This change removes that customization and prettier will use its very sane defaults.

Closes #7615