### PR TITLE
Update public folder usage docs to clarify globals

### DIFF
--- a/docusaurus/docs/using-the-public-folder.md
+++ b/docusaurus/docs/using-the-public-folder.md
@@ -63,4 +63,4 @@ The `public` folder is useful as a workaround for a number of less common cases:
 - You want to include a small script like [`pace.js`](https://github.hubspot.com/pace/docs/welcome/) outside of the bundled code.
 - Some library may be incompatible with Webpack and you have no other option but to include it as a `<script>` tag.
 
-Note that if you add a `<script>` that declares global variables, you also need to read the next section on using them.
+Note that if you add a `<script>` that declares global variables, you should read the topic [Using Global Variables](using-global-variables.md) in the next section which explains how to reference them.


### PR DESCRIPTION
Added the relevant topic linked directly, instead of saying it's just in the next section.
Adjusted the text so it sounds more like a recommendation rather than a requirement.
The topic linked is basically explainer to how you'd reference it using the global window object and ways to avoid linter errors. Thus I used 'reference' to give users a hint of what it the linked page would be for.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
