### PR TITLE
Allow disabling workbox

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -671,6 +671,7 @@ module.exports = function(webpackEnv) {
       // Generate a service worker script that will precache, and keep up to date,
       // the HTML & assets that are part of the Webpack build.
       isEnvProduction &&
+        !appPackageJson.disableServiceWorker &&
         new WorkboxWebpackPlugin.GenerateSW({
           clientsClaim: true,
           exclude: [/\.map$/, /asset-manifest\.json$/],


### PR DESCRIPTION
Allows users to set `disableServiceWorker` in the package.json to not include workbox in the bundle (for the people who delete the service worker file).

I will gladly document it, just not sure where to put it 🤷‍♂ 