### PR TITLE
Setup a flag to enable writeToDisk in dev mode

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -66,6 +66,9 @@ module.exports = function(webpackEnv) {
   const isEnvDevelopment = webpackEnv === 'development';
   const isEnvProduction = webpackEnv === 'production';
 
+  // Passing this flag will write build files to the production build path
+  const writeToDisk = process.argv.includes('--writeToDisk');
+
   // Variable used for enabling profiling in Production
   // passed into alias object. Uses a flag if passed into the build command
   const isEnvProductionProfile =
@@ -74,7 +77,7 @@ module.exports = function(webpackEnv) {
   // Webpack uses `publicPath` to determine where the app is being served from.
   // It requires a trailing slash, or the file assets will get an incorrect path.
   // In development, we always serve from the root. This makes config easier.
-  const publicPath = isEnvProduction
+  const publicPath = isEnvProduction || writeToDisk
     ? paths.servedPath
     : isEnvDevelopment && '/';
   // Some apps do not use client-side routing with pushState.
@@ -84,7 +87,7 @@ module.exports = function(webpackEnv) {
   // `publicUrl` is just like `publicPath`, but we will provide it to our app
   // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
   // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
-  const publicUrl = isEnvProduction
+  const publicUrl = isEnvProduction || writeToDisk
     ? publicPath.slice(0, -1)
     : isEnvDevelopment && '';
   // Get environment variables to inject into our app.
@@ -179,7 +182,7 @@ module.exports = function(webpackEnv) {
     ].filter(Boolean),
     output: {
       // The build folder.
-      path: isEnvProduction ? paths.appBuild : undefined,
+      path: isEnvProduction || writeToDisk ? paths.appBuild : undefined,
       // Add /* filename */ comments to generated require()s in the output.
       pathinfo: isEnvDevelopment,
       // There will be one main bundle, and one file per asynchronous chunk.

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -108,5 +108,6 @@ module.exports = function(proxy, allowedHost) {
       // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
       app.use(noopServiceWorkerMiddleware());
     },
+    writeToDisk: process.argv.includes('--writeToDisk'),
   };
 };

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -145,7 +145,9 @@ checkBrowsers(paths.appPath, isInteractive)
       }
 
       console.log(chalk.cyan('Starting the development server...\n'));
-      openBrowser(urls.localUrlForBrowser);
+      if (!process.argv.includes('--writeToDisk')) {
+        openBrowser(urls.localUrlForBrowser);
+      }
     });
 
     ['SIGINT', 'SIGTERM'].forEach(function(sig) {


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
### About
This PR sets up a flag to enable writing build-files to disk in development mode. As requested by issue #1070. This is quite helpful when using CRA with backends that are not written in JS, when making chrome extensions and when integrating React to a legacy UI system(eg: A UI written in PHP and react components injected in client-side). 

These changes are live in a production app (made possible using the npm patch-package module). I believe it makes more sense to make it a built-in feature of CRA. 

### How to verify changes
1. Start an app using `react-scripts start --writeToDisk`.
2. Do a change and see build files in the production build path.

### Documentation and Tests
No tests or docs have been written yet. Happy to make the PR more complete once I get the approval from the maintainers/community. 

### Disclaimer
This is my 1st PR to CRA. So I apologize if I have made a mistake in the contribution procedure. 