### PR TITLE
[docs]: update adding-typescript.md code blocks

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -13,9 +13,11 @@ To start a new Create React App project with [TypeScript](https://www.typescript
 
 ```sh
 npx create-react-app my-app --template typescript
+```
 
-# or
+or
 
+```sh
 yarn create react-app my-app --template typescript
 ```
 
@@ -27,9 +29,11 @@ To add [TypeScript](https://www.typescriptlang.org/) to a Create React App proje
 
 ```sh
 npm install --save typescript @types/node @types/react @types/react-dom @types/jest
+```
 
-# or
+or 
 
+```sh
 yarn add typescript @types/node @types/react @types/react-dom @types/jest
 ```
 


### PR DESCRIPTION
The purpose of this PR is to break the npm/yarn code block for the "Adding TypeScript" page so that when a reader clicks "Copy Code" it copies the single line of code and allows them to paste it into the command line. 
