### PR TITLE
Add placeholders where old template READMEs used to be

### DIFF
--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -39,7 +39,7 @@ function printHostingInstructions(
   console.log();
   console.log('Find out more about deployment here:');
   console.log();
-  console.log(`  ${chalk.yellow('https://create-react-app.dev/docs/deployment')}`);
+  console.log(`  ${chalk.yellow('bit.ly/CRA-deploy')}`);
   console.log();
 }
 

--- a/packages/react-scripts/template-typescript/README.md
+++ b/packages/react-scripts/template-typescript/README.md
@@ -1,0 +1,1 @@
+This file has moved [here](https://github.com/facebook/create-react-app/blob/master/packages/cra-template-typescript/template/README.md)

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1,0 +1,1 @@
+This file has moved [here](https://github.com/facebook/create-react-app/blob/master/packages/cra-template/template/README.md)


### PR DESCRIPTION
Since there are millions of existing apps out there that link to the old template READMEs we should have a placeholder there that links to the new location.
