### PR TITLE
No spinning React logo if `prefers-reduced-motion`

### DIFF
--- a/packages/cra-template/template/src/App.css
+++ b/packages/cra-template/template/src/App.css
@@ -3,9 +3,14 @@
 }
 
 .App-logo {
-  animation: App-logo-spin infinite 20s linear;
   height: 40vmin;
   pointer-events: none;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .App-logo {
+    animation: App-logo-spin infinite 20s linear;
+  }
 }
 
 .App-header {


### PR DESCRIPTION
The `prefers-reduced-motion` CSS media feature is used to detect if the user has requested that the system minimize the amount of animation or motion it uses.

This PR detects this, and prevents the spinning React logo from spinning.

Here it is as shown with and without the "Reduce motion" setting in the Accessibility section of the macOS System Preferences. 

![Screen Recording 2019-11-01 at 11 05 54 AM](https://user-images.githubusercontent.com/887639/68238958-1b723880-ffd8-11e9-8104-69cff9b0eeae.gif)
