### PR TITLE
Prefix apple-touch-icon links with PUBLIC_URL

### DIFF
--- a/packages/cra-template-typescript/template/public/index.html
+++ b/packages/cra-template-typescript/template/public/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="logo192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/packages/cra-template/template/public/index.html
+++ b/packages/cra-template/template/public/index.html
@@ -9,7 +9,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="logo192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
The link for apple-touch-icon is the only URL in the templates' `index.html`s that is relative, rather than using the `%PUBLIC_URL%` prefix.

Having all URLs in `index.html` be absolute makes it possible to host the site in one URL and alias `index.html` from another.  This is helpful, for example, when proxying a site into an Azure Functions domain.