### PR TITLE
Mark TypeScript as an optional peer dependency for react-scripts

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -88,6 +88,11 @@
   "optionalDependencies": {
     "fsevents": "2.0.7"
   },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
This PR adds TypeScript as an optional peer dependency for `react-scripts`. This modification is necessary to get `react-scripts` working with Yarn v2, and will enable the TypeScript template for `create-react-app` to work with Yarn v2.

This PR uses the `peerDependenciesMeta` key, which signifies to Yarn that `typescript` is an optional dependency. npm will support the key in the future, in which case `"typescript": "*"` can be added to `peerDependencies`. Until that change is made, simply having `peerDependenciesMeta` will be enough for Yarn, and won't adversely impact users of npm.

Other relevant issues: yarnpkg/berry/pull/475

/cc @iansu