### PR TITLE
Update docs according to lint-staged v10

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -166,8 +166,7 @@ Next we add a 'lint-staged' field to the `package.json`, for example:
   },
 + "lint-staged": {
 +   "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-+     "prettier --write",
-+     "git add"
++     "prettier --write"
 +   ]
 + },
   "scripts": {


### PR DESCRIPTION
According to `lint-staged` v10 changelog (https://github.com/okonet/lint-staged#v10):

> From `v10.0.0` onwards any new modifications to originally staged files will be automatically added to the commit. If your task previously contained a `git add` step, please remove this. The automatic behaviour ensures there are less race-conditions, since trying to run multiple git operations at the same time usually results in an error.

There's no need to specify `git add` on the config anymore. So it should be removed from the doc as well.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
