### PR TITLE
Fix guessEditor on linux for code-insiders

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -228,10 +228,12 @@ function guessEditor() {
       const output = child_process
         .execSync('ps x --no-heading -o comm --sort=comm')
         .toString();
+
+      const runningProcesses = output.split("\n");
       const processNames = Object.keys(COMMON_EDITORS_LINUX);
       for (let i = 0; i < processNames.length; i++) {
         const processName = processNames[i];
-        if (output.indexOf(processName) !== -1) {
+        if (runningProcesses.indexOf(processName) !== -1) {
           return [COMMON_EDITORS_LINUX[processName]];
         }
       }

--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -76,6 +76,7 @@ const COMMON_EDITORS_LINUX = {
   'rubymine.sh': 'rubymine',
   sublime_text: 'sublime_text',
   vim: 'vim',
+  nvim: 'nvim',
   'webstorm.sh': 'webstorm',
   'goland.sh': 'goland',
 };


### PR DESCRIPTION
Hello,

While using create-react-app on linux, I found that I couldn't open a file if using code-insiders.

The problem was that we run the `ps x --no-heading -o comm --sort=comm` command to retrieve the user's processes. We put the command result in an `output` variable, which is a string. We then use indexOf on it to look for a common linux editor.

```
const COMMON_EDITORS_LINUX = {
  atom: 'atom',
  Brackets: 'brackets',
  code: 'code',
  'code-insiders': 'code-insiders',
  vscodium: 'vscodium',
  emacs: 'emacs',
  gvim: 'gvim',
  'idea.sh': 'idea',
  'phpstorm.sh': 'phpstorm',
  'pycharm.sh': 'pycharm',
  'rubymine.sh': 'rubymine',
  sublime_text: 'sublime_text',
  vim: 'vim',
  'webstorm.sh': 'webstorm',
  'goland.sh': 'goland',
};
```

Considering this list of editors, the `indexOf` method will found `code` on the output string and thus return `code`, while we are expecting to find `code-insiders`.

Making `code-insiders` above `code` on the list would work, but i preferred a much future-proof method.

Instead of making the indexOf on the output string, I split the output to a `runningProcesses` array. This way the `indexOf` is made on an array, not on the whole output string.
It fixes the "priority problem" and allow to open files on code-insiders.

It also seem to be the method used if the platform is `win32`, so I tried to make the code consistent with it.

edit1: I have added nvim on the COMMON_EDITORS_LINUX map since with this fix it will not be taking into account anymore. Maybe there are other software that I am not aware of that could have the same problem.

This being my first PR ever, thank you to indicate me any thing I could have forgot.

Thank you,
