### PR TITLE
Fix(env): stringified with descriptive keys

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -88,12 +88,10 @@ function getClientEnvironment(publicUrl) {
       }
     );
   // Stringify all values so we can feed into Webpack DefinePlugin
-  const stringified = {
-    'process.env': Object.keys(raw).reduce((env, key) => {
-      env[key] = JSON.stringify(raw[key]);
-      return env;
-    }, {}),
-  };
+  const stringified = Object.keys(raw).reduce((env, key) => {
+    env[`process.env.'${key}`] = JSON.stringify(raw[key]);
+    return env;
+  }, {});
 
   return { raw, stringified };
 }


### PR DESCRIPTION
Related #6642

Sometimes when some env var isn't defined, the minified version is sent with a lot of extra information. It's happening because [webpack.DefinePlugin expect a descriptive key for each field](https://webpack.js.org/plugins/define-plugin/#usage)

#### Note
Analyze the impact of overwriting `process.env` object on the bundle.