### PR TITLE
Add yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ yarn-debug.log*
 yarn-error.log*
 /.changelog
 .npm/
+yarn.lock


### PR DESCRIPTION
Close #7765

### Description

From https://github.com/facebook/create-react-app/issues/7765, `yarn.lock` hasn't been dealt with yet in this project.

According to the discussion in that issue, `yarn.lock` should be ignored in this project.

### Acceptance criteria

- git status should be unchanged when running `yarn` for the first time.
- `yarn.lock` should be ignored in `.gitignore`.