### PR TITLE
fix: make error overlay fontsize larger

### DIFF
--- a/packages/react-error-overlay/src/components/CodeBlock.js
+++ b/packages/react-error-overlay/src/components/CodeBlock.js
@@ -12,6 +12,7 @@ import { redTransparent, yellowTransparent } from '../styles';
 const _preStyle = {
   position: 'relative',
   display: 'block',
+  fontSize: '1.3em',
   padding: '0.5em',
   marginTop: '0.5em',
   marginBottom: '0.5em',

--- a/packages/react-error-overlay/src/components/Footer.js
+++ b/packages/react-error-overlay/src/components/Footer.js
@@ -14,6 +14,7 @@ const footerStyle = {
   color: darkGray,
   marginTop: '0.5rem',
   flex: '0 0 auto',
+  fontSize: '1.3em',
 };
 
 type FooterPropsType = {|

--- a/packages/react-error-overlay/src/components/Header.js
+++ b/packages/react-error-overlay/src/components/Header.js
@@ -10,7 +10,8 @@ import React from 'react';
 import { red } from '../styles';
 
 const headerStyle = {
-  fontSize: '2em',
+  fontSize: '2.3em',
+  fontWeight: 'bold',
   fontFamily: 'sans-serif',
   color: red,
   whiteSpace: 'pre-wrap',


### PR DESCRIPTION
Fixes #7799.

before
![image](https://user-images.githubusercontent.com/20264467/66539686-793b6e00-eb5b-11e9-95df-1cc5b7a7182b.png)


after
![image](https://user-images.githubusercontent.com/20264467/66539673-73458d00-eb5b-11e9-87d1-e7f624bd4912.png)
