### PR TITLE
fix the hanging test in Jenkins. fix #6899

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "get-port": "^4.2.0",
     "globby": "^9.1.0",
     "husky": "^1.3.1",
+    "is-ci": "^2.0.0",
     "jest": "24.9.0",
     "lerna": "3.19.0",
     "lerna-changelog": "~0.8.2",

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -33,6 +33,7 @@ verifyTypeScriptSetup();
 // @remove-on-eject-end
 
 const jest = require('jest');
+const isCI = require('is-ci')
 const execSync = require('child_process').execSync;
 let argv = process.argv.slice(2);
 
@@ -56,7 +57,7 @@ function isInMercurialRepository() {
 
 // Watch unless on CI or explicitly running all tests
 if (
-  !process.env.CI &&
+  !isCI &&
   argv.indexOf('--watchAll') === -1 &&
   argv.indexOf('--watchAll=false') === -1
 ) {


### PR DESCRIPTION
CI=true check is insufficient.

It doesnt work for Jenkins, Teamcity, TaskCluster. Where Jenkins and Teamcity are big ones.

If you dont want to bring `is-ci` and `ci-info` in, I understand, but let me adjust the PR with this snippet from `ci-info`:

https://github.com/watson/ci-info/blob/master/index.js#L52-L59

```js
exports.isCI = !!(
  env.CI || // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
  env.CONTINUOUS_INTEGRATION || // Travis CI, Cirrus CI
  env.BUILD_NUMBER || // Jenkins, TeamCity
  env.RUN_ID || // TaskCluster, dsari
  false
)
```

Verification: I tried modified fork on a local jenkins and it react-scripts test dont hang up anymore