### PR TITLE
Update running-tests.md

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -101,8 +101,6 @@ yarn add enzyme enzyme-adapter-react-16 react-test-renderer
 
 As of Enzyme 3, you will need to install Enzyme along with an Adapter corresponding to the version of React you are using. (The examples above use the adapter for React 16.)
 
-The adapter will also need to be configured in your [global setup file](#initializing-test-environment):
-
 ### `src/setupTests.js`
 
 ```js


### PR DESCRIPTION
the setup test can't be configure in jest, the option setupTestFrameworkScriptFile and setupFilesAfterEnv are not supported and CRA will pick up setupTests.js from the root out of the box

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
