### PR TITLE
Indicate that the file structure is the template's

### DIFF
--- a/docusaurus/docs/custom-templates.md
+++ b/docusaurus/docs/custom-templates.md
@@ -31,7 +31,7 @@ If you're interested in building a custom template, first take a look at how we'
 A template must have the following structure:
 
 ```
-my-app/
+cra-template-[template-name]/
   README.md (for npm)
   template.json
   package.json


### PR DESCRIPTION
The directory tree that's currently shown is the structure that a CRA template should have, but `my-app` is used earlier in this tutorial to refer to the app that's _generated_ based on that template.