### PR TITLE
react-scripts dev server: Support PROXY env var for overridable "proxy"

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -59,6 +59,7 @@ if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
 // Tools like Cloud9 rely on this.
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
 const HOST = process.env.HOST || '0.0.0.0';
+const PROXY = process.env.PROXY || null;
 
 if (process.env.HOST) {
   console.log(
@@ -121,7 +122,7 @@ checkBrowsers(paths.appPath, isInteractive)
       webpack,
     });
     // Load proxy config
-    const proxySetting = require(paths.appPackageJson).proxy;
+    const proxySetting = PROXY || require(paths.appPackageJson).proxy;
     const proxyConfig = prepareProxy(
       proxySetting,
       paths.appPublic,


### PR DESCRIPTION
Usage example:
```sh
PROXY=https://some-server.com npm start
```
Or as a `script` in `package.json`:
```json
{
  "scripts": {
    "start": "react-scripts start",
    "start:staging": "PROXY=https://some-staging-server.com react-scripts start"
  },
  "proxy": "https://localhost:8888",
  "...": "..."
}
```