### PR TITLE
Fix --use-pnp for Yarn 2

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -283,7 +283,7 @@ function createApp(
       if (!yarnInfo.hasMaxYarnPnp) {
         console.log(
           chalk.yellow(
-            `The --use-pnp flag is no longer necessary with yarn ${yarnInfo.yarnVersion} and will be deprecated and removed in a future release.\n`
+            'The --use-pnp flag is no longer necessary with yarn 2 and will be deprecated and removed in a future release.\n'
           )
         );
         // 2 supports PnP by default and breaks when trying to use the flag

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -269,17 +269,26 @@ function createApp(
     }
   } else if (usePnp) {
     const yarnInfo = checkYarnVersion();
-    if (!yarnInfo.hasMinYarnPnp) {
-      if (yarnInfo.yarnVersion) {
+    if (yarnInfo.yarnVersion) {
+      if (!yarnInfo.hasMinYarnPnp) {
         console.log(
           chalk.yellow(
             `You are using Yarn ${yarnInfo.yarnVersion} together with the --use-pnp flag, but Plug'n'Play is only supported starting from the 1.12 release.\n\n` +
               `Please update to Yarn 1.12 or higher for a better, fully supported experience.\n`
           )
         );
+        // 1.11 had an issue with webpack-dev-middleware, so better not use PnP with it (never reached stable, but still)
+        usePnp = false;
       }
-      // 1.11 had an issue with webpack-dev-middleware, so better not use PnP with it (never reached stable, but still)
-      usePnp = false;
+      if (!yarnInfo.hasMaxYarnPnp) {
+        console.log(
+          chalk.yellow(
+            `The --use-pnp flag is no longer necessary with yarn ${yarnInfo.yarnVersion} and will be deprecated and removed in a future release.\n`
+          )
+        );
+        // 2 supports PnP by default and breaks when trying to use the flag
+        usePnp = false;
+      }
     }
   }
 
@@ -783,7 +792,9 @@ function checkNpmVersion() {
 
 function checkYarnVersion() {
   const minYarnPnp = '1.12.0';
+  const maxYarnPnp = '2.0.0';
   let hasMinYarnPnp = false;
+  let hasMaxYarnPnp = false;
   let yarnVersion = null;
   try {
     yarnVersion = execSync('yarnpkg --version')
@@ -791,6 +802,7 @@ function checkYarnVersion() {
       .trim();
     if (semver.valid(yarnVersion)) {
       hasMinYarnPnp = semver.gte(yarnVersion, minYarnPnp);
+      hasMaxYarnPnp = semver.lt(yarnVersion, maxYarnPnp);
     } else {
       // Handle non-semver compliant yarn version strings, which yarn currently
       // uses for nightly builds. The regex truncates anything after the first
@@ -799,6 +811,7 @@ function checkYarnVersion() {
       if (trimmedYarnVersionMatch) {
         const trimmedYarnVersion = trimmedYarnVersionMatch.pop();
         hasMinYarnPnp = semver.gte(trimmedYarnVersion, minYarnPnp);
+        hasMaxYarnPnp = semver.lt(trimmedYarnVersion, maxYarnPnp);
       }
     }
   } catch (err) {
@@ -806,6 +819,7 @@ function checkYarnVersion() {
   }
   return {
     hasMinYarnPnp: hasMinYarnPnp,
+    hasMaxYarnPnp: hasMaxYarnPnp,
     yarnVersion: yarnVersion,
   };
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
The `--use-pnp` flag will break Yarn 2 because PnP has been enabled by default and the flag has been removed. This improves user experience by automatically ignoring the flag for Yarn 2, and explaining that it won't be needed in the future.

I've tested this with Yarn 1 and it works normally, though Yarn 2 has a different installation linking system that I couldn't get to work with create-react-app locally.