### PR TITLE
Add Support TypeScript new optional-chaining feature

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -197,6 +197,8 @@ module.exports = function(api, opts, env) {
       isEnvTest &&
         // Transform dynamic import to require
         require('babel-plugin-dynamic-import-node'),
+      // Support TypeScript new optional-chaining feature
+      require('@babel/plugin-proposal-optional-chaining'),
     ].filter(Boolean),
     overrides: [
       isFlowEnabled && {

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -30,6 +30,7 @@
     "@babel/plugin-transform-flow-strip-types": "7.6.3",
     "@babel/plugin-transform-react-display-name": "7.2.0",
     "@babel/plugin-transform-runtime": "7.6.2",
+    "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "@babel/preset-env": "7.6.3",
     "@babel/preset-react": "7.6.3",
     "@babel/preset-typescript": "7.6.0",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
hi! recently, TypeScript release 3.7.1-rc to support optional-chaining. So, I want to use this feature in my CRA project.This PR is just doing this.