### PR TITLE
Set resetMocks to true by default in jest config

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -65,6 +65,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
       'jest-watch-typeahead/filename',
       'jest-watch-typeahead/testname',
     ],
+    resetMocks: true,
   };
   if (rootDir) {
     config.rootDir = rootDir;


### PR DESCRIPTION
- Add `resetMocks: true` to the template in createJestConfig
- This is a best practice (but not required) for working with RTL tests (https://github.com/facebook/create-react-app/pull/7881)

See also https://github.com/facebook/jest/issues/9047