### PR TITLE
Enable GitHub repos as --template targets

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -649,8 +649,9 @@ function getTemplateInstallPackage(template, originalDirectory) {
       templateToInstall = template;
     } else {
       // Add prefix 'cra-template-' to non-prefixed templates, leaving any
-      // @scope/ intact.
-      const packageMatch = template.match(/^(@[^/]+\/)?(.+)$/);
+      // @scope/ intact. This also applies to `owner/repo` templates, which
+      // loads from a GitHub repository.
+      const packageMatch = template.match(/^(@?[^/]+\/)?(.+)$/);
       const scope = packageMatch[1] || '';
       const templateName = packageMatch[2];
 


### PR DESCRIPTION
👋 This _should_ enable users to run:

```
npx create-react-app target --template owner/repo
```

All I did was make the starting `@` optional in the scoped template string check, before prepending `cra-template-`. I don't believe this will break scoped templates, I had a hard time getting the tests to run locally.

Unfortunately, this doesn't work at the moment - it looks like CRA expects to be able to use the template string directly in a `require`, so it tries to do `require('owner/repo')`, when it should be `require('repo')`. That looks like a larger change though 😅 would love some help figuring out the best way to pass that along (cc @iansu)!

Here's the error output I'm seeing at the moment:

```
Error: Command failed: node /Users/jasonetco/dev/create-react-app/packages/create-react-app/index.js my-app --template iansu/cra-template-wheeler-mode --scripts-version="/Users/jasonetco/dev/create-react-app/packages/react-scripts/react-scripts-3.3.0.tgz"
    at checkExecSyncError (child_process.js:621:11)
    at Object.execSync (child_process.js:657:15)
    at Object.<anonymous> (/Users/jasonetco/dev/create-react-app/tasks/cra.js:115:4)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1025:10)
    at internal/main/run_main_module.js:17:11 {
```

Closes #8166 