### PR TITLE
Disable resolve.symlinks.

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -401,6 +401,9 @@ module.exports = function(webpackEnv) {
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
               include: paths.appSrc,
+              resolve: {
+                symlinks: false
+              },
               loader: require.resolve('babel-loader'),
               options: {
                 customize: require.resolve(


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Hi all,

I have a non-monorepo use case where I'd like to import ES6 files from outside of the `src` folder via symlink, as recommended by [a CRA error message](https://stackoverflow.com/questions/44114436/the-create-react-app-imports-restriction-outside-of-src-directory).

Importing through a symlink gives me [this issue](https://github.com/facebook/create-react-app/issues/3547#issue-278993779), where the file is imported but not processed with the rest of the code under `src/`, as one would expect. My PR seems to solve it by treating symlinked files as if they were under `src/`, according to the well-received solution [here](https://github.com/webpack/webpack/issues/1643#issuecomment-317436595).

[Demo repo](https://github.com/joshwilsonvu/react-scripts-pr-test), with screenshots. The solution works at least for files under the project root.

