### PR TITLE
Move unused eslint webpack import into @remove-on-eject block

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -33,8 +33,8 @@ const getClientEnvironment = require('./env');
 const ModuleNotFoundPlugin = require('react-dev-utils/ModuleNotFoundPlugin');
 const ForkTsCheckerWebpackPlugin = require('react-dev-utils/ForkTsCheckerWebpackPlugin');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
-const eslint = require('eslint');
 // @remove-on-eject-begin
+const eslint = require('eslint');
 const getCacheIdentifier = require('react-dev-utils/getCacheIdentifier');
 // @remove-on-eject-end
 const postcssNormalize = require('postcss-normalize');


### PR DESCRIPTION
It seems that when creating a new app with `create-react-app`, there is an unnecessary/unused `eslint` import in the generated webpack config which can be seen if you eject the project. I have now moved this import into the `@remove-on-eject` block.

Verified as working by locally running `yarn create-react-app`, ejecting and viewing the new project's webpack config, where the extra import is now gone.