### PR TITLE
Move node polyfills in webpack to prepare for webpack 5

### DIFF
--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -55,6 +55,7 @@
     "jest": "25.5.4",
     "jest-fetch-mock": "2.1.2",
     "object-assign": "4.1.1",
+    "path-browserify": "^1.0.1",
     "promise": "8.1.0",
     "raw-loader": "^3.1.0",
     "react": "^16.12.0",

--- a/packages/react-error-overlay/src/utils/unmapper.js
+++ b/packages/react-error-overlay/src/utils/unmapper.js
@@ -9,7 +9,7 @@
 import StackFrame from './stack-frame';
 import { getSourceMap } from './getSourceMap';
 import { getLinesAround } from './getLinesAround';
-import path from 'path';
+import path from 'path-browserify';
 
 function count(search: string, string: string): number {
   // Count starts at -1 because a do-while loop always runs at least once


### PR DESCRIPTION
I've started to work on webpack 5 in CRA and I will make a draft PR soon.

[Webpack 5 removes automatic node.js polyfills](https://github.com/webpack/changelog-v5/blob/master/README.md#automatic-nodejs-polyfills-removed) (Concerns: Link mentions automatic pollyfill removal might not make it to final release depending on community feedback)

In preparation for that I replaced the webpack polyfill with a 3rd party.
https://github.com/browserify/path-browserify/


