### PR TITLE
fix: Add required peer dependencies for @testing-library/user-events in templates

### DIFF
--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@testing-library/dom": "^5.0.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/user-event": "^7.1.2",

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@testing-library/dom": "^5.0.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/user-event": "^7.1.2"


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

clean installs will have a warning that `@testing-library/dom` is missing 

<img width="703" alt="Screen Shot 2019-12-24 at 1 39 44 PM" src="https://user-images.githubusercontent.com/35270620/71422830-ef2b7d80-2652-11ea-9105-21af5b1d4a09.png">

apps created with the updated templates no longer have that warning!
