### PR TITLE
setupTestFrameworkScriptFile is deprecated

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -250,7 +250,7 @@ global.localStorage = localStorageMock;
 > ```js
 > "jest": {
 >   // ...
->   "setupFilesAfterEnv": "<rootDir>/src/setupTests.js"
+>   "setupFilesAfterEnv": ["<rootDir>/src/setupTests.js"]
 >  }
 > ```
 

--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -245,12 +245,12 @@ const localStorageMock = {
 global.localStorage = localStorageMock;
 ```
 
-> Note: Keep in mind that if you decide to "eject" before creating `src/setupTests.js`, the resulting `package.json` file won't contain any reference to it, so you should manually create the property `setupTestFrameworkScriptFile` in the configuration for Jest, something like the following:
+> Note: Keep in mind that if you decide to "eject" before creating `src/setupTests.js`, the resulting `package.json` file won't contain any reference to it, so you should manually create the property `setupFilesAfterEnv` in the configuration for Jest, something like the following:
 
 > ```js
 > "jest": {
 >   // ...
->   "setupTestFrameworkScriptFile": "<rootDir>/src/setupTests.js"
+>   "setupFilesAfterEnv": "<rootDir>/src/setupTests.js"
 >  }
 > ```
 


### PR DESCRIPTION
__Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`.__

ref: https://jestjs.io/docs/en/configuration#setupfilesafterenv-array

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
