### PR TITLE
Change arrow functions to function declarations

### DIFF
--- a/docusaurus/docs/adding-images-fonts-and-files.md
+++ b/docusaurus/docs/adding-images-fonts-and-files.md
@@ -51,12 +51,15 @@ One way to add SVG files was described in the section above. You can also import
 
 ```js
 import { ReactComponent as Logo } from './logo.svg';
-const App = () => (
-  <div>
-    {/* Logo is an actual React component */}
-    <Logo />
-  </div>
-);
+
+function App() {
+  return (
+    <div>
+      {/* Logo is an actual React component */}
+      <Logo />
+    </div>
+  );
+}
 ```
 
 This is handy if you don't want to load SVG as a separate file. Don't forget the curly braces in the import! The `ReactComponent` import name is significant and tells Create React App that you want a React component that renders an SVG, rather than its filename.

--- a/packages/cra-template-typescript/template/src/App.tsx
+++ b/packages/cra-template-typescript/template/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 
-const App = () => {
+function App() {
   return (
     <div className="App">
       <header className="App-header">


### PR DESCRIPTION
The JavaScript template uses a function declaration to define the App component, the TypeScript template and a page of the documentation used arrow functions. Changed it to use function declarations for consistency and readability.


