### PR TITLE
Allow subdomains in dev server

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -100,6 +100,7 @@ module.exports = function(proxy, allowedHost) {
     },
     https: getHttpsConfig(),
     host,
+    allowedHosts: ['.'.concat(host)],
     overlay: false,
     historyApiFallback: {
       // Paths with dots should still use the history fallback.


### PR DESCRIPTION
This is my attempt to get rid of the `DANGEROUSLY_DISABLE_HOST_CHECK` while working on apps that need the API proxy and subdomains. I'm wondering whether or not subdomains are vulnerable to similar spoofing attacks. At least one would expect the attack vector to be smaller if allowed hosts would be restricted to subdomains. See #2233 for previous discussion.