### PR TITLE
Set compact option to true for dependencies

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -458,7 +458,7 @@ module.exports = function(webpackEnv) {
               options: {
                 babelrc: false,
                 configFile: false,
-                compact: false,
+                compact: true,
                 presets: [
                   [
                     require.resolve('babel-preset-react-app/dependencies'),


### PR DESCRIPTION
It's weird why the option `compact` is set to `false` for dependencies before, but for performance reason (if any), it should be set to `true`.

See:
- https://babeljs.io/docs/en/options#compact
- https://babeljs.io/docs/en/options#overrides