### PR TITLE
Support shorthand scoped templates

### DIFF
--- a/docusaurus/docs/custom-templates.md
+++ b/docusaurus/docs/custom-templates.md
@@ -9,6 +9,8 @@ Custom Templates enable you to select a template to create your project from, wh
 
 You'll notice that Custom Templates are always named in the format `cra-template-[template-name]`, however you only need to provide the `[template-name]` to the creation command.
 
+Scoped templates are also supported, under the name `@[scope-name]/cra-template` or `@[scope-name]/cra-template-[template-name]`, which can be installed via `@[scope]` and `@[scope]/[template-name]` respectively.
+
 ### npm
 
 ```sh

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -644,17 +644,19 @@ function getTemplateInstallPackage(template, originalDirectory) {
         templateName === templateToInstall ||
         templateName.startsWith(`${templateToInstall}-`)
       ) {
-        // cra-template
-        // @SCOPE/cra-template
-        // cra-template-NAME
-        // @SCOPE/cra-template-NAME
+        // Covers:
+        // - cra-template
+        // - @SCOPE/cra-template
+        // - cra-template-NAME
+        // - @SCOPE/cra-template-NAME
         templateToInstall = `${scope}${templateName}`;
       } else if (templateName.startsWith('@')) {
-        // @SCOPE
+        // Covers using @SCOPE only
         templateToInstall = `${templateName}/${templateToInstall}`;
       } else {
-        // NAME
-        // @SCOPE/NAME
+        // Covers templates without the `cra-template` prefix:
+        // - NAME
+        // - @SCOPE/NAME
         templateToInstall = `${scope}${templateToInstall}-${templateName}`;
       }
     }

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -640,10 +640,23 @@ function getTemplateInstallPackage(template, originalDirectory) {
       const scope = packageMatch[1] || '';
       const templateName = packageMatch[2];
 
-      const name = templateName.startsWith(templateToInstall)
-        ? templateName
-        : `${templateToInstall}-${templateName}`;
-      templateToInstall = `${scope}${name}`;
+      if (
+        templateName === templateToInstall ||
+        templateName.startsWith(`${templateToInstall}-`)
+      ) {
+        // cra-template
+        // @SCOPE/cra-template
+        // cra-template-NAME
+        // @SCOPE/cra-template-NAME
+        templateToInstall = `${scope}${templateName}`;
+      } else if (templateName.startsWith('@')) {
+        // @SCOPE
+        templateToInstall = `${templateName}/${templateToInstall}`;
+      } else {
+        // NAME
+        // @SCOPE/NAME
+        templateToInstall = `${scope}${templateToInstall}-${templateName}`;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Continue from #7991. Allow `@scope` shorthand for template package name.

The motivation comes from https://github.com/storybookjs/storybook/issues/9327#issuecomment-571972738, where when library authors want to provide cra template under their scoped name, typing `--template @storybook/cra-template` every time seems tedious. Instead, it'd be better if the users can just type `--template @storybook` to use the template `@storybook/cra-template`. Since `@` is not a valid character for npm package name, it should be backward-compatible.

### Tests

To list all the possible combinations.

provided template | downloaded package
--- | ---
`--template cra-template` | `cra-template`
`--template cra-template-typescript` | `cra-template-typescript`
`--template typescript` | `cra-template-typescript`
`--template @scope/cra-template-typescript` | `@scope/cra-template-typescript`
`--template @scope/typescript` | `@scope/cra-template-typescript`
`--template @scope` (**Added**) | `@scope/cra-template`

---

This PR also fixes a bug (?) when users provided `--template cra-templates` would still download `cra-templates` while it should be `cra-template-cra-templates`, as templates should be prefixed by `cra-template-`, judging from the [doc](https://create-react-app.dev/docs/custom-templates). We can instead allow the other way around though if that makes more sense.

Pinging @mrmckeb as we mentioned it in the issue before :)