### PR TITLE
Webpack 5

### DIFF
--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -64,7 +64,7 @@
     "settle-promise": "1.0.0",
     "source-map": "0.5.6",
     "terser-webpack-plugin": "2.3.0",
-    "webpack": "^4.35.0"
+    "webpack": "5.0.0-beta.9"
   },
   "jest": {
     "setupFiles": [

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -83,5 +83,8 @@
       "/fixtures/",
       "setupJest.js"
     ]
+  },
+  "dependencies": {
+    "path-browserify": "^1.0.0"
   }
 }

--- a/packages/react-error-overlay/src/utils/unmapper.js
+++ b/packages/react-error-overlay/src/utils/unmapper.js
@@ -9,7 +9,7 @@
 import StackFrame from './stack-frame';
 import { getSourceMap } from './getSourceMap';
 import { getLinesAround } from './getLinesAround';
-import path from 'path';
+import path from 'path-browserify';
 
 function count(search: string, string: string): number {
   // Count starts at -1 because a do-while loop always runs at least once

--- a/packages/react-error-overlay/webpack.config.js
+++ b/packages/react-error-overlay/webpack.config.js
@@ -38,10 +38,11 @@ module.exports = {
   optimization: {
     nodeEnv: false,
   },
-  node: {
-    fs: 'empty',
-    process: false,
-  },
+  // todo: Update before final webpack 5 release
+  // node: {
+  //   fs: 'empty',
+  //   process: false,
+  // },
   performance: {
     hints: false,
   },

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -674,7 +674,10 @@ module.exports = function(webpackEnv) {
       // solution that requires the user to opt into importing specific locales.
       // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
       // You can remove this if you don't use Moment.js:
-      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+      new webpack.IgnorePlugin({
+        resourceRegExp: /^\.\/locale$/,
+        contextRegExp: /moment$/,
+      }),
       // Generate a service worker script that will precache, and keep up to date,
       // the HTML & assets that are part of the Webpack build.
       isEnvProduction &&

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -186,8 +186,6 @@ module.exports = function(webpackEnv) {
       filename: isEnvProduction
         ? 'static/js/[name].[contenthash:8].js'
         : isEnvDevelopment && 'static/js/bundle.js',
-      // TODO: remove this when upgrading to webpack 5
-      futureEmitAssets: true,
       // There are also additional JS chunk files if you use code splitting.
       chunkFilename: isEnvProduction
         ? 'static/js/[name].[contenthash:8].chunk.js'

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -726,16 +726,17 @@ module.exports = function(webpackEnv) {
     ].filter(Boolean),
     // Some libraries import Node modules but don't use them in the browser.
     // Tell Webpack to provide empty mocks for them so importing them works.
-    node: {
-      module: 'empty',
-      dgram: 'empty',
-      dns: 'mock',
-      fs: 'empty',
-      http2: 'empty',
-      net: 'empty',
-      tls: 'empty',
-      child_process: 'empty',
-    },
+    // todo: Update before final webpack 5 release
+    // node: {
+    //   module: 'empty',
+    //   dgram: 'empty',
+    //   dns: 'mock',
+    //   fs: 'empty',
+    //   http2: 'empty',
+    //   net: 'empty',
+    //   tls: 'empty',
+    //   child_process: 'empty',
+    // },
     // Turn off performance processing because we utilize
     // our own hints via the FileSizeReporter
     performance: false,

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -76,8 +76,8 @@
     "terser-webpack-plugin": "2.3.0",
     "ts-pnp": "1.1.5",
     "url-loader": "2.3.0",
-    "webpack": "4.41.2",
-    "webpack-dev-server": "3.9.0",
+    "webpack": "5.0.0-beta.9",
+    "webpack-dev-server": "3.10.0",
     "webpack-manifest-plugin": "2.2.0",
     "workbox-webpack-plugin": "4.3.1"
   },


### PR DESCRIPTION
This draft PR aims to integrate webpack 5 into `create-react-app`. 
Integration is currently in early stages and not ready to for community testing yet as there are a couple of tasks to resolve before we have first successful builds. Thank you for your patience! 

> 11/05/2019  Initial draft PR

### Internal work

|   | Description | Commit |
| --- | --- | --- |
| ✔️ | Make sure to use `mode`  | (we do since webpack 4)  |  
| ✔️ | Upgrade webpack to webpack 5 | https://github.com/facebook/create-react-app/commit/1ae2d5dbcdc22b692c33d8dd9a37f9c75ce7c873 | 
| ✔️ | Remove futureEmitAssets  | https://github.com/facebook/create-react-app/commit/7eabe2ac800a9e95d1fd5b329378d6750aacf3cf | 
| ✔️ | Update IgnorePlugin arg sig | https://github.com/facebook/create-react-app/commit/86b22005dda963692febf6d725d45e2d384c54f0 | 
| ⚠️ | Adjust webpack to [automatic node polyfill removal](https://github.com/webpack/changelog-v5#automatic-nodejs-polyfills-removed) (rebase #7914)  | https://github.com/facebook/create-react-app/commit/426e6ce0d12b81bdb0687efdfe6a4653ae71921f |  
| 🚧 | Upgrade all plugins and loaders to latest version  |  |  
| 🚧 | Make sure build has no errors or warnings  |  |  
| 🚧 | Remove deprecation warnings during build  |  |  
| 🚧 | [Update outdated options](https://github.com/webpack/changelog-v5/blob/master/MIGRATION%20GUIDE.md#update-outdated-options)  |  |  
| 🚧 | [Cleanup configuration](https://github.com/webpack/changelog-v5/blob/master/MIGRATION%20GUIDE.md#cleanup-configuration)  |  |  


### External work

|   | Description | Link |
| --- | --- | --- |
| 🚧 | mini-css-extract-plugin compatibility  | https://github.com/webpack-contrib/mini-css-extract-plugin/pull/458 |

