### PR TITLE
Allow sub domains in dev server

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -100,6 +100,7 @@ module.exports = function(proxy, allowedHost) {
     },
     https: getHttpsConfig(),
     host,
+    allowedHosts: ['.'.concat(host)],
     overlay: false,
     historyApiFallback: {
       // Paths with dots should still use the history fallback.


### PR DESCRIPTION
This is my attempt to get rid of the `DANGEROUSLY_DISABLE_HOST_CHECK` while working on apps that need the API proxy and subdomains. I'm not sure if this opens other similar security holes or if it breaks some other options that I don't personally use. I hope people with more experience would comment whether or not this is the way to go. See #2233 for previous discussion.