### PR TITLE
Update babel core to 7.7.0 and typescript to 3.7

### DIFF
--- a/packages/babel-plugin-named-asset-import/package.json
+++ b/packages/babel-plugin-named-asset-import/package.json
@@ -16,7 +16,7 @@
     "index.js"
   ],
   "peerDependencies": {
-    "@babel/core": "^7.1.0"
+    "@babel/core": "^7.7.0"
   },
   "devDependencies": {
     "babel-plugin-tester": "^7.0.1",

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -21,9 +21,9 @@
     "test.js"
   ],
   "dependencies": {
-    "@babel/core": "7.6.4",
-    "@babel/plugin-proposal-class-properties": "7.5.5",
-    "@babel/plugin-proposal-decorators": "7.6.0",
+    "@babel/core": "7.7.0",
+    "@babel/plugin-proposal-class-properties": "7.7.0",
+    "@babel/plugin-proposal-decorators": "7.7.0",
     "@babel/plugin-proposal-numeric-separator": "7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "7.6.2",
     "@babel/plugin-syntax-dynamic-import": "7.2.0",
@@ -31,10 +31,10 @@
     "@babel/plugin-transform-flow-strip-types": "7.6.3",
     "@babel/plugin-transform-react-display-name": "7.2.0",
     "@babel/plugin-transform-runtime": "7.6.2",
-    "@babel/preset-env": "7.6.3",
-    "@babel/preset-react": "7.6.3",
-    "@babel/preset-typescript": "7.6.0",
-    "@babel/runtime": "7.6.3",
+    "@babel/preset-env": "7.7.1",
+    "@babel/preset-react": "7.7.0",
+    "@babel/preset-typescript": "7.7.0",
+    "@babel/runtime": "7.7.1",
     "babel-plugin-dynamic-import-node": "2.3.0",
     "babel-plugin-macros": "2.6.1",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24"

--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -7,6 +7,6 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "@types/jest": "^24.0.0",
-    "typescript": "^3.6.0"
+    "typescript": "^3.7.1-rc"
   }
 }

--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -7,6 +7,6 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "@types/jest": "^24.0.0",
-    "typescript": "^3.7.1-rc"
+    "typescript": "^3.7.2"
   }
 }

--- a/packages/cra-template-typescript/template/src/serviceWorker.ts
+++ b/packages/cra-template-typescript/template/src/serviceWorker.ts
@@ -83,9 +83,7 @@ function registerValidSW(swUrl: string, config?: Config) {
               );
 
               // Execute callback
-              if (config && config.onUpdate) {
-                config.onUpdate(registration);
-              }
+              config?.onUpdate?.(registration);
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a
@@ -93,9 +91,7 @@ function registerValidSW(swUrl: string, config?: Config) {
               console.log('Content is cached for offline use.');
 
               // Execute callback
-              if (config && config.onSuccess) {
-                config.onSuccess(registration);
-              }
+              config?.onSuccess?.(registration);
             }
           }
         };

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -35,7 +35,7 @@
   ],
   "devDependencies": {
     "@babel/code-frame": "7.5.5",
-    "@babel/core": "7.6.4",
+    "@babel/core": "7.7.0",
     "anser": "1.4.8",
     "babel-eslint": "10.0.3",
     "babel-jest": "^24.9.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -28,7 +28,7 @@
   },
   "types": "./lib/react-app.d.ts",
   "dependencies": {
-    "@babel/core": "7.6.4",
+    "@babel/core": "^7.7.0",
     "@svgr/webpack": "4.3.3",
     "@typescript-eslint/eslint-plugin": "^2.5.0",
     "@typescript-eslint/parser": "^2.5.0",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

babel 7.7.0 is released (and I want to use TypeScript 3.7 features)
https://babeljs.io/blog/2019/11/05/7.7.0