### PR TITLE
Add Prettier config to app

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
   "trailingComma": "es5",
-  "singleQuote": true,
-  "semi": true
+  "singleQuote": true
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "screencast:error": "svg-term --cast jyu19xGl88FQ3poMY8Hbmfw8y --out screencast-error.svg --window --at 12000 --no-cursor",
     "alex": "alex .",
     "test": "cd packages/react-scripts && node bin/react-scripts.js test",
-    "format": "prettier --trailing-comma es5 --single-quote --write 'packages/*/*.js' 'packages/*/!(node_modules)/**/*.js'",
+    "format": "prettier --write 'packages/*/*.js' 'packages/*/!(node_modules)/**/*.js'",
     "compile:lockfile": "node tasks/compile-lockfile.js"
   },
   "devDependencies": {
@@ -50,7 +50,7 @@
   },
   "lint-staged": {
     "*.{js,md,css,html}": [
-      "prettier --trailing-comma es5 --single-quote --write",
+      "prettier --write",
       "git add"
     ],
     "yarn.lock": [

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -149,6 +149,12 @@ module.exports = function(
     extends: 'react-app',
   };
 
+  // Setup the prettier config
+  appPackage.prettier = {
+    trailingComma: 'es5',
+    singleQuote: true,
+  };
+
   // Setup the browsers list
   appPackage.browserslist = defaultBrowsers;
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

## Rationale
This monorepo has a Prettier config that affects formatting of all files, including the official templates. However, because this config isn't included in the templates, running Prettier (as recommended in the docs) will change the formatting of the app, which can be confusing or inconvenient.

## Changes made
Modified the init script to copy the monorepo's Prettier config to `package.json` (for any template). In the future we may want to make this extensible if third party templates need to set their own Prettier configs.

## Testing
Created an example app with `yarn create-react-app my-app`, confirming that the Prettier config was created in package.json and running Prettier does not reformat the files (as the formatting is already correct)