### PR TITLE
Update running-tests.md

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -204,7 +204,7 @@ import App from './App';
 
 it('renders welcome message', () => {
   const { getByText } = render(<App />);
-  expect(getByText('Welcome to React')).toBeInTheDocument();
+  expect(getByText('Learn React')).toBeInTheDocument();
 });
 ```
 


### PR DESCRIPTION
Fixed the  unit test in the @testing-library bit of the page as Welcome to React is not being used in the `App.js`.

Made the change in newly created CRA app and ran the tests in Gitlab CI:
```
$ react-scripts test
PASS src/App.test.js
  ✓ renders welcome message (82ms)
```