### PR TITLE
update open to v7.0.2

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -123,7 +123,7 @@ function startBrowserProcess(browser, url, args) {
   // Fallback to open
   // (It will always open new tab)
   try {
-    var options = { app: browser, wait: false };
+    var options = { app: browser, wait: false, url: true };
     open(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -69,7 +69,7 @@
     "inquirer": "7.0.4",
     "is-root": "2.1.0",
     "loader-utils": "1.2.3",
-    "open": "^6.4.0",
+    "open": "^7.0.2",
     "pkg-up": "3.1.0",
     "react-error-overlay": "^6.0.5",
     "recursive-readdir": "2.2.2",


### PR DESCRIPTION
reverts #8364

`open` works again with WSL in its latest version. :)

Note: I've only tested it on my machine (OS Build 18362.592), someone else should test it too and give feedback before merging. 👌

@andriijas