### PR TITLE
Allow node_modules to be mocked as described in the Jest documentation

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -8,6 +8,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const chalk = require('react-dev-utils/chalk');
 const paths = require('../../config/paths');
 const modules = require('../../config/modules');
@@ -22,8 +23,17 @@ module.exports = (resolve, rootDir, isEjecting) => {
     ? `<rootDir>/src/setupTests.${setupTestsFileExtension}`
     : undefined;
 
+  const roots = ['<rootDir>/src'];
+
+  const nodeMocksRootPath = path.join(rootDir || paths.appPath, '__mocks__');
+  const nodeMocksRootStats =
+    fs.existsSync(nodeMocksRootPath) && fs.statSync(nodeMocksRootPath);
+  if (nodeMocksRootStats && nodeMocksRootStats.isDirectory()) {
+    roots.push('<rootDir>/__mocks__');
+  }
+
   const config = {
-    roots: ['<rootDir>/src'],
+    roots,
 
     collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!src/**/*.d.ts'],
 


### PR DESCRIPTION
This PR fixes #7539.

The [Jest documentation](https://jestjs.io/docs/en/manual-mocks#mocking-node-modules) says:

> If the module you are mocking is a Node module (e.g.: lodash), the mock should be placed in the __mocks__ directory adjacent to node_modules (unless you configured roots to point to a folder other than the project root) and will be automatically mocked.

We have to check if the directory exists before we add it because the watcher used by Jest (`jest-haste-map` > `'./lib/FSEventsWatcher.js'` > `walker`) will throw an error if `'<rootDir>/__mocks__'` doesn't exist.