### PR TITLE
docs: save source-map-explorer in dev dependencies

### DIFF
--- a/docusaurus/docs/analyzing-the-bundle-size.md
+++ b/docusaurus/docs/analyzing-the-bundle-size.md
@@ -17,7 +17,7 @@ npm install --save source-map-explorer
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add source-map-explorer
+yarn add --dev source-map-explorer
 ```
 
 Then in `package.json`, add the following line to `scripts`:


### PR DESCRIPTION
If install with `yarn add source-map-explorer` the package will be add in prod dependencies. But it package used only during development.

https://yarnpkg.com/en/docs/cli/add#toc-yarn-add-dev-d

Use flag --dev It seems to me more understandable than -D.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
