### PR TITLE
Add `--help` flag to `react-scripts`

### DIFF
--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -92,7 +92,6 @@ program
   .action(function() {
     execScript('test', []);
   });
-
 program
   .command('eject')
   .description('Eject config.')

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -71,10 +71,18 @@ program
   .action(function(cmd) {
     const opts = cmd.opts();
     const args = [];
-    if (opts.port) process.env.PORT = opts.port;
-    if (opts.host) process.env.HOST = opts.host;
-    if (opts.https) process.env.HTTPS = 'true';
-    if (opts.smokeTest) args.push('--smoke-test');
+    if (opts.port) {
+      process.env.PORT = opts.port;
+    }
+    if (opts.host) {
+      process.env.HOST = opts.host;
+    }
+    if (opts.https) {
+      process.env.HTTPS = 'true';
+    }
+    if (opts.smokeTest) {
+      args.push('--smoke-test');
+    }
     execScript('start', args);
   });
 program

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -67,18 +67,15 @@ program
   .option('--port <port>', 'Specify port', 3000)
   .option('--host <host>', 'Specify host', '0.0.0.0')
   .option('--https', 'Use https')
+  .option('--smoke-test')
   .action(function(cmd) {
     const opts = cmd.opts();
-    if (opts.port) {
-      process.env.PORT = opts.port;
-    }
-    if (opts.host) {
-      process.env.HOST = opts.host;
-    }
-    if (opts.https) {
-      process.env.HTTPS = 'true';
-    }
-    execScript('start', []);
+    const args = [];
+    if (opts.port) process.env.PORT = opts.port;
+    if (opts.host) process.env.HOST = opts.host;
+    if (opts.https) process.env.HTTPS = 'true';
+    if (opts.smokeTest) args.push('--smoke-test');
+    execScript('start', args);
   });
 program
   .command('build')
@@ -89,7 +86,10 @@ program
 program
   .command('test')
   .description('Launches the test runner in the interactive watch mode.')
-  .action(function() {
+  .option('--smoke-test')
+  .action(function(cmd) {
+    const opts = cmd.opts();
+    console.log(opts);
     execScript('test', []);
   });
 program

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -57,7 +57,7 @@ function execScript(script, scriptArgs) {
   process.exit(result.status);
 }
 
-const program = new commander.Command(packageJson.name).version(
+const program = new commander.Command('react-scripts').version(
   packageJson.version
 );
 

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -94,7 +94,7 @@ program
   });
 program
   .command('eject')
-  .description('Eject config.')
+  .description('Eject Create React App configuration.')
   .action(function() {
     execScript('eject', []);
   });

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -90,7 +90,7 @@ program
   .command('test')
   .description('Launches the test runner in the interactive watch mode.')
   .action(function() {
-    execScript('build', []);
+    execScript('test', []);
   });
 
 program

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -39,6 +39,7 @@
     "babel-preset-react-app": "^9.1.0",
     "camelcase": "^5.3.1",
     "case-sensitive-paths-webpack-plugin": "2.2.0",
+    "commander": "^4.1.0",
     "css-loader": "3.3.2",
     "dotenv": "8.2.0",
     "dotenv-expand": "5.1.0",


### PR DESCRIPTION
This PR use `commander` (which is already used by `create-react-app` CLI) to provide a beautify CLI interface. 

----- 

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

> please provide us with clear instructions on how you verified your changes work.

Before this PR:

```
$ yarn run react-scripts --help                                                                                                                                                                                                                                              
yarn run v1.19.2
$ /Users/ocavue/code/github/rino/node_modules/.bin/react-scripts --help
Unknown script "--help".
Perhaps you need to update react-scripts?
See: https://facebook.github.io/create-react-app/docs/updating-to-new-releases
```

After this PR:

```
$ yarn run react-scripts --help    
Usage: react-scripts [options] [command]

Options:
  -V, --version    output the version number
  -h, --help       output usage information

Commands:
  start [options]  Runs the app in the development mode.
  build            Builds the app for production to the `build` folder.
  test             Launches the test runner in the interactive watch mode.
  eject            Eject config.
```

```
$ yarn run react-scripts start -h
Usage: react-scripts start [options]

Runs the app in the development mode.

Options:
  --port <port>  Specify port (default: 3000)
  --host <host>  Specify host (default: "0.0.0.0")
  --https        Use https
  -h, --help     output usage information
```
