### PR TITLE
fix: add template support for homepage, browserslist properties

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -150,7 +150,14 @@ module.exports = function(
   };
 
   // Setup the browsers list
-  appPackage.browserslist = defaultBrowsers;
+  const templateBrowsers = templateJson.browserslist || defaultBrowsers;
+  appPackage.browserslist = templateBrowsers;
+  
+  // Setup the homepage if defined
+  const templateHomepage = templateJson.homepage;
+  if(typeof templateHomepage !== "undefined") {
+    appPackage.homepage = templateHomepage
+  }
 
   fs.writeFileSync(
     path.join(appPath, 'package.json'),


### PR DESCRIPTION
This change updates the init script to allow for the homepage property to be set by a template. The homepage field with a value of "." is used when running applications at non-root of a domain. Additionally this adds support for templates to customize the browserlist property. This is useful specifically when a template includes IE support out of the box.

