### PR TITLE
fix(react-scripts): proactively append to .gitignore during generation

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -190,23 +190,20 @@ module.exports = function(
     }
   }
 
-  // Rename gitignore after the fact to prevent npm from renaming it to .npmignore
-  // See: https://github.com/npm/npm/issues/1862
-  try {
+  const gitignoreExists = fs.existsSync(path.join(appPath, '.gitignore'));
+  if (gitignoreExists) {
+    // Append if there's already a `.gitignore` file there
+    const data = fs.readFileSync(path.join(appPath, 'gitignore'));
+    fs.appendFileSync(path.join(appPath, '.gitignore'), data);
+    fs.unlinkSync(path.join(appPath, 'gitignore'));
+  } else {
+    // Rename gitignore after the fact to prevent npm from renaming it to .npmignore
+    // See: https://github.com/npm/npm/issues/1862
     fs.moveSync(
       path.join(appPath, 'gitignore'),
       path.join(appPath, '.gitignore'),
       []
     );
-  } catch (err) {
-    // Append if there's already a `.gitignore` file there
-    if (err.code === 'EEXIST') {
-      const data = fs.readFileSync(path.join(appPath, 'gitignore'));
-      fs.appendFileSync(path.join(appPath, '.gitignore'), data);
-      fs.unlinkSync(path.join(appPath, 'gitignore'));
-    } else {
-      throw err;
-    }
   }
 
   let command;


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

close #7892

Proactively append to `.gitignore` during generation instead relying on a `try/catch`

As #7892 illustrates, relying on the `EEXISTS` error is not reliable after the `fs-extra@8.X` upgrade. This fact was [confirmed by the `fs-extra` team](https://github.com/jprichardson/node-fs-extra/issues/734) when I opened an an issue with them.

The solution is to check whether or not `.gitignore` exists in the current repo and proactively append `gitignore` to it, rather than rely on the try catch logic to sniff for `EEXISTS` / `dest already exists` errors from `fs-extra`

### Testing

I attempted to test this:

1. adding a directory to the monorepo, `foo` 
1. placing a `.gitignore` into it with contents. 
1. I commit that to avoid the git status porcelain check
1. Run `yarn create-react-app foo --template typescript`

This succeeds, but gives me warnings about not having a version that supports `template`. If I do not supply a template, the CLI tells me none was applied.

When I run this without the `template` arg, I get a reverse error message, stating no template was applied. Having maintained a fork for a long time, I know not to rely on the npm script `create-react-app` as gospel for a real generation. I also know that this new template functionality is still in progress - so I am guessing it's just a quick of this being a bit in-flight.

I think a better approach may be to add a check for this proper appending via CI, but I wanted to get this out here first. I'd also state that the code is pretty darn simple, mostly co-opted from the existing try / catch, and that I don't see any `.gitignore` coverage currently in the e2e tests. Perhaps a visual review is okay without a formal test - but I'll leave that to the maintainers to decide.

