### PR TITLE
Add version to transform-runtime plugin

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -170,6 +170,10 @@ module.exports = function(api, opts, env) {
         {
           corejs: false,
           helpers: areHelpersEnabled,
+          // By default, babel assumes babel/helpers version 7.0.0-beta.0,
+          // explicitely resolving to match the provided helper functions.
+          // https://github.com/babel/babel/issues/10261
+          version: require('@babel/helpers/package.json').version,
           regenerator: true,
           // https://babeljs.io/docs/en/babel-plugin-transform-runtime#useesmodules
           // We should turn this on once the lowest version of Node LTS


### PR DESCRIPTION
By default, babel assumes babel/helpers version 7.0.0-beta.0, this PR explicitly resolves the helpers to match the provide functions.

See: https://github.com/babel/babel/issues/10261