### PR TITLE
Add onUpdate() configuration to service worker registration

### DIFF
--- a/packages/cra-template-typescript/template/src/serviceWorker.ts
+++ b/packages/cra-template-typescript/template/src/serviceWorker.ts
@@ -23,6 +23,7 @@ const isLocalhost = Boolean(
 type Config = {
   onSuccess?: (registration: ServiceWorkerRegistration) => void;
   onUpdate?: (registration: ServiceWorkerRegistration) => void;
+  onWaiting?: (serviceWorker: ServiceWorker) => void
 };
 
 export function register(config?: Config) {
@@ -66,9 +67,16 @@ function registerValidSW(swUrl: string, config?: Config) {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
+      if (registration.waiting &&
+        config &&
+        config.onWaiting &&
+        registration.waiting.scriptURL === swUrl
+      ) {
+        config.onWaiting(registration.waiting)
+      }
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
-        if (installingWorker == null) {
+        if (installingWorker == null || installingWorker.scriptURL !== swUrl) {
           return;
         }
         installingWorker.onstatechange = () => {

--- a/packages/cra-template/template/src/serviceWorker.js
+++ b/packages/cra-template/template/src/serviceWorker.js
@@ -58,9 +58,17 @@ function registerValidSW(swUrl, config) {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
+      if (
+        registration.waiting &&
+        config &&
+        config.onWaiting &&
+        registration.waiting.scriptURL === swUrl
+      ) {
+        config.onWaiting(registration.waiting);
+      }
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
-        if (installingWorker == null) {
+        if (installingWorker == null || installingWorker.scriptURL !== swUrl) {
           return;
         }
         installingWorker.onstatechange = () => {
@@ -101,7 +109,7 @@ function registerValidSW(swUrl, config) {
 function checkValidServiceWorker(swUrl, config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl, {
-    headers: { 'Service-Worker': 'script' }
+    headers: { 'Service-Worker': 'script' },
   })
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.


### PR DESCRIPTION
This enables users to tell the service worker to skip waiting.

Example:
```
serviceWorker.register({
  ...
   onWaiting((waitingWorker) => {
     waitingWorker.postMessage({ type: "SKIP_WAITING" })
     window.location.reload();
   })
...
});
```

This PR also adds check if multiple service workers are registered so only the correct one triggers the callbacks we pass to `serviceWorker.register`


