### PR TITLE
Add titleProp to SVGR ReactComponent type definition

### DIFF
--- a/packages/react-scripts/lib/react-app.d.ts
+++ b/packages/react-scripts/lib/react-app.d.ts
@@ -42,7 +42,9 @@ declare module '*.webp' {
 declare module '*.svg' {
   import * as React from 'react';
 
-  export const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  export const ReactComponent: React.FunctionComponent<React.SVGProps<
+    SVGSVGElement
+  > & { title?: string }>;
 
   const src: string;
   export default src;


### PR DESCRIPTION
After #7118 was merged, the `react-app.d.ts` wasn't updated to reflect the new property added, this PR adds that property