### PR TITLE
chore: Fix broken link for CRA deployment

### DIFF
--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -39,7 +39,7 @@ function printHostingInstructions(
   console.log();
   console.log('Find out more about deployment here:');
   console.log();
-  console.log(`  ${chalk.yellow('https://bit.ly/CRA-deploy')}`);
+  console.log(`  ${chalk.yellow('https://create-react-app.dev/docs/deployment')}`);
   console.log();
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

### Problem

From the build,

```
Find out more about deployment here:

  https://bit.ly/CRA-deploy

Done in 64.14s.
```

The link `https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#deployment` doesn't work anymore.

### Proposed solution

Change it to `https://create-react-app.dev/docs/deployment`.