### PR TITLE
Fix light background in docusaurus night mode

### DIFF
--- a/docusaurus/website/src/pages/index.js
+++ b/docusaurus/website/src/pages/index.js
@@ -79,7 +79,7 @@ function Home() {
           </div>
         </div>
       )}
-      <div className={styles.lightBackground}>
+      <div className={styles.gettingStartedSection}>
         <div className="container padding-vert--xl text--left">
           <div className="row">
             <div className="col col--4 col--offset-1">

--- a/docusaurus/website/src/pages/styles.module.css
+++ b/docusaurus/website/src/pages/styles.module.css
@@ -42,5 +42,8 @@
 
 .lightBackground {
   background-color: #f7f7f7;
-  color: rgb(31, 34, 39);
+}
+
+html[data-theme='dark'] .lightBackground {
+  background-color: #33363b;
 }

--- a/docusaurus/website/src/pages/styles.module.css
+++ b/docusaurus/website/src/pages/styles.module.css
@@ -40,10 +40,10 @@
   margin: 0 auto;
 }
 
-.lightBackground {
+.gettingStartedSection {
   background-color: #f7f7f7;
 }
 
-html[data-theme='dark'] .lightBackground {
+html[data-theme='dark'] .gettingStartedSection {
   background-color: #33363b;
 }


### PR DESCRIPTION
Closes #7930

Tested with the manual toggle, and with setting `prefers-color-scheme`. Not sure if there's a cleaner way to do this, but it works.
