### PR TITLE
Passthrough wasm files to webpack internal loaders

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -58,6 +58,7 @@ const moduleFileExtensions = [
   'json',
   'web.jsx',
   'jsx',
+  'wasm',
 ];
 
 // Resolve file paths in the same order as webpack

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -568,9 +568,9 @@ module.exports = function(webpackEnv) {
               loader: require.resolve('file-loader'),
               // Exclude `js` files to keep "css" loader working as it injects
               // its runtime that would otherwise be processed through "file" loader.
-              // Also exclude `html` and `json` extensions so they get processed
+              // Also exclude `html`, `wasm` and `json` extensions so they get processed
               // by webpacks internal loaders.
-              exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
+              exclude: [/\.(js|mjs|jsx|ts|tsx|wasm)$/, /\.html$/, /\.json$/],
               options: {
                 name: 'static/media/[name].[hash:8].[ext]',
               },


### PR DESCRIPTION
Closes #4912.

Hi! 
I was unable to load a .wasm file in an app generated with CRA, since the file-loader was catching it and throwing an error.

After ejecting, I realized that a minor change would allow the wasm files to be handled by webpack's internal loaders. This PR adds that change to CRA, so that wasm can be used without ejecting.

I tested my changes manually, by creating an app with CRA, linking my version of react-scripts, running the app normally, and then running the app loading an hello-world wasm project.

Hope this is useful!
