### PR TITLE
Fix typo in comment: `?.` is right, `.?` is not

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -196,7 +196,7 @@ module.exports = function(api, opts, env) {
       ],
       // Adds syntax support for import()
       require('@babel/plugin-syntax-dynamic-import').default,
-      // Adds syntax support for optional chaining (.?)
+      // Adds syntax support for optional chaining (?.)
       require('@babel/plugin-proposal-optional-chaining').default,
       // Adds syntax support for default value using ?? operator
       require('@babel/plugin-proposal-nullish-coalescing-operator').default,


### PR DESCRIPTION
This is just a comment fix.

Actual optional chaining operator syntax is `?.`, not `.?`.

https://github.com/tc39/proposal-optional-chaining#syntax

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
