### PR TITLE
Add current version and bin location to --info output

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -156,6 +156,10 @@ const program = new commander.Command(packageJson.name)
 
 if (program.info) {
   console.log(chalk.bold('\nEnvironment Info:'));
+  console.log(
+    `\n  current version of ${packageJson.name}: ${packageJson.version}`
+  );
+  console.log(`  running from ${__dirname}`);
   return envinfo
     .run(
       {


### PR DESCRIPTION
Make the --info subcommand outuput the current version information and the location of the file being run. Our issue template tells users to provide the output of --info, so having the current version is incredibly helpful, especially since it doesn't necessarily match the globally installed version that envinfo outputs. Knowing the location helps us determine whether the running bin is globally installed or in the local node_modules.

New output looks like this:

```diff
Environment Info:

+  current version of create-react-app: 3.3.0
+  running from C:\Users\alex\AppData\Local\Yarn\Data\global\node_modules\create-react-app
+
  System:
    OS: Windows 10 10.0.18362
    CPU: (8) x64 Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz
  Binaries:
    Node: 12.13.1 - C:\Program Files\nodejs\node.EXE
    Yarn: 1.19.1 - C:\Program Files (x86)\Yarn\bin\yarn.CMD
    npm: 6.10.1 - C:\Program Files\nodejs\npm.CMD
  Browsers:
    Edge: 44.18362.449.0
    Internet Explorer: 11.0.18362.1
  npmPackages:
    react: Not Found
    react-dom: Not Found
    react-scripts: Not Found
  npmGlobalPackages:
    create-react-app: Not Found

```