### PR TITLE
Add `source-map-explorer` as a dev dependancy

### DIFF
--- a/docusaurus/docs/analyzing-the-bundle-size.md
+++ b/docusaurus/docs/analyzing-the-bundle-size.md
@@ -11,13 +11,13 @@ bloat is coming from.
 To add Source map explorer to a Create React App project, follow these steps:
 
 ```sh
-npm install --save source-map-explorer
+npm install --save-dev source-map-explorer
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add source-map-explorer
+yarn add --dev source-map-explorer
 ```
 
 Then in `package.json`, add the following line to `scripts`:


### PR DESCRIPTION
Since `source-map-explorer` is only required during development, I propose that it goes under package.json's devDependencies

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
