### PR TITLE
Update build script deployment URL

### DIFF
--- a/packages/react-dev-utils/printHostingInstructions.js
+++ b/packages/react-dev-utils/printHostingInstructions.js
@@ -41,7 +41,7 @@ function printHostingInstructions(
   console.log();
   console.log('Find out more about deployment here:');
   console.log();
-  console.log(`  ${chalk.yellow('bit.ly/CRA-deploy')}`);
+  console.log(`  ${chalk.yellow('create-react-app.dev/docs/deployment')}`);
   console.log();
 }
 


### PR DESCRIPTION
Currently when running `npm run build` in a create-react-app project the output has the following text
```
Find out more about deployment here:

  bit.ly/CRA-deploy
```
This link leads to [https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#deployment](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#deployment) which doesn't contain any information about deploying the app.

This PR changes the link to the create-react-app documentation's deployment page.