### PR TITLE
Suggest installing source-map-explorer as a dev dependency

### DIFF
--- a/docusaurus/docs/analyzing-the-bundle-size.md
+++ b/docusaurus/docs/analyzing-the-bundle-size.md
@@ -11,13 +11,13 @@ bloat is coming from.
 To add Source map explorer to a Create React App project, follow these steps:
 
 ```sh
-npm install --save source-map-explorer
+npm install --save-dev source-map-explorer
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add source-map-explorer
+yarn add -D source-map-explorer
 ```
 
 Then in `package.json`, add the following line to `scripts`:


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

This is just a small change to suggest installing `source-map-explorer` as a dev dependency to keep bundle size down.
