### PR TITLE
Update babel-plugin-macros to 2.7.1

### DIFF
--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -38,7 +38,7 @@
     "@babel/preset-typescript": "7.7.2",
     "@babel/runtime": "7.7.2",
     "babel-plugin-dynamic-import-node": "2.3.0",
-    "babel-plugin-macros": "2.6.2",
+    "babel-plugin-macros": "2.7.1",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24"
   }
 }


### PR DESCRIPTION
This PR updates `babel-plugin-macros` to 2.7.1.

Version 2.7.1 contains [this fix](https://github.com/kentcdodds/babel-plugin-macros/pull/136) that avoids flooding the console with messages resembling more or less the following:

```
There was an error trying to load the config "styledComponents" for the macro imported from "styled-components/macro
```

Fixes https://github.com/facebook/create-react-app/issues/7524

Related: https://github.com/styled-components/styled-components/issues/2713