### PR TITLE
fix(eslint-config-react-app): adjust TS override pattern to match files outside of current working directory

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -54,7 +54,7 @@ module.exports = {
 
   overrides: [
     {
-      files: ['**/*.ts?(x)'],
+      files: ['*.ts?(x)'],
       parser: '@typescript-eslint/parser',
       parserOptions: {
         ecmaVersion: 2018,


### PR DESCRIPTION
I'll start with that this is speculative pull request. I didn't find issue related to it, but given minimal code change I figured I might as well start with change proposal.

I'm not exactly sure how intentional it is currently for pattern to start with globstar here (initial pull request for TS support in this eslint preset already had it - https://github.com/facebook/create-react-app/pull/6513) and later on there were just few changes that unified it a bit, but didn't touch `**/` part of pattern.

Impact that `**/` prefix has is that `eslint` will not match files if they are outside of `cwd`. This can happen if you are working with yarn workspaces and your setup doesn't compile TS files and leave them as is.

Please check https://runkit.com/pieh/5e7150eb43c9c70019a74c16 for very simplified illustration of problematic scenario (with some parts of `eslint` inlined there with links to source), so it's easier to see what's going on. You can play with override pattern there to see that "TS path outside project directory" match changes when you remove `**/` prefix from `false` to `true`

Ref: [Issue on gatsbyjs/gatsby about TS linting in workspaces](https://github.com/gatsbyjs/gatsby/issues/21913#issuecomment-599586957)