### PR TITLE
Update setting-up-your-editor.md

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -29,8 +29,8 @@ If you're using TypeScript and Visual Studio Code, the [ESLint Visual Studio Cod
   "eslint.validate": [
     "javascript",
     "javascriptreact",
-    { "language": "typescript", "autoFix": true },
-    { "language": "typescriptreact", "autoFix": true }
+    "typescript",
+    "typescriptreact"
   ]
 }
 ```


### PR DESCRIPTION
> Auto Fix is enabled by default. Use the single string form.

 Warning is shown in `.vscode/settings.json` due to changes in vscode-eslint. 

![Screen Shot 2019-12-27 at 8 02 21 PM](https://user-images.githubusercontent.com/52206564/71537007-0634ce80-28e4-11ea-97b3-0c71c3ec8954.png)

As autoFix is set to default, object format in `eslint.validate` is now deprecated.

Check this commit. [vscode-eslint#7b5c40536131aa94eccd8a175e37104f5b785071](https://github.com/microsoft/vscode-eslint/commit/7b5c40536131aa94eccd8a175e37104f5b785071#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R223)


<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
