### PR TITLE
Add scripts support to templates

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -105,16 +105,44 @@ module.exports = function(
     '..'
   );
 
+  let templateJsonPath;
+  if (templateName) {
+    templateJsonPath = path.join(templatePath, 'template.json');
+  } else {
+    // TODO: Remove support for this in v4.
+    templateJsonPath = path.join(appPath, '.template.dependencies.json');
+  }
+
+  let templateJson = {};
+  if (fs.existsSync(templateJsonPath)) {
+    templateJson = require(templateJsonPath);
+  }
+
   // Copy over some of the devDependencies
   appPackage.dependencies = appPackage.dependencies || {};
 
   // Setup the script rules
-  appPackage.scripts = {
-    start: 'react-scripts start',
-    build: 'react-scripts build',
-    test: 'react-scripts test',
-    eject: 'react-scripts eject',
-  };
+  const templateScripts = templateJson.scripts || {};
+  appPackage.scripts = Object.assign(
+    {
+      start: 'react-scripts start',
+      build: 'react-scripts build',
+      test: 'react-scripts test',
+      eject: 'react-scripts eject',
+    },
+    templateScripts
+  );
+
+  // Update scripts for Yarn users
+  if (useYarn) {
+    appPackage.scripts = Object.entries(appPackage.scripts).reduce(
+      (acc, [key, value]) => ({
+        ...acc,
+        [key]: value.replace(/(npm run |npm )/, 'yarn '),
+      }),
+      {}
+    );
+  }
 
   // Setup the eslint config
   appPackage.eslintConfig = {
@@ -196,21 +224,13 @@ module.exports = function(
   }
 
   // Install additional template dependencies, if present
-  let templateJsonPath;
-  if (templateName) {
-    templateJsonPath = path.join(templatePath, 'template.json');
-  } else {
-    templateJsonPath = path.join(appPath, '.template.dependencies.json');
-  }
-
-  if (fs.existsSync(templateJsonPath)) {
-    const templateDependencies = require(templateJsonPath).dependencies;
+  const templateDependencies = templateJson.dependencies;
+  if (templateDependencies) {
     args = args.concat(
       Object.keys(templateDependencies).map(key => {
         return `${key}@${templateDependencies[key]}`;
       })
     );
-    fs.unlinkSync(templateJsonPath);
   }
 
   // Install react and react-dom for backward compatibility with old CRA cli


### PR DESCRIPTION
To test, add a "scripts" key to any `template.json` file, and use that template.

This code merges keys in, allowing template authors to add or replace the default scripts.

---

Example command below. While testing, you may need to bump the `react-scripts` version (via `package.json`) to `3.3.0`.
```
node ./create-react-app/packages/create-react-app template-test \                                                                                                                                                                                                           feat/template-scripts
  --template file:./create-react-app/packages/cra-template-typescript/ \
  --scripts-version file:./create-react-app/packages/react-scripts/
```