### PR TITLE
Fix typo in yarn example

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -16,7 +16,7 @@ npx create-react-app my-app --template typescript
 
 # or
 
-yarn create react-app my-app --template typescript
+yarn create-react-app my-app --template typescript
 ```
 
 > If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that `npx` always uses the latest version.


### PR DESCRIPTION
Very Minor typo fix.
Changes `yarn create react-app ...` to `yarn create-react-app ...`
Fixes #8395

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
