### PR TITLE
Add App.module.css instead of App.css on project initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ my-app
 │   ├── index.html
 │   └── manifest.json
 └── src
-    ├── App.css
+    ├── App.module.css
     ├── App.js
     ├── App.test.js
     ├── index.css

--- a/packages/cra-template-typescript/template/src/App.module.css
+++ b/packages/cra-template-typescript/template/src/App.module.css
@@ -1,19 +1,19 @@
-.App {
+.app {
   text-align: center;
 }
 
-.App-logo {
+.logo {
   height: 40vmin;
   pointer-events: none;
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .App-logo {
+  .logo {
     animation: App-logo-spin infinite 20s linear;
   }
 }
 
-.App-header {
+.header {
   background-color: #282c34;
   min-height: 100vh;
   display: flex;
@@ -24,7 +24,7 @@
   color: white;
 }
 
-.App-link {
+.link {
   color: #61dafb;
 }
 

--- a/packages/cra-template-typescript/template/src/App.tsx
+++ b/packages/cra-template-typescript/template/src/App.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import logo from './logo.svg';
-import './App.css';
+import styles from './App.module.css';
 
 const App: React.FC = () => {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
+    <div className={styles.app}>
+      <header className={styles.header}>
+        <img src={logo} className={styles.logo} alt="logo" />
         <p>
           Edit <code>src/App.tsx</code> and save to reload.
         </p>
         <a
-          className="App-link"
+          className={styles.link}
           href="https://reactjs.org"
           target="_blank"
           rel="noopener noreferrer"

--- a/packages/cra-template/template/src/App.js
+++ b/packages/cra-template/template/src/App.js
@@ -1,17 +1,17 @@
 import React from 'react';
 import logo from './logo.svg';
-import './App.css';
+import styles from './App.module.css';
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
+    <div className={styles.app}>
+      <header className={styles.header}>
+        <img src={logo} className={styles.logo} alt="logo" />
         <p>
           Edit <code>src/App.js</code> and save to reload.
         </p>
         <a
-          className="App-link"
+          className={styles.link}
           href="https://reactjs.org"
           target="_blank"
           rel="noopener noreferrer"

--- a/packages/cra-template/template/src/App.module.css
+++ b/packages/cra-template/template/src/App.module.css
@@ -1,19 +1,19 @@
-.App {
+.app {
   text-align: center;
 }
 
-.App-logo {
+.logo {
   height: 40vmin;
   pointer-events: none;
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .App-logo {
+  .logo {
     animation: App-logo-spin infinite 20s linear;
   }
 }
 
-.App-header {
+.header {
   background-color: #282c34;
   min-height: 100vh;
   display: flex;
@@ -24,7 +24,7 @@
   color: white;
 }
 
-.App-link {
+.link {
   color: #61dafb;
 }
 


### PR DESCRIPTION
The idea behind this change is to show how CSS Modules works in CRA. 

In the end a new project shows how to import a regular stylesheet in the index.js and how to import CSS Module.

This change came in my mind after this thread:
https://twitter.com/dan_abramov/status/1195440508681646080?s=20

![image](https://user-images.githubusercontent.com/46542370/69226154-bfd7ab80-0b90-11ea-8787-237555525d28.png)
