### PR TITLE
fix(docs): make change to setupTests.js explicit

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -197,7 +197,7 @@ Similar to `enzyme` you can create a `src/setupTests.js` file to avoid boilerpla
 import '@testing-library/jest-dom/extend-expect';
 ```
 
-Here's an example of using `react-testing-library` and `jest-dom` for testing that the `<App />` component renders "Welcome to React".
+Here's an example of using `react-testing-library` and `jest-dom` for testing that the `<App />` component renders "Welcome to React". This assumes that `import '@testing-library/jest-dom/extend-expect'` has been added to the `src/setupTests.js` file above.  
 
 ```js
 import React from 'react';


### PR DESCRIPTION
It was not clear to me, that the change to the setupTests.js file was required in order for the example to work. Adding this sentence may help others avoid the trap of simply copying and pasting the test code snippet.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
