### PR TITLE
Fixes unchecked access to 'deploy' script on build

### DIFF
--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -22,7 +22,9 @@ function printHostingInstructions(
   if (publicUrl && publicUrl.includes('.github.io/')) {
     // "homepage": "http://user.github.io/project"
     const publicPathname = url.parse(publicPath).pathname;
-    const hasDeployScript = typeof appPackage.scripts.deploy !== 'undefined';
+    const hasDeployScript =
+      typeof appPackage.scripts !== 'undefined' &&
+      typeof appPackage.scripts.deploy !== 'undefined';
     printBaseMessage(buildFolder, publicPathname);
 
     printDeployInstructions(publicUrl, hasDeployScript, useYarn);


### PR DESCRIPTION
Fixes #8291.

Tested executing `PUBLIC_URL=http://renato-bohler.github.io/my-app yarn build` on `create-react-app` root folder before and after changes.

# Before changes (c03bb366)

![image](https://user-images.githubusercontent.com/25781956/71949111-0faa1a80-31b1-11ea-8041-589087f40655.png)

# After changes (fe7904ae)

![image](https://user-images.githubusercontent.com/25781956/71949143-3405f700-31b1-11ea-988a-577a529822b4.png)

