### PR TITLE
allow specification of package.main in template.json

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -137,7 +137,6 @@ module.exports = function(
     'author',
     'contributors',
     'files',
-    'main',
     'browser',
     'bin',
     'man',


### PR DESCRIPTION
Fixes https://github.com/facebook/create-react-app/issues/8373

I'm creating a template to work with [pulumi](https://github.com/pulumi/pulumi). Pulumi programs need to have a `main` specified in the package.json in order to work ([example](https://github.com/pulumi/examples/blob/master/aws-js-s3-folder/package.json)). CRA currently blacklists/sanitizes `main` declarations which is preventing the generation of fully functional apps.

This change allows specification of the `main` field in `template.json`.

Testing was done by modifying the typescript template to include a main, and then running:

```sh
$ yarn create-react-app foo --template file:./packages/cra-template-typescript
```

which resulted in:

```sh
$ create-react-cloud evanboyle$ cat foo/package.json 
{
  "name": "foo",
  "version": "0.1.0",
  "private": true,
  "dependencies": {
    "@testing-library/jest-dom": "^4.2.4",
    "@testing-library/react": "^9.3.2",
    "@testing-library/user-event": "^7.1.2",
    "@types/jest": "^24.0.0",
    "@types/node": "^12.0.0",
    "@types/react": "^16.9.0",
    "@types/react-dom": "^16.9.0",
    "react": "^16.12.0",
    "react-dom": "^16.12.0",
    "react-scripts": "/Users/evanboyle/code/create-react-cloud/packages/react-scripts/react-scripts-3.4.0.tgz",
    "typescript": "~3.7.2"
  },
  "scripts": {
    "start": "react-scripts start",
    "build": "react-scripts build",
    "test": "react-scripts test",
    "eject": "react-scripts eject"
  },
  "eslintConfig": {
    "extends": "react-app"
  },
  "browserslist": {
    "production": [
      ">0.2%",
      "not dead",
      "not op_mini all"
    ],
    "development": [
      "last 1 chrome version",
      "last 1 firefox version",
      "last 1 safari version"
    ]
  },
  "main": "indes.js"
}

```
