### PR TITLE
Use @typescript-eslint/no-unused-expressions to support optional chaining

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -92,6 +92,15 @@ module.exports = {
             typedefs: false,
           },
         ],
+        'no-unused-expressions': 'off',
+        '@typescript-eslint/no-unused-expressions': [
+          'error',
+          {
+            allowShortCircuit: true,
+            allowTernary: true,
+            allowTaggedTemplates: true,
+          },
+        ],
         'no-unused-vars': 'off',
         '@typescript-eslint/no-unused-vars': [
           'warn',


### PR DESCRIPTION
Eslint's `no-unused-expressions` rule doesn't support the new optional chaining syntax and yields false positives. Typescript-eslints's equivalent [was recently updated](https://github.com/typescript-eslint/typescript-eslint/pull/1175) to support it, so use it instead.

This fix only affects TypeScript, so in order to make it work for plain JavaScript we'd have to wait for official Eslint support or perhaps add another plugin like [this one](https://github.com/babel/eslint-plugin-babel).

![image](https://user-images.githubusercontent.com/3779535/69186728-66806580-0b19-11ea-81d6-e71da7d9e56f.png)

