### PR TITLE
Fix CSS font-face minification

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -274,6 +274,9 @@ module.exports = function(webpackEnv) {
                 }
               : false,
           },
+          cssProcessorPluginOptions: {
+              preset: ['default', { minifyFontValues: { removeQuotes: false } }]
+          }
         }),
       ],
       // Automatically split vendor and commons


### PR DESCRIPTION
Hello!

By default CSS is minified and the quotes around CSS Font-Face names are removed (to save how many bits?). This prevents custom fonts working in IE11 and presumably others too.

This just overrides the behaviour. 

Pulled from my working production build where we fixed the bug.

See issue https://github.com/facebook/create-react-app/issues/7748

Fixes #4121