### PR TITLE
Optimize localhost detection regex in service worker templates

### DIFF
--- a/packages/cra-template-typescript/template/src/serviceWorker.ts
+++ b/packages/cra-template-typescript/template/src/serviceWorker.ts
@@ -16,7 +16,7 @@ const isLocalhost = Boolean(
     window.location.hostname === '[::1]' ||
     // 127.0.0.0/8 are considered localhost for IPv4.
     window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+      /^127(?:\.(?:25[0-5]|2[0-4]\d|[01]?\d{1,2})){3}$/
     )
 );
 

--- a/packages/cra-template/template/src/serviceWorker.js
+++ b/packages/cra-template/template/src/serviceWorker.js
@@ -16,7 +16,7 @@ const isLocalhost = Boolean(
     window.location.hostname === '[::1]' ||
     // 127.0.0.0/8 are considered localhost for IPv4.
     window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+      /^127(?:\.(?:25[0-5]|2[0-4]\d|[01]?\d{1,2})){3}$/
     )
 );
 


### PR DESCRIPTION
As detected by [eslint-plugin-optimize-regex](https://github.com/BrainMaestro/eslint-plugin-optimize-regex), the regular expression that is used in the service worker template(s) to determine whether the hostname is `localhost` can be optimized. This PR includes the refactoring.

ESLint warning:

![ESLint warning](https://user-images.githubusercontent.com/7271961/70818307-a6aecd00-1dd3-11ea-9bdd-361e44831ce4.JPG)