### PR TITLE
docs: use devDependencies for husky, lint-staged and prettier

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -117,13 +117,13 @@ Prettier is an opinionated code formatter with support for JavaScript, CSS and J
 To format our code whenever we make a commit in git, we need to install the following dependencies:
 
 ```sh
-npm install --save husky lint-staged prettier
+npm install --save-dev husky lint-staged prettier
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add husky lint-staged prettier
+yarn add --dev husky lint-staged prettier
 ```
 
 - `husky` makes it possible to use githooks as if they are npm scripts.


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

This pull request updates the documentation in this page: https://create-react-app.dev/docs/setting-up-your-editor

I believe that we only need husky, lint-staged or prettier during development. Therefore, it should be better to install them as devDependencies instead. 
