### PR TITLE
Fix navbar line break in docusaurus

### DIFF
--- a/docusaurus/website/src/css/custom.css
+++ b/docusaurus/website/src/css/custom.css
@@ -7,3 +7,7 @@
   --ifm-color-primary-lighter: rgb(83, 224, 197);
   --ifm-color-primary-lightest: rgb(132, 233, 214);
 }
+
+.navbar__brand {
+  white-space: nowrap;
+}


### PR DESCRIPTION
The new docusaurus 2 site is gorgeous. I noticed a line break in the navbar in safari 13. I didn't manage to sort out why it happens. Putting in `Create React App` on the official docusaurus website didn't break the line (middle screenshot below). Right now Im not sure whatever it's an issue in `bootstrap` or `docusaurus`

I ended up fixing it with `white-space: nowrap`

I also tried:
- Fixing flex basis on the container
- Fixing flex wrap 

![Screenshot 2019-10-16 at 11 47 48](https://user-images.githubusercontent.com/33141/66916348-51e11700-f01b-11e9-9133-06dabbf36bea.png)

It's a minor but it makes it looks smoother.  

ping @endiliey