### PR TITLE
Add a note about .eslintignore files being respected

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -48,6 +48,7 @@ Note that any rules set to `"error"` will stop the project from building.
 There are a few things to remember:
 
 1. We highly recommend extending the base config, as removing it could introduce hard-to-find issues.
+1. `.eslintignore` files will be respected
 1. When working with TypeScript, you'll need to provide an `overrides` object for rules that should _only_ target TypeScript files.
 
 In the below example:


### PR DESCRIPTION
As of https://github.com/facebook/create-react-app/pull/7562 (which dropped in 3.2), `.eslintignore` files will be respected when I opt in to extending the eslintconfig. This wasn't too clear from the existing docs.
