### PR TITLE
Fix sass importLoaders

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -531,7 +531,7 @@ module.exports = function(webpackEnv) {
               exclude: sassModuleRegex,
               use: getStyleLoaders(
                 {
-                  importLoaders: 2,
+                  importLoaders: 3,
                   sourceMap: isEnvProduction && shouldUseSourceMap,
                 },
                 'sass-loader'
@@ -548,7 +548,7 @@ module.exports = function(webpackEnv) {
               test: sassModuleRegex,
               use: getStyleLoaders(
                 {
-                  importLoaders: 2,
+                  importLoaders: 3,
                   sourceMap: isEnvProduction && shouldUseSourceMap,
                   modules: {
                     getLocalIdent: getCSSModuleLocalIdent,


### PR DESCRIPTION
This PR fixes the importLoaders setting for sass files. I believe this was broken in #5829 when an additional loader was introduced but the `importLoaders` setting was not incremented.

I ran into this trying to upgrade react-scripts locally. Verified this change fixes it for our project.

This is the error I ran into:
```
Error: resolve-url-loader: CSS error
  file:///MySassFile.module.scss:42:6: Unknown word
You tried to parse SCSS with the standard CSS parser; try again with the postcss-scss parser
  You tried to parse SCSS with the standard CSS parser; try again with the postcss-scss parser
    at runMicrotasks (<anonymous>)
```