### PR TITLE
webpackHotDevClient now uses wss when https is used

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -59,7 +59,7 @@ if (module.hot && typeof module.hot.dispose === 'function') {
 // Connect to WebpackDevServer via a socket.
 var connection = new WebSocket(
   url.format({
-    protocol: 'ws',
+    protocol: window.location.protocol === 'https:' ? 'wss' : 'ws',
     hostname: window.location.hostname,
     port: window.location.port,
     // Hardcoded in WebpackDevServer


### PR DESCRIPTION
Fixes #8075.

**Summary**
* If https protocol is being used we should use WebSockets over SSL/TLS (WSS) protocol instead of WebSockets (WS)
 
**Test Plan**
Follow steps in the issue https://github.com/facebook/create-react-app/issues/8075