### PR TITLE
Add support for editor detection on WSL

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -12,6 +12,7 @@ const child_process = require('child_process');
 const os = require('os');
 const chalk = require('chalk');
 const shellQuote = require('shell-quote');
+const isWsl = require('is-wsl');
 
 function isTerminalEditor(editor) {
   switch (editor) {
@@ -78,6 +79,11 @@ const COMMON_EDITORS_LINUX = {
   vim: 'vim',
   'webstorm.sh': 'webstorm',
   'goland.sh': 'goland',
+};
+
+const VSCODE_WSL_MAPPING = {
+  'Code.exe': 'code',
+  'Code - Insiders.exe': 'code-insiders',
 };
 
 const COMMON_EDITORS_WIN = [
@@ -186,58 +192,135 @@ function getArgumentsForLineNumber(
   return [fileName];
 }
 
-function guessEditor() {
+function guessEditorDarwin() {
+  const output = child_process.execSync('ps x').toString();
+  const processNames = Object.keys(COMMON_EDITORS_OSX);
+  for (let i = 0; i < processNames.length; i++) {
+    const processName = processNames[i];
+    if (output.indexOf(processName) !== -1) {
+      return [COMMON_EDITORS_OSX[processName]];
+    }
+  }
+}
+
+// When called via WSL, new lines are \r\r\n instead of just \r\n
+const wmicLineEnding = isWsl ? /\r?\r\n/g : '\r\n';
+
+const winDrivePath = /^([ABCDEFGHIJKLMNOPQRSTUVWXYZ]):\\/;
+function convertWinToWslPath(path) {
+  const match = path.match(winDrivePath);
+  if (!match) {
+    return null;
+  }
+
+  const [, driveLetter] = match;
+  return `/mnt/${driveLetter.toLowerCase()}/${path
+    .substr(3)
+    .replace(/\\/g, '/')}`;
+}
+
+function isWslVSCodeServerInstalled() {
+  const vscodeServerPath = path.join(os.homedir(), '.vscode-server');
+  return fs.existsSync(vscodeServerPath);
+}
+
+function isWslWinFilesystemPath(path) {
+  return path.startsWith('/mnt/');
+}
+
+function getWinRunningProcesses() {
+  // Some processes need elevated rights to get its executable path.
+  // Just filter them out upfront. This also saves 10-20ms on the command.
+  const output = child_process
+    .execSync(
+      'wmic.exe process where "executablepath is not null" get executablepath'
+    )
+    .toString();
+  return output.split(wmicLineEnding);
+}
+
+function guessEditorWin() {
+  const runningProcesses = getWinRunningProcesses();
+  for (let i = 0; i < runningProcesses.length; i++) {
+    const processPath = runningProcesses[i].trim();
+    const processName = path.win32.basename(processPath);
+
+    if (COMMON_EDITORS_WIN.indexOf(processName) !== -1) {
+      return [processPath];
+    }
+  }
+}
+
+function guessEditorLinux() {
+  // --no-heading No header line
+  // x List all processes owned by you
+  // -o comm Need only names column
+  const output = child_process
+    .execSync('ps x --no-heading -o comm --sort=comm')
+    .toString();
+  const processNames = Object.keys(COMMON_EDITORS_LINUX);
+  for (let i = 0; i < processNames.length; i++) {
+    const processName = processNames[i];
+    if (output.indexOf(processName) !== -1) {
+      return [COMMON_EDITORS_LINUX[processName]];
+    }
+  }
+}
+
+function guessEditorWsl(fileName) {
+  // We prefer VS Code when the remote server is installed in WSL
+  if (isWslVSCodeServerInstalled()) {
+    const runningProcesses = getWinRunningProcesses();
+    for (let i = 0; i < runningProcesses.length; i++) {
+      const processPath = runningProcesses[i].trim();
+      const processName = path.win32.basename(processPath);
+
+      if (VSCODE_WSL_MAPPING[processName]) {
+        return [VSCODE_WSL_MAPPING[processName]];
+      }
+    }
+  }
+
+  // Fall back to Windows editor guessing when trying
+  // to launch a file located in the Windows filesystem
+  if (isWslWinFilesystemPath(fileName)) {
+    const [editor, ...args] = guessEditorWin();
+    return [convertWinToWslPath(editor), ...args];
+  }
+
+  // Last resort, fall back to Linux guessing
+  return guessEditorLinux();
+}
+
+function guessEditor(fileName) {
   // Explicit config always wins
   if (process.env.REACT_EDITOR) {
     return shellQuote.parse(process.env.REACT_EDITOR);
   }
+
+  let guess;
 
   // We can find out which editor is currently running by:
   // `ps x` on macOS and Linux
   // `Get-Process` on Windows
   try {
     if (process.platform === 'darwin') {
-      const output = child_process.execSync('ps x').toString();
-      const processNames = Object.keys(COMMON_EDITORS_OSX);
-      for (let i = 0; i < processNames.length; i++) {
-        const processName = processNames[i];
-        if (output.indexOf(processName) !== -1) {
-          return [COMMON_EDITORS_OSX[processName]];
-        }
-      }
+      guess = guessEditorDarwin();
     } else if (process.platform === 'win32') {
-      // Some processes need elevated rights to get its executable path.
-      // Just filter them out upfront. This also saves 10-20ms on the command.
-      const output = child_process
-        .execSync(
-          'wmic process where "executablepath is not null" get executablepath'
-        )
-        .toString();
-      const runningProcesses = output.split('\r\n');
-      for (let i = 0; i < runningProcesses.length; i++) {
-        const processPath = runningProcesses[i].trim();
-        const processName = path.basename(processPath);
-        if (COMMON_EDITORS_WIN.indexOf(processName) !== -1) {
-          return [processPath];
-        }
-      }
+      guess = guessEditorWin();
     } else if (process.platform === 'linux') {
-      // --no-heading No header line
-      // x List all processes owned by you
-      // -o comm Need only names column
-      const output = child_process
-        .execSync('ps x --no-heading -o comm --sort=comm')
-        .toString();
-      const processNames = Object.keys(COMMON_EDITORS_LINUX);
-      for (let i = 0; i < processNames.length; i++) {
-        const processName = processNames[i];
-        if (output.indexOf(processName) !== -1) {
-          return [COMMON_EDITORS_LINUX[processName]];
-        }
+      if (isWsl) {
+        guess = guessEditorWsl(fileName);
+      } else {
+        guess = guessEditorLinux();
       }
     }
   } catch (error) {
     // Ignore...
+  }
+
+  if (guess) {
+    return guess;
   }
 
   // Last resort, use old skool env vars
@@ -295,7 +378,7 @@ function launchEditor(fileName, lineNumber, colNumber) {
     colNumber = 1;
   }
 
-  let [editor, ...args] = guessEditor();
+  let [editor, ...args] = guessEditor(fileName);
 
   if (!editor) {
     printInstructions(fileName, null);
@@ -306,15 +389,9 @@ function launchEditor(fileName, lineNumber, colNumber) {
     return;
   }
 
-  if (
-    process.platform === 'linux' &&
-    fileName.startsWith('/mnt/') &&
-    /Microsoft/i.test(os.release())
-  ) {
+  if (isWsl && isWslWinFilesystemPath(fileName)) {
     // Assume WSL / "Bash on Ubuntu on Windows" is being used, and
     // that the file exists on the Windows file system.
-    // `os.release()` is "4.4.0-43-Microsoft" in the current release
-    // build of WSL, see: https://github.com/Microsoft/BashOnWindows/issues/423#issuecomment-221627364
     // When a Windows editor is specified, interop functionality can
     // handle the path translation, but only if a relative path is used.
     fileName = path.relative('', fileName);

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -66,6 +66,7 @@
     "immer": "1.10.0",
     "inquirer": "6.5.0",
     "is-root": "2.1.0",
+    "is-wsl": "^2.1.1",
     "loader-utils": "1.2.3",
     "open": "^7.0.0",
     "pkg-up": "2.0.0",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

The logic here is the following:

- If we can find the VS Code Remote server installed in WSL, check if some VS Code process is running on the Windows-side and execute `code` (or `code-insiders`) on WSL side
- If we're trying to open a file under `/mnt/` we'll use the normal Windows detection with conversion of the Windows file path to a WSL file path
- For anything else we fall back to the normal Linux detection (which will work with terminal editors only)

## Seeing this in action

Inside WSL filesystem with VS Code open:

![cra-wsl-vscode_Trim](https://user-images.githubusercontent.com/9491603/70799679-9a624a00-1daa-11ea-8874-8f2de6602251.gif)

Inside Windows filesystem with Notepad++ open:

![cra-wsl-notepad-_Trim](https://user-images.githubusercontent.com/9491603/70799690-a221ee80-1daa-11ea-8264-6611f8ba26b6.gif)
