### PR TITLE
Fix absolute paths issue in Jest

### DIFF
--- a/packages/react-scripts/config/modules.js
+++ b/packages/react-scripts/config/modules.js
@@ -101,7 +101,7 @@ function getJestAliases(options = {}) {
 
   if (path.relative(paths.appPath, baseUrlResolved) === '') {
     return {
-      'src/(.*)$': '<rootDir>/src/$1',
+      '^src/(.*)$': '<rootDir>/src/$1',
     };
   }
 }


### PR DESCRIPTION
This PR fixes #7818, by fixing the entry added to Jest's `moduleNameMapper` that unintentionally matched with paths that did not start with `src`. 