### PR TITLE
added e2e test for checking typescript template with unsupported node

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,3 +77,16 @@ jobs:
         displayName: 'Install Node.js 6.x'
       - bash: tasks/e2e-old-node.sh
         displayName: 'Run tests'
+  # ******************************************************************************
+  # Unsupported Node with TypeScript flag
+  # ******************************************************************************
+  - job: UnsupportedNodeWithTypeScript
+    pool:
+      vmImage: ubuntu-16.04
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 8.9.x
+        displayName: 'Install Node.js 8.9.x'
+      - bash: tasks/e2e-typescript-unsupported-node.sh
+        displayName: 'Run unsupported TypeScript test'

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -217,7 +217,7 @@ function createApp(
 ) {
   const unsupportedNodeVersion = !semver.satisfies(process.version, '>=8.10.0');
   if (unsupportedNodeVersion && useTypeScript) {
-    console.log(
+    console.error(
       chalk.red(
         `You are using Node ${process.version} with the TypeScript template. Node 8.10 or higher is required to use TypeScript.\n`
       )

--- a/tasks/e2e-typescript-unsupported-node.sh
+++ b/tasks/e2e-typescript-unsupported-node.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright (c) 2015-present, Facebook, Inc.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# ******************************************************************************
+# This is an end-to-end test intended to run on CI.
+# You can also run it locally but it's slow.
+# ******************************************************************************
+
+# Start in tasks/ even if run from root directory
+cd "$(dirname "$0")"
+
+temp_app_path=`mktemp -d 2>/dev/null || mktemp -d -t 'temp_app_path'`
+
+function cleanup {
+  echo 'Cleaning up.'
+  cd "$root_path"
+  rm -rf $temp_app_path
+}
+
+# Error messages are redirected to stderr
+function handle_error {
+  echo "$(basename $0): ERROR! An error was encountered executing line $1." 1>&2;
+  cleanup
+  echo 'Exiting with error.' 1>&2;
+  exit 1
+}
+
+function handle_exit {
+  cleanup
+  echo 'Exiting without error.' 1>&2;
+  exit
+}
+
+# Exit the script with a helpful error message when any error is encountered
+trap 'set +x; handle_error $LINENO $BASH_COMMAND' ERR
+
+# Cleanup before exit on any termination signal
+trap 'set +x; handle_exit' SIGQUIT SIGTERM SIGINT SIGKILL SIGHUP
+
+# Echo every command being executed
+set -x
+
+# Go to root
+cd ..
+root_path=$PWD
+
+# We need to install create-react-app deps to test it
+cd "$root_path"/packages/create-react-app
+npm install
+cd "$root_path"
+
+# If the node version is < 8.10 but greater then 8.0, the script with the typescript flag should just give an error.
+cd $temp_app_path
+err_output=`node "$root_path"/packages/create-react-app/index.js test-node-version --typescript 2>&1 > /dev/null || echo ''`
+[[ $err_output =~ You\ are\ using\ Node ]] && exit 0 || exit 1
+
+# Cleanup
+cleanup


### PR DESCRIPTION
Another subset of #7839 

I added some e2e tests based on the following bash script: `e2e-old-node.sh`. I tested it on my local machine and I hope it runs as apart of the changes made to `azure-pipelines.yml`

The test just installs node version 8.9.x and ensures that the code errors out 
