### PR TITLE
refactor: remove double coerce

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -443,6 +443,8 @@ function run(
       )
       .then(({ isOnline, packageInfo, templateInfo }) => {
         let packageVersion = semver.coerce(packageInfo.version);
+
+        // This environment variable can be removed post-release.
         const templatesVersionMinimum = process.env.CRA_INTERNAL_TEST
           ? '3.2.0'
           : '3.3.0';
@@ -454,7 +456,7 @@ function run(
 
         // Only support templates when used alongside new react-scripts versions.
         const supportsTemplates = semver.gte(
-          semver.coerce(packageVersion),
+          packageVersion,
           templatesVersionMinimum
         );
         if (supportsTemplates) {


### PR DESCRIPTION
A small change, this doesn't require a release/update to the current beta for templates.

The `packageVersion` was already coerced on line 445. I've also added a note to remove the env variable post official release.