### PR TITLE
[TypeScript] Drop `allowSyntheticDefaultImports` default value

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -103,7 +103,6 @@ function verifyTypeScriptSetup() {
     allowJs: { suggested: true },
     skipLibCheck: { suggested: true },
     esModuleInterop: { suggested: true },
-    allowSyntheticDefaultImports: { suggested: true },
     strict: { suggested: true },
     forceConsistentCasingInFileNames: { suggested: true },
     // TODO: Enable for v4.0 (#6936)


### PR DESCRIPTION
It's unnecessary because `esModuleInterop: true` already implies `allowSyntheticDefaultImports: true`. Therefore it produces only unnecessary noise in the generated `tsconfig.json`.

See https://www.typescriptlang.org/docs/handbook/compiler-options.html.