### PR TITLE
Let 'open' take care of interpreting $BROWSER

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -123,7 +123,14 @@ function startBrowserProcess(browser, url, args) {
   // Fallback to open
   // (It will always open new tab)
   try {
-    var options = { app: browser, wait: false, url: true };
+    var options = {
+      // only pass app if there were explicit BROWSER_ARGS,
+      // because $BROWSER is better handled by 'open' (https://github.com/sindresorhus/open)
+      // which is based on xdg-open.
+      app: args.length > 0 ? browser : undefined,
+      wait: false,
+      url: true,
+    };
     open(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {


### PR DESCRIPTION
**Problem** 
Users sometimes use a command including subcommands and options in `$BROWSER`. [Open](https://github.com/sindresorhus/open) does handle this nicely, but create react app already reads the contents of $BROWSER and passes it as the command (`app`), which fails.

**Solution**
This PR avoids passing the contents of `$BROWSER` unless the create-react-app specific `$BROWSER_ARGS` is used as well. This way we can rely on the common contract for `$BROWSER` which is handled better by xdg-open.