### PR TITLE
Print local timestamp after build

### DIFF
--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -41,6 +41,7 @@ function printHostingInstructions(
   console.log();
   console.log(`  ${chalk.yellow('https://bit.ly/CRA-deploy')}`);
   console.log();
+  console.log(new Date().toString());
 }
 
 function printBaseMessage(buildFolder, hostingLocation) {


### PR DESCRIPTION
So each message is different and you can know if you build the app before going for coffee or a break. 
It's useful for frequent builds in devops.

It just print the last line here:

Find out more about deployment here:

  https://bit.ly/CRA-deploy

**Mon Oct 07 2019 14:43:46 GMT-0400 (Eastern Daylight Time)**

