### PR TITLE
http-proxy-middleware require import has changed

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -95,12 +95,12 @@ module.exports = function(app) {
 You can now register proxies as you wish! Here's an example using the above `http-proxy-middleware`:
 
 ```js
-const proxy = require('http-proxy-middleware');
+const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function(app) {
   app.use(
     '/api',
-    proxy({
+    createProxyMiddleware({
       target: 'http://localhost:5000',
       changeOrigin: true,
     })


### PR DESCRIPTION
Since http-proxy-middleware has a version higher v1.x.x the import of the require statement has changed... Please refer to docs --> https://github.com/chimurai/http-proxy-middleware

I had that issue when I installed this package with version > 1.x. During build process I got that error proxy is not defined. Well, the import has changed, as I said. 

Hope that helps and thank you for CRA. Keep up the good work!

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
