### PR TITLE
Downgrade open from 7.0.0 to 6.4.0

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -104,7 +104,7 @@ function startBrowserProcess(browser, url, args) {
   // Fallback to open
   // (It will always open new tab)
   try {
-    var options = { app: browser, wait: false, url: true };
+    var options = { app: browser, wait: false };
     open(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -67,7 +67,7 @@
     "inquirer": "7.0.3",
     "is-root": "2.1.0",
     "loader-utils": "1.2.3",
-    "open": "^7.0.0",
+    "open": "^6.4.0",
     "pkg-up": "3.1.0",
     "react-error-overlay": "^6.0.4",
     "recursive-readdir": "2.2.2",


### PR DESCRIPTION
- reverted #7910
- fixes #8081

Note: The vulnerability described in #7908 affects only `open` versions `0.0.5` and lower. Readme in `open` says: 

> The original open package was previously deprecated in favor of this package, and we got the name, so this package is now named open instead of opn. If you're upgrading from the original open package (open@0.0.5 or lower), keep in mind that the API is different.
> 
> Why?
> 
> Actively maintained.
> - Supports app arguments.
> - Safer as it uses spawn instead of exec.
> - Fixes most of the open original node-open issues.
> - Includes the latest xdg-open script for Linux.
> - Supports WSL paths to Windows apps under /mnt/*.

@andriijas