### PR TITLE
Sync copyright in docs with the rest of the project

### DIFF
--- a/docusaurus/website/docusaurus.config.js
+++ b/docusaurus/website/docusaurus.config.js
@@ -110,7 +110,7 @@ const siteConfig = {
         alt: 'Facebook Open Source Logo',
         src: 'img/oss_logo.png',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc.`,
+      copyright: `Copyright © 2015-${new Date().getFullYear()} Facebook, Inc.`,
     },
   },
 };


### PR DESCRIPTION
The copyright headers all say `2015-present`, so I added the `2015-` part so it all looks the same. 