### PR TITLE
Add template support for any package.json keys (#8082)

### DIFF
--- a/docusaurus/docs/custom-templates.md
+++ b/docusaurus/docs/custom-templates.md
@@ -58,28 +58,31 @@ You can add whatever files you want in here, but you must have at least the file
 
 ### The `template.json` file
 
-This is the configuration file for your template. It allows you to define information that should become a part of the generated project's `package.json` file, such as dependencies (only dependencies are supported for now) and any custom scripts that your template relies on. It should be structured as follows:
+This is the configuration file for your template. As this is a new feature, more options will be added over time. For now, only a `package` key is supported.
+
+The `package` key lets you provide any keys/values that you want added to the new project's `package.json`, such as dependencies (only dependencies are supported for now) and any custom scripts that your template relies on.
+
+Below is an example `template.json` file:
 
 ```json
 {
   "package": {
     "dependencies": {
+      "eslint-plugin-jsx-a11y": "^6.2.3",
       "serve": "^11.2.0"
     },
     "scripts": {
       "serve": "serve -s build",
       "build-and-serve": "npm run build && npm run serve"
     },
-    "browserslist": [
-      "defaults",
-      "not IE 11",
-      "not IE_Mob 11",
-      "maintained node versions",
-    ]
+    "eslintConfig": {
+      "extends": ["react-app", "plugin:jsx-a11y/recommended"],
+      "plugins": ["jsx-a11y"]
+    }
   }
 }
 ```
 
-Any values you add for `"dependencies"` and `"scripts"` will be merged with the values used in the initialisation process of `react-scripts`. Any other information you add to `"package"` will be added to the generated project's `package.json` file, replacing any existing values associated with those keys.
+Any values you add for `"dependencies"` and `"scripts"` will be merged with the Create React App defaults. Values for any other keys will be used as-is, replacing any matching Create React App defaults.
 
 For convenience, we always replace `npm run` with `yarn` in your custom `"scripts"`, as well as in your `README` when projects are initialized with yarn.

--- a/docusaurus/docs/custom-templates.md
+++ b/docusaurus/docs/custom-templates.md
@@ -58,18 +58,28 @@ You can add whatever files you want in here, but you must have at least the file
 
 ### The `template.json` file
 
-This is where you can define dependencies (only dependencies are supported for now), as well as any custom scripts that your template relies on.
+This is the configuration file for your template. It allows you to define information that should become a part of the generated project's `package.json` file, such as dependencies (only dependencies are supported for now) and any custom scripts that your template relies on. It should be structured as follows:
 
 ```json
 {
-  "dependencies": {
-    "serve": "^11.2.0"
-  },
-  "scripts": {
-    "serve": "serve -s build",
-    "build-and-serve": "npm run build && npm run serve"
+  "package": {
+    "dependencies": {
+      "serve": "^11.2.0"
+    },
+    "scripts": {
+      "serve": "serve -s build",
+      "build-and-serve": "npm run build && npm run serve"
+    },
+    "browserslist": [
+      "defaults",
+      "not IE 11",
+      "not IE_Mob 11",
+      "maintained node versions",
+    ]
   }
 }
 ```
+
+Any values you add for `"dependencies"` and `"scripts"` will be merged with the values used in the initialisation process of `react-scripts`. Any other information you add to `"package"` will be added to the generated project's `package.json` file, replacing any existing values associated with those keys.
 
 For convenience, we always replace `npm run` with `yarn` in your custom `"scripts"`, as well as in your `README` when projects are initialized with yarn.

--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -1,12 +1,14 @@
 {
-  "dependencies": {
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/node": "^12.0.0",
-    "@types/react": "^16.9.0",
-    "@types/react-dom": "^16.9.0",
-    "@types/jest": "^24.0.0",
-    "typescript": "~3.7.2"
+  "package": {
+    "dependencies": {
+      "@testing-library/react": "^9.3.2",
+      "@testing-library/jest-dom": "^4.2.4",
+      "@testing-library/user-event": "^7.1.2",
+      "@types/node": "^12.0.0",
+      "@types/react": "^16.9.0",
+      "@types/react-dom": "^16.9.0",
+      "@types/jest": "^24.0.0",
+      "typescript": "~3.7.2"
+    }
   }
 }

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -1,7 +1,9 @@
 {
-  "dependencies": {
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/user-event": "^7.1.2"
+  "package": {
+    "dependencies": {
+      "@testing-library/react": "^9.3.2",
+      "@testing-library/jest-dom": "^4.2.4",
+      "@testing-library/user-event": "^7.1.2"
+    }
   }
 }

--- a/packages/react-scripts/fixtures/kitchensink/template.json
+++ b/packages/react-scripts/fixtures/kitchensink/template.json
@@ -1,10 +1,12 @@
 {
-  "dependencies": {
-    "bootstrap": "4.3.1",
-    "jest": "24.9.0",
-    "node-sass": "4.12.0",
-    "normalize.css": "7.0.0",
-    "prop-types": "15.7.2",
-    "test-integrity": "2.0.1"
+  "package": {
+    "dependencies": {
+      "bootstrap": "4.3.1",
+      "jest": "24.9.0",
+      "node-sass": "4.12.0",
+      "normalize.css": "7.0.0",
+      "prop-types": "15.7.2",
+      "test-integrity": "2.0.1"
+    }
   }
 }

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -156,8 +156,8 @@ module.exports = function(
   // replacing any existing entries.
   const templatePackageToReplace = Object.keys(templatePackage).filter(key => {
     return (
-      templatePackageBlacklist.indexOf(key) === -1 &&
-      templatePackageToMerge.indexOf(key) === -1
+      !templatePackageBlacklist.includes(key) &&
+      !templatePackageToMerge.includes(key)
     );
   });
 

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -126,7 +126,6 @@ module.exports = function(
     'version',
     'description',
     'keywords',
-    'homepage',
     'bugs',
     'license',
     'author',

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -122,26 +122,45 @@ module.exports = function(
 
   // Keys to ignore in templatePackage
   const templatePackageBlacklist = [
+    'name',
+    'version',
+    'description',
+    'keywords',
+    'homepage',
+    'bugs',
+    'license',
+    'author',
+    'contributors',
+    'files',
+    'main',
+    'browser',
+    'bin',
+    'man',
+    'directories',
+    'repository',
     'devDependencies',
     'peerDependencies',
-    'name',
+    'bundledDependencies',
+    'optionalDependencies',
+    'engineStrict',
+    'os',
+    'cpu',
+    'preferGlobal',
+    'private',
+    'publishConfig',
   ];
 
   // Keys from templatePackage that will be merged with appPackage
-  const templatePackageToMerge = [
-    'dependencies',
-    'scripts',
-  ];
+  const templatePackageToMerge = ['dependencies', 'scripts'];
 
   // Keys from templatePackage that will be added to appPackage,
   // replacing any existing entries.
-  const templatePackageToReplace = Object.keys(templatePackage)
-    .filter(key => {
-      return (
-        templatePackageBlacklist.indexOf(key) === -1 &&
-        templatePackageToMerge.indexOf(key) === -1
-      );
-    });
+  const templatePackageToReplace = Object.keys(templatePackage).filter(key => {
+    return (
+      templatePackageBlacklist.indexOf(key) === -1 &&
+      templatePackageToMerge.indexOf(key) === -1
+    );
+  });
 
   // Copy over some of the devDependencies
   appPackage.dependencies = appPackage.dependencies || {};
@@ -253,7 +272,8 @@ module.exports = function(
 
   // Install additional template dependencies, if present
   // TODO: deprecate 'dependencies' key directly on templateJson
-  const templateDependencies = templatePackage.dependencies || templateJson.dependencies;
+  const templateDependencies =
+    templatePackage.dependencies || templateJson.dependencies;
   if (templateDependencies) {
     args = args.concat(
       Object.keys(templateDependencies).map(key => {


### PR DESCRIPTION
This PR adds support for any `package.json` keys in a `template.json` file. It uses a blacklist of specific keys that shouldn’t be touched, and explicitly lists which keys will be merged with existing config - any other keys will be replaced as discussed in #8082.

### Some notes:

- explicit merging of `"scripts"` and `"dependencies"` kept intact
- `templatePackage` keys that aren’t blacklisted or specified as merge keys will be added to `appPackage`
    - this also replaces existing entries in `appPackage` with the new values specified in `templatePackage`
- stock templates have been updated to reflect the change in `template.json`, "kitchensink" fixture also updated
- docs have been updated

### Some thoughts:

- some of the names used feel a bit chunky, open to suggestions!
- I chose `"browserslist"` as the example for the docs page based on #8209 but can change if there’s a clearer example (a real example felt better than `"some key": "some value"`)
- I added a couple of deprecation notes as "TODOs" as a I saw this convention elsewhere in `react-scripts/init.js`. These are based on the plan to deprecate the old template style [here](https://github.com/facebook/create-react-app/issues/8082#issuecomment-567381839). Let me know if this should live somewhere else, or if there’s a specific format you follow
- not sure how you manage changelogs but if you’re using issue titles the related issue doesn’t really represent this PR anymore so it should be changed

### Test plan:

I created a [custom template](https://github.com/tomvalorsa/cra-template-test) that was a direct copy of `cra-template`, and then tested different scenarios. There are various tests split across different branches (one per branch). N.B. the changes here are just related to `template.json` on each of these branches. Quick summary:

- `master` - direct copy of `cra-template`
- `test-01-package-key` - added a different dependency to `package.dependencies` to ensure it was installed correctly
- `test-02-scripts-key` - added scripts to add and replace to `package.scripts`
- `test-03-old-deps-scripts` - added deps and scripts in the old format to ensure it still works
- `test-04-old-and-new-deps-and-scripts` - added both new and old formats to ensure the new format takes precedence
- `test-05-blacklist-keys` - added all of the blacklist keys to ensure they aren’t copied over
- `test-06-custom-keys-to-replace-extend` - added some custom, non-blacklisted keys to ensure they are copied over
- `test-07-empty-old-config` - tried with an empty config
- `test-08-empty-new-config` - tried with an empty `package`
- I also ran with `cra-template-typescript`

All of the above worked as expected, I’m happy to run again and provide screenshots if needed. I ran these tests by cloning my custom template and running the following command, changing branches in the custom template dir as necessary:

```
npx create-react-app test-app --scripts-version=file:path/to/react-scripts --template=file:path/to/custom/template
```

I wasn’t sure how to run other tests in the repo so I’m pushing this up now to see if CI passes.

Any feedback would be greatly appreciated :)