### PR TITLE
cleanup @babel/plugin-transform-destructuring configuration

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -120,26 +120,7 @@ module.exports = function(api, opts, env) {
       // Necessary to include regardless of the environment because
       // in practice some other transforms (such as object-rest-spread)
       // don't work without it: https://github.com/babel/babel/issues/7215
-      [
-        require('@babel/plugin-transform-destructuring').default,
-        {
-          // Use loose mode for performance:
-          // https://github.com/facebook/create-react-app/issues/5602
-          loose: false,
-          selectiveLoose: [
-            'useState',
-            'useEffect',
-            'useContext',
-            'useReducer',
-            'useCallback',
-            'useMemo',
-            'useRef',
-            'useImperativeHandle',
-            'useLayoutEffect',
-            'useDebugValue',
-          ],
-        },
-      ],
+      require('@babel/plugin-transform-destructuring').default,
       // Turn on legacy decorators for TypeScript files
       isTypeScriptEnabled && [
         require('@babel/plugin-proposal-decorators').default,

--- a/packages/babel-preset-react-app/dependencies.js
+++ b/packages/babel-preset-react-app/dependencies.js
@@ -100,26 +100,7 @@ module.exports = function(api, opts) {
       // Necessary to include regardless of the environment because
       // in practice some other transforms (such as object-rest-spread)
       // don't work without it: https://github.com/babel/babel/issues/7215
-      [
-        require('@babel/plugin-transform-destructuring').default,
-        {
-          // Use loose mode for performance:
-          // https://github.com/facebook/create-react-app/issues/5602
-          loose: false,
-          selectiveLoose: [
-            'useState',
-            'useEffect',
-            'useContext',
-            'useReducer',
-            'useCallback',
-            'useMemo',
-            'useRef',
-            'useImperativeHandle',
-            'useLayoutEffect',
-            'useDebugValue',
-          ],
-        },
-      ],
+      require('@babel/plugin-transform-destructuring').default,
       // Polyfills the runtime needed for async/await, generators, and friends
       // https://babeljs.io/docs/en/babel-plugin-transform-runtime
       [


### PR DESCRIPTION
The `@babel/plugin-transform-destructuring` Babel plugin does not have a `selectiveLoose` [option](https://babeljs.io/docs/en/babel-plugin-transform-destructuring#options) currently and this code has been a source of confusion for me and possibly others. It was introduced in https://github.com/facebook/create-react-app/pull/5997 and I'm not sure if the intention was to wait for the `selectiveLoose` option to be available. Even if this worked as hoped for I think that only `useState` and `useReducer` should be targeted for this optimization.

Thanks! Please let me know if I'm missing something obvious.