### PR TITLE
Pass through fully specified template name

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -645,6 +645,8 @@ function getTemplateInstallPackage(template, originalDirectory) {
     ) {
       // for tar.gz or alternative paths
       templateToInstall = template;
+    } else if (template.startsWith(templateToInstall)) {
+      templateToInstall = template;
     } else if (!template.startsWith(templateToInstall)) {
       // Add prefix `cra-template` to non-prefixed templates.
       templateToInstall += `-${template}`;


### PR DESCRIPTION
If template name already starts with cra-template leave it alone.
