### PR TITLE
Remove @babel/core from babel-preset-react-app dependencies

### DIFF
--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -21,7 +21,6 @@
     "test.js"
   ],
   "dependencies": {
-    "@babel/core": "7.8.4",
     "@babel/plugin-proposal-class-properties": "7.8.3",
     "@babel/plugin-proposal-decorators": "7.8.3",
     "@babel/plugin-proposal-numeric-separator": "7.8.3",


### PR DESCRIPTION
It's not a dependency of `babel-preset-react-app` - it's not used anywhere inside it. Potentially it could be set as a peer dependency - just for information purposes, but not sure if you want that. It definitely ain't a hard dependency though.