### PR TITLE
Fix commit error when create new project with CRA

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -59,7 +59,7 @@ function tryGitInit() {
 function tryGitCommit(appPath) {
   try {
     execSync('git add -A', { stdio: 'ignore' });
-    execSync('git commit -m "Initialize project using Create React App"', {
+    execSync('ALLOW_CONSOLE_LOG=1 git commit -m "Initialize project using Create React App"', {
       stdio: 'ignore',
     });
     return true;


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Fix this issue: https://spectrum.chat/create-react-app/general/error-shown-when-use-create-react-app~4ff97d56-7772-4a78-9540-b3667a2ea063

Because the lint does not allow `console.log` at: `packages/cra-template/template/src/serviceWorker.js` (https://github.com/facebook/create-react-app/blob/master/packages/cra-template/template/src/serviceWorker.js#L44) and `packages/cra-template-typescript/template/src/serviceWorker.ts` (https://github.com/facebook/create-react-app/blob/master/packages/cra-template-typescript/template/src/serviceWorker.ts#L52)

```
[console.log] found in [+          console.log(]
use ALLOW_CONSOLE_LOG=1 git commit to bypass this check
Commit aborted due to founded issues in diff
```
