### PR TITLE
Wider Chromium support for openBrowser

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -69,7 +69,7 @@ function startBrowserProcess(browser, url, args) {
   // requested a different browser, we can try opening
   // Chrome with AppleScript. This lets us reuse an
   // existing tab when possible instead of creating a new one.
-  const shouldTryOpenChromeWithAppleScript =
+  const shouldTryOpenChromiumWithAppleScript =
     process.platform === 'darwin' &&
     (typeof browser !== 'string' || browser === OSX_CHROME);
 

--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -73,18 +73,38 @@ function startBrowserProcess(browser, url, args) {
     process.platform === 'darwin' &&
     (typeof browser !== 'string' || browser === OSX_CHROME);
 
-  if (shouldTryOpenChromeWithAppleScript) {
-    try {
-      // Try our best to reuse existing tab
-      // on OS X Google Chrome with AppleScript
-      execSync('ps cax | grep "Google Chrome"');
-      execSync('osascript openChrome.applescript "' + encodeURI(url) + '"', {
-        cwd: __dirname,
-        stdio: 'ignore',
-      });
-      return true;
-    } catch (err) {
-      // Ignore errors.
+  if (shouldTryOpenChromiumWithAppleScript) {
+    // Will use the first open browser found from list
+    const supportedChromiumBrowsers = [
+      'Google Chrome Canary',
+      'Google Chrome',
+      'Microsoft Edge',
+      'Brave Browser',
+      'Vivaldi',
+      'Chromium',
+      'Safari',
+    ];
+
+    for (let chromiumBrowser of supportedChromiumBrowsers) {
+      try {
+        // Try our best to reuse existing tab
+        // on OSX Chromium-based browser with AppleScript
+        execSync('ps cax | grep "' + chromiumBrowser + '"');
+        execSync(
+          'osascript openChrome.applescript "' +
+            encodeURI(url) +
+            '" "' +
+            chromiumBrowser +
+            '"',
+          {
+            cwd: __dirname,
+            stdio: 'ignore',
+          }
+        );
+        return true;
+      } catch (err) {
+        // Ignore errors.
+      }
     }
   }
 

--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -82,7 +82,6 @@ function startBrowserProcess(browser, url, args) {
       'Brave Browser',
       'Vivaldi',
       'Chromium',
-      'Safari',
     ];
 
     for (let chromiumBrowser of supportedChromiumBrowsers) {

--- a/packages/react-dev-utils/openChrome.applescript
+++ b/packages/react-dev-utils/openChrome.applescript
@@ -8,47 +8,56 @@ LICENSE file in the root directory of this source tree.
 property targetTab: null
 property targetTabIndex: -1
 property targetWindow: null
+property theProgram: "Google Chrome"
 
 on run argv
   set theURL to item 1 of argv
 
-  tell application "Chrome"
+  -- Allow requested program to be optional,
+  -- default to Google Chrome
+  if (count of argv) > 1 then
+    set theProgram to item 2 of argv
+  end if
 
-    if (count every window) = 0 then
-      make new window
-    end if
+  using terms from application "Google Chrome"
+    tell application theProgram
 
-    -- 1: Looking for tab running debugger
-    -- then, Reload debugging tab if found
-    -- then return
-    set found to my lookupTabWithUrl(theURL)
-    if found then
-      set targetWindow's active tab index to targetTabIndex
-      tell targetTab to reload
-      tell targetWindow to activate
-      set index of targetWindow to 1
-      return
-    end if
+      if (count every window) = 0 then
+        make new window
+      end if
 
-    -- 2: Looking for Empty tab
-    -- In case debugging tab was not found
-    -- We try to find an empty tab instead
-    set found to my lookupTabWithUrl("chrome://newtab/")
-    if found then
-      set targetWindow's active tab index to targetTabIndex
-      set URL of targetTab to theURL
-      tell targetWindow to activate
-      return
-    end if
+      -- 1: Looking for tab running debugger
+      -- then, Reload debugging tab if found
+      -- then return
+      set found to my lookupTabWithUrl(theURL)
+      if found then
+        set targetWindow's active tab index to targetTabIndex
+        tell targetTab to reload
+        tell targetWindow to activate
+        set index of targetWindow to 1
+        return
+      end if
 
-    -- 3: Create new tab
-    -- both debugging and empty tab were not found
-    -- make a new tab with url
-    tell window 1
-      activate
-      make new tab with properties {URL:theURL}
+      -- 2: Looking for Empty tab
+      -- In case debugging tab was not found
+      -- We try to find an empty tab instead
+      set found to my lookupTabWithUrl("chrome://newtab/")
+      if found then
+        set targetWindow's active tab index to targetTabIndex
+        set URL of targetTab to theURL
+        tell targetWindow to activate
+        return
+      end if
+
+      -- 3: Create new tab
+      -- both debugging and empty tab were not found
+      -- make a new tab with url
+      tell window 1
+        activate
+        make new tab with properties {URL:theURL}
+      end tell
     end tell
-  end tell
+  end using terms from
 end run
 
 -- Function:
@@ -56,28 +65,30 @@ end run
 -- if found, store tab, index, and window in properties
 -- (properties were declared on top of file)
 on lookupTabWithUrl(lookupUrl)
-  tell application "Chrome"
-    -- Find a tab with the given url
-    set found to false
-    set theTabIndex to -1
-    repeat with theWindow in every window
-      set theTabIndex to 0
-      repeat with theTab in every tab of theWindow
-        set theTabIndex to theTabIndex + 1
-        if (theTab's URL as string) contains lookupUrl then
-          -- assign tab, tab index, and window to properties
-          set targetTab to theTab
-          set targetTabIndex to theTabIndex
-          set targetWindow to theWindow
-          set found to true
+  using terms from application "Google Chrome"
+    tell application theProgram
+      -- Find a tab with the given url
+      set found to false
+      set theTabIndex to -1
+      repeat with theWindow in every window
+        set theTabIndex to 0
+        repeat with theTab in every tab of theWindow
+          set theTabIndex to theTabIndex + 1
+          if (theTab's URL as string) contains lookupUrl then
+            -- assign tab, tab index, and window to properties
+            set targetTab to theTab
+            set targetTabIndex to theTabIndex
+            set targetWindow to theWindow
+            set found to true
+            exit repeat
+          end if
+        end repeat
+
+        if found then
           exit repeat
         end if
       end repeat
-
-      if found then
-        exit repeat
-      end if
-    end repeat
-  end tell
+    end tell
+  end using terms from
   return found
 end lookupTabWithUrl


### PR DESCRIPTION
Hey there! The Contribution Guidelines say to ask before submitting a PR, but it doesn't say how to ask. I don't have a lot of experience contributing to OSS, so please let me know if I missed something.

This PR allows for CRA to control tabs on other Chromium-based browsers besides Google Chrome. How the code works:

1. Checks if AppleScript is applicable. Logic isn't changed, but I renamed the variable to `shouldTryOpenChromiumWithAppleScript`.
2. Runs through a list of supported browsers:
    * Chrome Canary (has to come before Chrome because of grep)
    * Chrome
    * Edge
    * Brave
    * Vivaldi
    * Chromium
3. For each browser, it greps to see if that browser is a process
4. If it finds a match, it passes the browser name to the AppleScript
5. AppleScript uses the Google Chrome dictionary to control the provided browser

Other than that, the logic is essentially the same. Most people shouldn't see a difference in behavior except for those using a browser in the list above that's not Chrome; for those people, CRA will reuse the existing tab rather than a new tab.

I noticed that Safari has its own dictionary for AppleScripts. If it benefits anyone, I could look into implementing similar logic for Safari users. Unfortunately for Firefox users like myself, there seems to be no hope.

Apologies if I left something out, but I tried my best. Let me know what needs to be changed, would be proud to have my code in CRA.

Closes #8264 