### PR TITLE
feat: add additional Jest keys to whitelist

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -276,9 +276,11 @@ The default Jest coverage configuration can be overridden by adding any of the f
 
 Supported overrides:
 
+- [`clearMocks`](https://jestjs.io/docs/en/configuration.html#clearmocks-boolean)
 - [`collectCoverageFrom`](https://jestjs.io/docs/en/configuration.html#collectcoveragefrom-array)
 - [`coverageReporters`](https://jestjs.io/docs/en/configuration.html#coveragereporters-array-string)
 - [`coverageThreshold`](https://jestjs.io/docs/en/configuration.html#coveragethreshold-object)
+- [`displayName`](https://jestjs.io/docs/en/configuration.html#displayname-string-object)
 - [`extraGlobals`](https://jestjs.io/docs/en/configuration.html#extraglobals-array-string)
 - [`globalSetup`](https://jestjs.io/docs/en/configuration.html#globalsetup-string)
 - [`globalTeardown`](https://jestjs.io/docs/en/configuration.html#globalteardown-string)

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -71,10 +71,12 @@ module.exports = (resolve, rootDir, isEjecting) => {
   }
   const overrides = Object.assign({}, require(paths.appPackageJson).jest);
   const supportedKeys = [
+    'clearMocks',
     'collectCoverageFrom',
+    'coveragePathIgnorePatterns',
     'coverageReporters',
     'coverageThreshold',
-    'coveragePathIgnorePatterns',
+    'displayName',
     'extraGlobals',
     'globalSetup',
     'globalTeardown',


### PR DESCRIPTION
[`clearMocks`](https://jestjs.io/docs/en/configuration#clearmocks-boolean) is a useful feature that clears all mocks between tests.
- Kent Dodds [tweeted about it recently](https://twitter.com/kentcdodds/status/1182744387190607872?s=09).

[`displayName`](https://jestjs.io/docs/en/configuration#displayname-string-object) is really interesting, as it enables developers working in multiproject setups (and monorepos) to visually identify which suite of tests is running.