### PR TITLE
Add "entrypoints" key to asset manifest

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -631,20 +631,27 @@ module.exports = function(webpackEnv) {
           filename: 'static/css/[name].[contenthash:8].css',
           chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
         }),
-      // Generate a manifest file which contains a mapping of all asset filenames
-      // to their corresponding output file so that tools can pick it up without
-      // having to parse `index.html`.
+      // Generate an asset manifest file with the following content:
+      // - "files" key: Mapping of all asset filenames to their corresponding
+      //   output file so that tools can pick it up without having to parse
+      //   `index.html`
+      // - "entrypoints" key: Array of files which are included in `index.html`,
+      //   can be used to reconstruct the HTML if necessary
       new ManifestPlugin({
         fileName: 'asset-manifest.json',
         publicPath: publicPath,
-        generate: (seed, files) => {
-          const manifestFiles = files.reduce(function(manifest, file) {
+        generate: (seed, files, entrypoints) => {
+          const manifestFiles = files.reduce((manifest, file) => {
             manifest[file.name] = file.path;
             return manifest;
           }, seed);
+          const entrypointFiles = entrypoints.main.filter(
+            fileName => !fileName.endsWith('.map')
+          );
 
           return {
             files: manifestFiles,
+            entrypoints: entrypointFiles,
           };
         },
       }),

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -79,7 +79,7 @@
     "url-loader": "2.1.0",
     "webpack": "4.40.2",
     "webpack-dev-server": "3.2.1",
-    "webpack-manifest-plugin": "2.0.4",
+    "webpack-manifest-plugin": "2.1.1",
     "workbox-webpack-plugin": "4.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
**Problem:**

We would like to generate the `index.html` file on the server. In order to get code splitting to work, we need to know which chunks are entrypoints of the React app (to be able to request these from the HTML file). Unfortunately, this currently doesn't seem to be possible (see https://github.com/facebook/create-react-app/issues/5225#issuecomment-427312764).

Ideally, `splitChunks.name` would simply be set to `true` in the Webpack config, so the entrypoints could be inferred from the file names. However, this seems to lead to caching issues (see https://github.com/facebook/create-react-app/pull/5030#issuecomment-422820779).

This PR implements @iansu's suggestion from https://github.com/facebook/create-react-app/issues/5513#issuecomment-486838664: It adds an additional `"entrypoints"` key to the `asset-manifest.json` file with the names of the files that need to be included in the generated HTML.

**Before:**

```json
{
  "files": {
    "main.css": "/static/css/main.2cce8147.chunk.css",
    "main.js": "/static/js/main.fd729682.chunk.js",
    "main.js.map": "/static/js/main.fd729682.chunk.js.map",
    "runtime-main.js": "/static/js/runtime-main.f7c36e2a.js",
    "runtime-main.js.map": "/static/js/runtime-main.f7c36e2a.js.map",
    "static/js/2.ae086021.chunk.js": "/static/js/2.ae086021.chunk.js",
    "static/js/2.ae086021.chunk.js.map": "/static/js/2.ae086021.chunk.js.map",
    "index.html": "/index.html",
    "precache-manifest.be4e4fdd4a55417b6c618c280ec25a62.js": "/precache-manifest.be4e4fdd4a55417b6c618c280ec25a62.js",
    "service-worker.js": "/service-worker.js",
    "static/css/main.2cce8147.chunk.css.map": "/static/css/main.2cce8147.chunk.css.map",
    "static/media/logo.svg": "/static/media/logo.5d5d9eef.svg"
  }
}
```

**After:**

```json
{
  "files": {
    "main.css": "/static/css/main.b100e6da.chunk.css",
    "main.js": "/static/js/main.70abf459.chunk.js",
    "main.js.map": "/static/js/main.70abf459.chunk.js.map",
    "runtime-main.js": "/static/js/runtime-main.fdecdd6f.js",
    "runtime-main.js.map": "/static/js/runtime-main.fdecdd6f.js.map",
    "static/js/2.a3ab821d.chunk.js": "/static/js/2.a3ab821d.chunk.js",
    "static/js/2.a3ab821d.chunk.js.map": "/static/js/2.a3ab821d.chunk.js.map",
    "index.html": "/index.html",
    "precache-manifest.47b41692c7614ae757144cfe8f04d3cb.js": "/precache-manifest.47b41692c7614ae757144cfe8f04d3cb.js",
    "service-worker.js": "/service-worker.js",
    "static/css/main.b100e6da.chunk.css.map": "/static/css/main.b100e6da.chunk.css.map",
    "static/media/logo.svg": "/static/media/logo.25bf045c.svg"
  },
  "entrypoints": [
    "static/js/runtime-main.fdecdd6f.js",
    "static/js/2.a3ab821d.chunk.js",
    "static/css/main.b100e6da.chunk.css",
    "static/js/main.70abf459.chunk.js"
  ]
}
```

**Note: This PR is a draft because it requires https://github.com/danethurber/webpack-manifest-plugin/pull/192 to be merged into `webpack-manifest-plugin` first. Without that change, the information about the order in which the assets need to be included isn't available yet (see https://github.com/facebook/create-react-app/issues/5513#issuecomment-488311627).**

Closes #5513 