### PR TITLE
Bump the .env file not atop the custom certificate section

### DIFF
--- a/docusaurus/docs/using-https-in-development.md
+++ b/docusaurus/docs/using-https-in-development.md
@@ -32,6 +32,9 @@ HTTPS=true npm start
 
 Note that the server will use a self-signed certificate, so your web browser will almost definitely display a warning upon accessing the page.
 
+You can also create a `.env` file with `HTTPS=true` set.
+[Learn more about environment variables in CRA](https://create-react-app.dev/docs/adding-custom-environment-variables).
+
 ## Custom SSL certificate
 
 To set a custom certificate, set the `SSL_CRT_FILE` and `SSL_KEY_FILE` environment variables to the path of the certificate and key files in the same way you do for `HTTPS` above. Note that you will also need to set `HTTPS=true`.
@@ -49,6 +52,3 @@ To avoid having to set the environment variable each time, you can either includ
   "start": "HTTPS=true react-scripts start"
 }
 ```
-
-Or you can create a `.env` file with `HTTPS=true` set.
-[Learn more about environment variables in CRA](https://create-react-app.dev/docs/adding-custom-environment-variables).


### PR DESCRIPTION
It belongs to the section for the out of the box certificate.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
