### PR TITLE
fix forEach undefined error with eslintFormatter

### DIFF
--- a/packages/react-dev-utils/eslintFormatter.js
+++ b/packages/react-dev-utils/eslintFormatter.js
@@ -23,7 +23,7 @@ function formatter(results) {
   let hasErrors = false;
   let reportContainsErrorRuleIDs = false;
 
-  results.forEach(result => {
+  results && results.forEach(result => {
     let messages = result.messages;
     if (messages.length === 0) {
       return;


### PR DESCRIPTION
I ejected my create-react-app and used eslint-loader v3.0.0. When I started the app, I encountered the below issue: `TypeError: Cannot read property 'forEach' of undefined`.

This PR is to fix this issue.

<img width="877" alt="Screen Shot 2019-09-23 at 3 48 25 AM" src="https://user-images.githubusercontent.com/7416078/65394244-4f412800-ddb5-11e9-8d8d-69c435f48ed9.png">
