### PR TITLE
Add TextMate to MacOS editors

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -60,6 +60,7 @@ const COMMON_EDITORS_OSX = {
   '/Applications/MacVim.app/Contents/MacOS/MacVim': 'mvim',
   '/Applications/GoLand.app/Contents/MacOS/goland':
     '/Applications/GoLand.app/Contents/MacOS/goland',
+  '/Applications/TextMate.app/Contents/MacOS/TextMate': 'mate',
 };
 
 const COMMON_EDITORS_LINUX = {


### PR DESCRIPTION
Hello,

Following #2636, this add Textmate (https://macromates.com/) to the editors list. Its arguments format was [already present](https://github.com/facebook/create-react-app/blob/b2258429c28b78706408e5ed467591f7e1c30b3c/packages/react-dev-utils/launchEditor.js#L148-L151).

Tested on MacOS 10.13.6.