### PR TITLE
Allow testMatch override for Jest

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -85,6 +85,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'resetModules',
     'restoreMocks',
     'snapshotSerializers',
+    'testMatch'
     'transform',
     'transformIgnorePatterns',
     'watchPathIgnorePatterns',


### PR DESCRIPTION
This change just allows the `testMatch` for Jest to be overridden to allow changing of finding tests. We need this to be able to have mock files and test utility files for cleaner code organization and reuse.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
I edited the file locally with my custom `testMatch` config and saw that it applied successfully and ran the tests as expected.
