### PR TITLE
Fix navbar line break in header

### DIFF
--- a/docusaurus/website/src/css/custom.css
+++ b/docusaurus/website/src/css/custom.css
@@ -26,3 +26,8 @@
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
+
+.navbar .navbar__brand > strong {
+  flex-shrink: 0;
+  max-width: 100%;
+}


### PR DESCRIPTION
Fixed a line break in navigation in safari.

The bug:
![image](https://user-images.githubusercontent.com/46542370/73947831-302cd800-4909-11ea-9fb6-21cd1b5f0b51.png)

Fixed version:
![image](https://user-images.githubusercontent.com/46542370/73947892-42a71180-4909-11ea-871c-39a006acaab9.png)
