### PR TITLE
Bumps pnp-webpack-plugin

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -60,7 +60,7 @@
     "jest-watch-typeahead": "0.4.2",
     "mini-css-extract-plugin": "0.9.0",
     "optimize-css-assets-webpack-plugin": "5.0.3",
-    "pnp-webpack-plugin": "1.6.3",
+    "pnp-webpack-plugin": "1.6.4",
     "postcss-flexbugs-fixes": "4.1.0",
     "postcss-loader": "3.0.0",
     "postcss-normalize": "8.0.1",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -60,7 +60,7 @@
     "jest-watch-typeahead": "0.4.2",
     "mini-css-extract-plugin": "0.9.0",
     "optimize-css-assets-webpack-plugin": "5.0.3",
-    "pnp-webpack-plugin": "1.6.0",
+    "pnp-webpack-plugin": "1.6.3",
     "postcss-flexbugs-fixes": "4.1.0",
     "postcss-loader": "3.0.0",
     "postcss-normalize": "8.0.1",


### PR DESCRIPTION
Since the PnP instance was stored in a global closure, a refreshed instance (when a dependency was added or removed) wasn't being being picked up. I fixed it in the plugin, now updating the dependency 😃

Fixes https://github.com/yarnpkg/berry/issues/958
