### PR TITLE
Disable ESLint's buggy no-unused-expressions rule

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -189,14 +189,7 @@ module.exports = {
     'no-undef': 'error',
     'no-restricted-globals': ['error'].concat(restrictedGlobals),
     'no-unreachable': 'warn',
-    'no-unused-expressions': [
-      'error',
-      {
-        allowShortCircuit: true,
-        allowTernary: true,
-        allowTaggedTemplates: true,
-      },
-    ],
+    'no-unused-expressions': 'off',
     'no-unused-labels': 'warn',
     'no-unused-vars': [
       'warn',


### PR DESCRIPTION
ESLint's [`no-unused-expressions` rule](https://eslint.org/docs/rules/no-unused-expressions) is buggy. It currently considers the `r()` in `r(), e.retry()` to be an "unused expression" which they define as an expression "which has no effect on the state of the program". So I'm suggesting we disable it entirely in CRA.

Side note: I noticed [it's already disabled for TypeScript users](https://github.com/facebook/create-react-app/blob/29c5e55adef2ce11e69b8d9584a664e94e6d9151/packages/eslint-config-react-app/index.js#L95) so this change maintains parity with linting TS. Or hey, maybe I should just go write all my code in TypeScript :P 