### PR TITLE
Create jsconfig.json

### DIFF
--- a/packages/cra-template/template/jsconfig.json
+++ b/packages/cra-template/template/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "*": [
+        "src/*"
+      ]
+    }
+  },
+  "include": [
+    "src/*"
+  ]
+}


### PR DESCRIPTION
I was adding this file to make easy import as an absolute path from `src/*` folder.

[Custom import paths jsconfig.json](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360002490579-Custom-import-paths-jsconfig-json)
[jsconfig.jsin](https://code.visualstudio.com/docs/languages/jsconfig)

