### PR TITLE
docs: fix module mapper regex in Flow documentation

### DIFF
--- a/docusaurus/docs/adding-flow.md
+++ b/docusaurus/docs/adding-flow.md
@@ -22,7 +22,7 @@ make sure to add the following line to your `.flowconfig` to make Flow aware of 
 
 ```diff
   [options]
-+ module.name_mapper='^\(.*\)$' -> '<PROJECT_ROOT>/src/\1'
++ module.name_mapper='^\([^\.].*\)$' -> '<PROJECT_ROOT>/src/\1'
 ```
 
 To learn more about Flow, check out [its documentation](https://flow.org/).


### PR DESCRIPTION
With the currently documented regex we catch relative imports, that then get wrongly mapped.

For example, `./Foobar.js` will become `<PROJECT_ROOT>/src/./Foobar.js`, instead of `<PROJECT_ROOT>/src/the/real/file/path/Foobar.js`.

The new regex will exclude imports starting with a dot (`.`)

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
