### PR TITLE
fix(react-scripts): enable css grid autoprefix

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -115,6 +115,7 @@ module.exports = function(webpackEnv) {
             require('postcss-preset-env')({
               autoprefixer: {
                 flexbox: 'no-2009',
+                grid: true,
               },
               stage: 3,
             }),


### PR DESCRIPTION
https://github.com/csstools/postcss-preset-env#autoprefixer

Closes #8136

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
