### PR TITLE
List requirement to use `main` in package.json

### DIFF
--- a/docusaurus/docs/custom-templates.md
+++ b/docusaurus/docs/custom-templates.md
@@ -88,3 +88,14 @@ Below is an example `template.json` file:
 Any values you add for `"dependencies"` and `"scripts"` will be merged with the Create React App defaults. Values for any other keys will be used as-is, replacing any matching Create React App defaults.
 
 For convenience, we always replace `npm run` with `yarn` in your custom `"scripts"`, as well as in your `README` when projects are initialized with yarn.
+
+### `package.json`
+
+There are not many requirements specific to custom templates for your `package.json`, other than that the `main` key refers to your `template.json` file:
+
+```json
+{
+  "name": "cra-template-[template-name]",
+  "main": "template.json"
+}
+```


### PR DESCRIPTION
I'm not 100% sure whether `main` is required to point to `template.json`, but when I did not include the key altogether, I ran into the following error:

```
Error: Cannot find module 'cra-template-[template-name]'
Require stack:
- /tmp/my-app/node_modules/react-scripts/scripts/init.js
- /tmp/my-app/[eval]
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:793:17)
    at Function.resolve (internal/modules/cjs/helpers.js:80:19)
    at module.exports (/tmp/my-app/node_modules/react-scripts/scripts/init.js:110:13)
    at [eval]:3:14
    at Script.runInThisContext (vm.js:116:20)
    at Object.runInThisContext (vm.js:306:38)
    at Object.<anonymous> ([eval]-wrapper:9:26)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at evalScript (internal/process/execution.js:80:25)
    at internal/main/eval_string.js:23:3 {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/tmp/my-app/node_modules/react-scripts/scripts/init.js',
    '/tmp/my-app/[eval]'
  ]
}
```