### PR TITLE
Update webpack to improve performance

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -77,7 +77,7 @@
     "terser-webpack-plugin": "1.4.1",
     "ts-pnp": "1.1.4",
     "url-loader": "2.1.0",
-    "webpack": "4.40.2",
+    "webpack": "4.41.0",
     "webpack-dev-server": "3.2.1",
     "webpack-manifest-plugin": "2.1.1",
     "workbox-webpack-plugin": "4.3.1"


### PR DESCRIPTION
Speeds up the process.

## Webpack changelogs

* disallow cache group named test with shorthand syntax to point out a potential config error
* Improve performance of LimitChunkCountPlugin
* fix a bug that the HMR plugin affected child compilations
* improve performance of splitChunks name option by caching hashed value
* improve rebuild performance by caching module size computation
