### PR TITLE
Fix preprocessors not running on stylesheets imported from stylesheets

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -141,6 +141,8 @@ module.exports = function(webpackEnv) {
             sourceMap: true,
           },
         }
+        // ** STOP ** Are you adding a new loader after css-loader?
+        // Make sure to increment importLoaders appropriately where getStyleLoaders is called.
       );
     }
     return loaders;
@@ -528,7 +530,7 @@ module.exports = function(webpackEnv) {
               exclude: sassModuleRegex,
               use: getStyleLoaders(
                 {
-                  importLoaders: 2,
+                  importLoaders: 3,
                   sourceMap: isEnvProduction && shouldUseSourceMap,
                 },
                 'sass-loader'
@@ -545,7 +547,7 @@ module.exports = function(webpackEnv) {
               test: sassModuleRegex,
               use: getStyleLoaders(
                 {
-                  importLoaders: 2,
+                  importLoaders: 3,
                   sourceMap: isEnvProduction && shouldUseSourceMap,
                   modules: {
                     getLocalIdent: getCSSModuleLocalIdent,


### PR DESCRIPTION
Fixes https://github.com/facebook/create-react-app/issues/7919 and fixes https://github.com/facebook/create-react-app/issues/7777

An extra loader to preprocessed CSS files was introduced in https://github.com/facebook/create-react-app/commit/914c95e87facb7ca5debf5bd5514f211807f71bf#diff-dc0c4e7c623b73660da1809fc60cf6ba, but the `importLoaders` option was not updated to account for this.

This meant that when a stylesheet was imported from another stylesheet (like when using . `@import` as reported in https://github.com/facebook/create-react-app/issues/7777,  or `composes: ` reported in https://github.com/facebook/create-react-app/issues/7919), Webpack would not run all required loaders over the imported stylesheets. As the `importLoaders` value was still `2`, it would run `postcss-loader` and `resolve-url-loader` but most importantly, it incorrectly skipped the preProcessor,

I fixed the issue here, and added a small comment warning future developers about this, as seen elsewhere in the webpack config.

I verified this change by running it over my reproduction case mention in https://github.com/facebook/create-react-app/issues/7919.