### PR TITLE
Allow for browserslist environment variables

### DIFF
--- a/packages/react-dev-utils/browsersHelper.js
+++ b/packages/react-dev-utils/browsersHelper.js
@@ -42,7 +42,7 @@ function shouldSetBrowsers(isInteractive) {
 }
 
 function checkBrowsers(dir, isInteractive, retry = true) {
-  const current = browserslist.findConfig(dir);
+  const current = browserslist.loadConfig({path: dir});
   if (current != null) {
     return Promise.resolve(current);
   }


### PR DESCRIPTION
Browserslist allows for setting browserslist config using environment variables, but CRA still prompts for setting browserslist config when it is already configured for the environment.

For example, running this currently results in CRA improperly detecting that browserslist is not configured, even though it is.

```shell
BROWSERSLIST="> 5%" npm run build
```
