### PR TITLE
Support setting baseUrl to root directory

### DIFF
--- a/packages/react-scripts/config/modules.js
+++ b/packages/react-scripts/config/modules.js
@@ -15,7 +15,7 @@ const chalk = require('react-dev-utils/chalk');
 const resolve = require('resolve');
 
 /**
- * Get the baseUrl of a compilerOptions object.
+ * Get additional module paths based on the baseUrl of a compilerOptions object.
  *
  * @param {Object} options
  */
@@ -46,6 +46,15 @@ function getAdditionalModulePaths(options = {}) {
     return [paths.appSrc];
   }
 
+  // If the path is equal to the root directory we ignore it here.
+  // We don't want to allow importing from the root directly as source files are
+  // not transpiled outside of `src`. We do allow importing them with the
+  // absolute path (e.g. `src/Components/Button.js`) but we set that up with
+  // an alias.
+  if (path.relative(paths.appPath, baseUrlResolved) === '') {
+    return null;
+  }
+
   // Otherwise, throw an error.
   throw new Error(
     chalk.red.bold(
@@ -53,6 +62,48 @@ function getAdditionalModulePaths(options = {}) {
         ' Create React App does not support other values at this time.'
     )
   );
+}
+
+/**
+ * Get webpack aliases based on the baseUrl of a compilerOptions object.
+ *
+ * @param {*} options
+ */
+function getWebpackAliases(options = {}) {
+  const baseUrl = options.baseUrl;
+
+  if (!baseUrl) {
+    return {};
+  }
+
+  const baseUrlResolved = path.resolve(paths.appPath, baseUrl);
+
+  if (path.relative(paths.appPath, baseUrlResolved) === '') {
+    return {
+      src: paths.appSrc,
+    };
+  }
+}
+
+/**
+ * Get jest aliases based on the baseUrl of a compilerOptions object.
+ *
+ * @param {*} options
+ */
+function getJestAliases(options = {}) {
+  const baseUrl = options.baseUrl;
+
+  if (!baseUrl) {
+    return {};
+  }
+
+  const baseUrlResolved = path.resolve(paths.appPath, baseUrl);
+
+  if (path.relative(paths.appPath, baseUrlResolved) === '') {
+    return {
+      'src/(.*)$': '<rootDir>/src/$1',
+    };
+  }
 }
 
 function getModules() {
@@ -89,6 +140,8 @@ function getModules() {
 
   return {
     additionalModulePaths: additionalModulePaths,
+    webpackAliases: getWebpackAliases(options),
+    jestAliases: getJestAliases(options),
     hasTsConfig,
   };
 }

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -306,6 +306,7 @@ module.exports = function(webpackEnv) {
         // Support React Native Web
         // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
         'react-native': 'react-native-web',
+        ...(modules.webpackAliases || {}),
       },
       plugins: [
         // Adds support for installing with Plug'n'Play, leading to faster installs and adding
@@ -352,7 +353,9 @@ module.exports = function(webpackEnv) {
                     const eslintCli = new eslint.CLIEngine();
                     let eslintConfig;
                     try {
-                      eslintConfig = eslintCli.getConfigForFile(paths.appIndexJs);
+                      eslintConfig = eslintCli.getConfigForFile(
+                        paths.appIndexJs
+                      );
                     } catch (e) {
                       console.error(e);
                       process.exit(1);

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -56,6 +56,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     moduleNameMapper: {
       '^react-native$': 'react-native-web',
       '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
+      ...(modules.jestAliases || {}),
     },
     moduleFileExtensions: [...paths.moduleFileExtensions, 'node'].filter(
       ext => !ext.includes('mjs')


### PR DESCRIPTION
This PR adds support for setting the baseUrl in `tsconfig.json`/`jsconfig.json` to the root directory (`.`).

Initially I planned to add support for aliases but that turned out to be quite difficult due to difference in implementation between webpack and TypeScript. Instead this PR aims to facility the most requested option to import files with their absolute path (as seen from root) like `src/components/Button.js`. (https://github.com/facebook/create-react-app/issues/6850)

We don't want users to import from any directory other than `src` so the implementation maps a baseUrl of `.` to an alias that transforms `src` to the absolute `appSrc` directory. This should prevent users from doing something like `import { something } from 'library/utils.js'`.

- [ ] Update error message to communicate that `.` is allowed as `baseUrl`
