### PR TITLE
(Fix #8488) Update CSS for highlighted code links

### DIFF
--- a/docusaurus/website/src/css/custom.css
+++ b/docusaurus/website/src/css/custom.css
@@ -27,6 +27,10 @@
   padding: 0 var(--ifm-pre-padding);
 }
 
+.contents__link.contents__link--active code {
+  color: var(--ifm-color-primary-darker);
+}
+
 .navbar .navbar__brand > strong {
   flex-shrink: 0;
   max-width: 100%;


### PR DESCRIPTION
- Verified the same classes are used on the deployed site
- Checked contrast values meet WCAG standards [exact ratios to be posted in comment shortly]
- Before: lightmode -- no highlighting for active code blocks:
<img width="317" alt="Screen Shot 2020-02-14 at 3 00 42 PM" src="https://user-images.githubusercontent.com/3665912/74577051-4ad30280-4f42-11ea-933b-a785d6bdb09d.png">
- After -- highlighting observable: 
<img width="232" alt="Screen Shot 2020-02-14 at 3 49 06 PM" src="https://user-images.githubusercontent.com/3665912/74577066-59b9b500-4f42-11ea-8629-6b926e182e84.png">

To show states comprehensively:
- Light mode -- normal section:
<img width="234" alt="Screen Shot 2020-02-14 at 3 48 59 PM" src="https://user-images.githubusercontent.com/3665912/74577104-75bd5680-4f42-11ea-8ff3-e83191cf976e.png">
- Light mode -- code section:
<img width="232" alt="Screen Shot 2020-02-14 at 3 49 06 PM" src="https://user-images.githubusercontent.com/3665912/74577117-7e159180-4f42-11ea-993e-2c91f11fa11d.png">
- Dark mode -- normal section:
<img width="219" alt="Screen Shot 2020-02-14 at 3 49 20 PM" src="https://user-images.githubusercontent.com/3665912/74577126-85d53600-4f42-11ea-8d25-c16b364f6350.png">
- Dark mode -- code section:
<img width="219" alt="Screen Shot 2020-02-14 at 3 49 13 PM" src="https://user-images.githubusercontent.com/3665912/74577135-8d94da80-4f42-11ea-96e6-b7aedf530550.png">

fixes #8488