### PR TITLE
Minimal supported node version 

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -215,11 +215,11 @@ function createApp(
   usePnp,
   useTypeScript
 ) {
-  const unsupportedNodeVersion = !semver.satisfies(process.version, '>=8.10.0');
+  const unsupportedNodeVersion = !semver.satisfies(process.version, '>=8.16.0');
   if (unsupportedNodeVersion && useTypeScript) {
     console.log(
       chalk.red(
-        `You are using Node ${process.version} with the TypeScript template. Node 8.10 or higher is required to use TypeScript.\n`
+        `You are using Node ${process.version} with the TypeScript template. Node 8.16.0 or higher is required to use TypeScript.\n`
       )
     );
 
@@ -228,7 +228,7 @@ function createApp(
     console.log(
       chalk.yellow(
         `You are using Node ${process.version} so the project will be bootstrapped with an old unsupported version of tools.\n\n` +
-          `Please update to Node 8.10 or higher for a better, fully supported experience.\n`
+          `Please update to Node 8.16.0 or higher for a better, fully supported experience.\n`
       )
     );
     // Fall back to latest supported react-scripts on Node 4
@@ -530,7 +530,7 @@ function run(
           console.log(
             chalk.yellow(
               `\nNote: the project was bootstrapped with an old unsupported version of tools.\n` +
-                `Please update to Node >=8.10 and npm >=5 to get supported tools in new projects.\n`
+                `Please update to Node >=8.16.0 and npm >=5 to get supported tools in new projects.\n`
             )
           );
         }

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -12,7 +12,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.16"
   },
   "bugs": {
     "url": "https://github.com/facebook/create-react-app/issues"


### PR DESCRIPTION
For solve #5430.
The minimal node version supported was v8.16.0. The "fs" module require this version.
