### PR TITLE
fix(test): force install npm in e2e-behaviour

### DIFF
--- a/tasks/e2e-behavior.sh
+++ b/tasks/e2e-behavior.sh
@@ -63,7 +63,7 @@ root_path=$PWD
 
 if hash npm 2>/dev/null
 then
-  npm i -g npm@latest
+  npm i -g --force npm@latest
 fi
 
 # Bootstrap monorepo


### PR DESCRIPTION
This will fix e2e-behaviour on macos

Related: https://github.com/npm/cli/issues/611#issuecomment-575287540

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
