### PR TITLE
Log stack trace on compilation error

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -119,7 +119,7 @@ function createCompiler({
   } catch (err) {
     console.log(chalk.red('Failed to compile.'));
     console.log();
-    console.log(err.message || err);
+    console.error(err);
     console.log();
     process.exit(1);
   }


### PR DESCRIPTION
This PR makes sure to log the error properly (including the stack trace) to the console when webpack fails to compile the bundle.

If fixes a previously closed (but not addressed) issue: https://github.com/facebook/create-react-app/issues/4284