### PR TITLE
Without this fix, ionic sample app does not even run and just emit an error.

### DIFF
--- a/packages/react-dev-utils/noopServiceWorkerMiddleware.js
+++ b/packages/react-dev-utils/noopServiceWorkerMiddleware.js
@@ -11,7 +11,7 @@ const path = require('path');
 
 module.exports = function createNoopServiceWorkerMiddleware(servedPath) {
   return function noopServiceWorkerMiddleware(req, res, next) {
-    if (req.url === path.join(servedPath, 'service-worker.js')) {
+    if (servedPath !== undefined && req.url === path.join(servedPath, 'service-worker.js')) {
       res.setHeader('Content-Type', 'text/javascript');
       res.send(
         `// This service worker file is effectively a 'no-op' that will reset any


### PR DESCRIPTION
<--
Without this fix, the tutorial of Ionic App (https://ionicframework.com/getting-started/) does not work and just throw an error like below.

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at validateString (internal/validators.js:118:11)
    at Object.join (path.js:1039:7)
    at noopServiceWorkerMiddleware (/path/to/node_modules/react-dev-utils/noopServiceWorkerMiddleware.js:14:26)
    at Layer.handle [as handle_request] (/path/to/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/path/to/node_modules/express/lib/router/index.js:317:13)
    at /path/to/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/path/to/node_modules/express/lib/router/index.js:335:12)
    at next (/path/to/node_modules/express/lib/router/index.js:275:10)
    at launchEditorMiddleware (/path/to/node_modules/react-dev-utils/errorOverlayMiddleware.js:20:7)
    at Layer.handle [as handle_request] (/path/to/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/path/to/node_modules/express/lib/router/index.js:317:13)
    at /path/to/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/path/to/node_modules/express/lib/router/index.js:335:12)
    at next (/path/to/node_modules/express/lib/router/index.js:275:10)
    at handleWebpackInternalMiddleware (/path/to/node_modules/react-dev-utils/evalSourceMapMiddleware.js:42:7)
    at Layer.handle [as handle_request] (/path/to/node_modules/express/lib/router/layer.js:95:5)
-->