### PR TITLE
Update chokidar to v3

### DIFF
--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -42,7 +42,7 @@
     "babel-loader": "8.0.6",
     "babel-preset-react-app": "^9.0.2",
     "chalk": "^2.4.2",
-    "chokidar": "^2.1.2",
+    "chokidar": "^3.3.0",
     "cross-env": "5.2.1",
     "eslint": "^6.1.0",
     "eslint-config-react-app": "^5.0.2",


### PR DESCRIPTION
chokidar depends on fsevents. v1.x of fsevents is deprecated and superceded by v2.x which is updated in chokidar v3. This should now be urgently updated.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
