### PR TITLE
Update proxying-api-requests-in-development.md

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -98,11 +98,17 @@ You can now register proxies as you wish! Here's an example using the above `htt
 const proxy = require('http-proxy-middleware');
 
 module.exports = function(app) {
-  app.use(
-    '/api',
-    proxy({
+  //http requests
+  app.use('/api', proxy('/api', {
       target: 'http://localhost:5000',
       changeOrigin: true,
+    })
+  );
+  //websocket requests
+  app.use('/ws', proxy('/ws', {
+      target: 'http://localhost:5000',
+      changeOrigin: true,
+      ws: true
     })
   );
 };


### PR DESCRIPTION
We should always pass path parameter to app.use and context parameter to proxy, which are almost always the same, except cases mentioned in third Note. 

app.use mounts the specified middleware function at the specified path: the middleware function is executed when the base of the requested path matches path.

proxy first parameter specify context (part of url) which then will be checked whether request url has it or not. This is not necessarily with http requests, but will break WebpackDevServer sockjs-node HMR functionality when we try to proxy some of our own websocket requests. Default context is '/' and because all urls has '/', /sockjs-node from WDS also will be proxied, but it shouldn't. http requests work without specifying context because no one else sends http requests.

Related to this [comment](https://github.com/facebook/create-react-app/issues/8416#issuecomment-582314397).
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
