### PR TITLE
fix: measureFileSizesBeforeBuild should return real file size

### DIFF
--- a/packages/react-dev-utils/FileSizeReporter.js
+++ b/packages/react-dev-utils/FileSizeReporter.js
@@ -136,9 +136,9 @@ function measureFileSizesBeforeBuild(buildFolder) {
       var sizes;
       if (!err && fileNames) {
         sizes = fileNames.filter(canReadAsset).reduce((memo, fileName) => {
-          var contents = fs.readFileSync(fileName);
+          var fileStat = fs.statSync(fileName);
           var key = removeFileNameHash(buildFolder, fileName);
-          memo[key] = gzipSize(contents);
+          memo[key] = fileStat.size;
           return memo;
         }, {});
       }


### PR DESCRIPTION
react-dev-utils/FileSizeReporter.js

function measureFileSizesBeforeBuild should return real file size not after gzip.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
