### PR TITLE
Fix  EXTEND_ESLINT bug

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -362,7 +362,7 @@ module.exports = function(webpackEnv) {
                     let eslintConfig;
                     try {
                       eslintConfig = eslintCli.getConfigForFile(
-                        paths.appIndexJs
+                        "*.ts"
                       );
                     } catch (e) {
                       console.error(e);


### PR DESCRIPTION
Fixed webpack.config.js so that it can match eslint config for typescript (*.ts) files as well.

eslint.CLIEngine was extracting eslint configs for only js files because `paths.appIndexJs` was passed to `getConfigForFile`

eslint.CLIEngine uses the relative path of given path to extract matching configs, so it was only extracting configs for `*.js`.

Fixed it by passing `*.ts` instead.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
