### PR TITLE
Support JetBrains Rider IDE as an editor

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -60,6 +60,8 @@ const COMMON_EDITORS_OSX = {
   '/Applications/MacVim.app/Contents/MacOS/MacVim': 'mvim',
   '/Applications/GoLand.app/Contents/MacOS/goland':
     '/Applications/GoLand.app/Contents/MacOS/goland',
+  '/Applications/Rider.app/Contents/MacOS/rider':
+    '/Applications/Rider.app/Contents/MacOS/rider',
 };
 
 const COMMON_EDITORS_LINUX = {
@@ -78,6 +80,7 @@ const COMMON_EDITORS_LINUX = {
   vim: 'vim',
   'webstorm.sh': 'webstorm',
   'goland.sh': 'goland',
+  'rider.sh': 'rider',
 };
 
 const COMMON_EDITORS_WIN = [
@@ -102,6 +105,8 @@ const COMMON_EDITORS_WIN = [
   'webstorm64.exe',
   'goland.exe',
   'goland64.exe',
+  'rider.exe',
+  'rider64.exe',
 ];
 
 // Transpiled version of: /^([A-Za-z]:[/\\])?[\p{L}0-9/.\-_\\]+$/u
@@ -174,6 +179,8 @@ function getArgumentsForLineNumber(
     case 'webstorm64':
     case 'goland':
     case 'goland64':
+    case 'rider':
+    case 'rider64':
       return addWorkspaceToArgumentsIfExists(
         ['--line', lineNumber, fileName],
         workspace


### PR DESCRIPTION
Rider is JetBrains .NET IDE, which supports the React plugin identically to other JetBrains IDEs such as Idea and WebStorm.
