### PR TITLE
Add babel runtime version to transform-runtime plugin to reduce bundle size

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -171,7 +171,7 @@ module.exports = function(api, opts, env) {
           corejs: false,
           helpers: areHelpersEnabled,
           // By default, babel assumes babel/runtime version 7.0.0-beta.0,
-          // explicitely resolving to match the provided helper functions.
+          // explicitly resolving to match the provided helper functions.
           // https://github.com/babel/babel/issues/10261
           version: require('@babel/runtime/package.json').version,
           regenerator: true,

--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -170,6 +170,10 @@ module.exports = function(api, opts, env) {
         {
           corejs: false,
           helpers: areHelpersEnabled,
+          // By default, babel assumes babel/runtime version 7.0.0-beta.0,
+          // explicitely resolving to match the provided helper functions.
+          // https://github.com/babel/babel/issues/10261
+          version: require('@babel/runtime/package.json').version,
           regenerator: true,
           // https://babeljs.io/docs/en/babel-plugin-transform-runtime#useesmodules
           // We should turn this on once the lowest version of Node LTS


### PR DESCRIPTION
(Reopening due to force-push https://github.com/facebook/create-react-app/pull/7725)

By default, babel assumes babel/helpers version 7.0.0-beta.0, this PR explicitly resolves the helpers to match the provide functions.

See: https://github.com/babel/babel/issues/10261

Looking at the code in [babel-plugin-transform-runtime/src/index.js](https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-runtime/src/index.js) it does not seem to be enough to provide an absolute path to the runtime.