### PR TITLE
Add TypeScript peer dependency to react-scripts

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -88,6 +88,9 @@
   "optionalDependencies": {
     "fsevents": "2.1.2"
   },
+  "peerDependencies": {
+    "typescript": "^3.2.1"
+  },
   "peerDependenciesMeta": {
     "typescript": {
       "optional": true


### PR DESCRIPTION
This is currently missing and will break Yarn PnP. We're requiring `^3.2.1` as this is the minimum version requirement of `@typescript/eslint`.

cc @ianschmitz @mrmckeb 

Closes #8022 