### PR TITLE
Make the PWA link point to the right place

### DIFF
--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -1,1 +1,1 @@
-This file has moved [here](https://github.com/facebook/create-react-app/blob/master/packages/cra-template/template/README.md)
+Learn about making a Progressive Web App [here](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)


### PR DESCRIPTION
Currently, the `https://bit.ly/CRA-PWA` link points to this README, which points to another document, which points to [this page](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app).

This change puts a link to [this page](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app) in the README to save folks an extra click.