### PR TITLE
Upgrade jest-watch-typeahead

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -57,7 +57,7 @@
     "jest": "24.9.0",
     "jest-environment-jsdom-fourteen": "0.1.0",
     "jest-resolve": "24.9.0",
-    "jest-watch-typeahead": "0.4.0",
+    "jest-watch-typeahead": "0.4.1",
     "mini-css-extract-plugin": "0.8.0",
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "pnp-webpack-plugin": "1.5.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -57,7 +57,7 @@
     "jest": "24.9.0",
     "jest-environment-jsdom-fourteen": "0.1.0",
     "jest-resolve": "24.9.0",
-    "jest-watch-typeahead": "0.4.1",
+    "jest-watch-typeahead": "0.4.2",
     "mini-css-extract-plugin": "0.8.0",
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "pnp-webpack-plugin": "1.5.0",


### PR DESCRIPTION
The previous version has a confusing bug - a selected pattern gets interpreted as regexp. This has been fixed in 0.4.1 and is worth bumping a dependency here.