### PR TITLE
Remove alex precommit check

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "lint-staged": {
     "*.{js,md,css,html}": [
-      "alex",
       "prettier --trailing-comma es5 --single-quote --write",
       "git add"
     ],


### PR DESCRIPTION
Unfortunately alex doesn't seem to work nicely with lint-staged. Removing this check for the time being. It still runs on CI though.
