### PR TITLE
added check for typescript template and unsupported node version

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -193,17 +193,16 @@ function createApp(
   useTypescript,
   template
 ) {
-  const unSupportedNodeVersion = !semver.satisfies(process.version, '>=8.10.0');
-  if (unSupportedNodeVersion && useTypescript) {
+  const unsupportedNodeVersion = !semver.satisfies(process.version, '>=8.10.0');
+  if (unsupportedNodeVersion && useTypescript) {
     console.log(
-      chalk.yellow(
-        `You are using Node ${process.version} with the TypeScript template. Since the old unsuporoted version of tools do not supported TypeScript, you will have to upgrade.\n\n` +
-          `Please update to Node 8.10 or higher for a better, fully supported experience.\n`
+      chalk.red(
+        `You are using Node ${process.version} with the TypeScript template. Node 8.10 or higher is required to use TypeScript.\n`
       )
     );
 
     process.exit(1);
-  } else if (unSupportedNodeVersion) {
+  } else if (unsupportedNodeVersion) {
     console.log(
       chalk.yellow(
         `You are using Node ${process.version} so the project will be bootstrapped with an old unsupported version of tools.\n\n` +

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -193,6 +193,27 @@ function createApp(
   useTypescript,
   template
 ) {
+  const unSupportedNodeVersion = !semver.satisfies(process.version, '>=8.10.0');
+  if (unSupportedNodeVersion && useTypescript) {
+    console.log(
+      chalk.yellow(
+        `You are using Node ${process.version} with the TypeScript template. Since the old unsuporoted version of tools do not supported TypeScript, you will have to upgrade.\n\n` +
+          `Please update to Node 8.10 or higher for a better, fully supported experience.\n`
+      )
+    );
+
+    process.exit(1);
+  } else if (unSupportedNodeVersion) {
+    console.log(
+      chalk.yellow(
+        `You are using Node ${process.version} so the project will be bootstrapped with an old unsupported version of tools.\n\n` +
+          `Please update to Node 8.10 or higher for a better, fully supported experience.\n`
+      )
+    );
+    // Fall back to latest supported react-scripts on Node 4
+    version = 'react-scripts@0.9.x';
+  }
+
   const root = path.resolve(name);
   const appName = path.basename(root);
 
@@ -220,17 +241,6 @@ function createApp(
   process.chdir(root);
   if (!useYarn && !checkThatNpmCanReadCwd()) {
     process.exit(1);
-  }
-
-  if (!semver.satisfies(process.version, '>=8.10.0')) {
-    console.log(
-      chalk.yellow(
-        `You are using Node ${process.version} so the project will be bootstrapped with an old unsupported version of tools.\n\n` +
-          `Please update to Node 8.10 or higher for a better, fully supported experience.\n`
-      )
-    );
-    // Fall back to latest supported react-scripts on Node 4
-    version = 'react-scripts@0.9.x';
   }
 
   if (!useYarn) {


### PR DESCRIPTION
This PR related to #7715 

## Problem

When using the `--typescript` option with `create-react-app` with an unsupported version node.js ie. from the issue 8.9.4. It creates a React project, but completely ignores the TypeScript template. 

Whats happening is that before this fix, if you're using an unsupported version of Node.js, `createReactApp.js` falls back to using version `0.9.5`. Within `0.9.5`, the init script (or `scripts/init.js`)  there is no code paths that support the TypeScript option. This is why you can still get a react app project, but without TypeScript being configured.

## Solution

Within `createReactApp.js` I just added a check and error message that tells the user they must upgrade to a supported version to continue

## Testing

I tested the command using `nvm`, 8.10 fully created a TypeScript project but anything below exits with the following message:

```
You are using Node v8.9.4 with the TypeScript template. Since the old unsuporoted version of tools do not supported TypeScript, you will have to upgrade.

Please update to Node 8.10 or higher for a better, fully supported experience.
```

Please let me know if you have any questions!