### PR TITLE
Add slashes to WebSocket protocol URL

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -64,6 +64,7 @@ var connection = new WebSocket(
     port: window.location.port,
     // Hardcoded in WebpackDevServer
     pathname: '/sockjs-node',
+    slashes: true,
   })
 );
 


### PR DESCRIPTION
Fixes #8084 

webpackHotDevClient WebSocket constructor now adds slashes between protocol and hostname, fixes issue on some browsers like IE11.