### PR TITLE
Fix trailing slash for windows os

### DIFF
--- a/packages/react-dev-utils/redirectServedPathMiddleware.js
+++ b/packages/react-dev-utils/redirectServedPathMiddleware.js
@@ -10,7 +10,7 @@ const path = require('path');
 
 module.exports = function createRedirectServedPathMiddleware(servedPath) {
   // remove end slash so user can land on `/test` instead of `/test/`
-  servedPath = servedPath.slice(0, -1);
+  servedPath = servedPath.endsWith(path.sep) ? servedPath.slice(0, -1) : servedPath
   return function redirectServedPathMiddleware(req, res, next) {
     if (
       servedPath === '' ||

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -75,7 +75,9 @@ module.exports = function(webpackEnv) {
   // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
   // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
   // Get environment variables to inject into our app.
-  const env = getClientEnvironment(paths.publicUrlOrPath.slice(0, -1));
+  const env = getClientEnvironment(
+  paths.publicUrlOrPath.endsWith(path.sep) ? paths.publicUrlOrPath.slice(0, -1) : paths.publicUrlOrPath
+  );
 
   // common function to get style loaders
   const getStyleLoaders = (cssOptions, preProcessor) => {

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -9,6 +9,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const errorOverlayMiddleware = require('react-dev-utils/errorOverlayMiddleware');
 const evalSourceMapMiddleware = require('react-dev-utils/evalSourceMapMiddleware');
 const noopServiceWorkerMiddleware = require('react-dev-utils/noopServiceWorkerMiddleware');
@@ -87,7 +88,7 @@ module.exports = function(proxy, allowedHost) {
     // we specified in the webpack config. When homepage is '.', default to serving
     // from the root.
     // remove last slash so user can land on `/test` instead of `/test/`
-    publicPath: paths.publicUrlOrPath.slice(0, -1),
+    publicPath: paths.publicUrlOrPath.endsWith(path.sep) ? paths.publicUrlOrPath.slice(0, -1) : paths.publicUrlOrPath,
     // WebpackDevServer is noisy by default so we emit custom message instead
     // by listening to the compiler events with `compiler.hooks[...].tap` calls above.
     quiet: true,

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -32,6 +32,7 @@ verifyTypeScriptSetup();
 // @remove-on-eject-end
 
 const fs = require('fs');
+const path = require('path');
 const chalk = require('react-dev-utils/chalk');
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
@@ -101,7 +102,7 @@ checkBrowsers(paths.appPath, isInteractive)
       protocol,
       HOST,
       port,
-      paths.publicUrlOrPath.slice(0, -1)
+      paths.publicUrlOrPath.endsWith(path.sep) ? paths.publicUrlOrPath.slice(0, -1) : paths.publicUrlOrPath
     );
     const devSocket = {
       warnings: warnings =>


### PR DESCRIPTION
This is happening in windows machine. 

(I cut some sections of logs)
Problem:
![react-app](https://user-images.githubusercontent.com/10108736/77229164-905f9c80-6b8c-11ea-8cb8-b24c424c7a09.png)

This PR fix:
![react-app-fix](https://user-images.githubusercontent.com/10108736/77229169-96557d80-6b8c-11ea-9339-7a16f6e29391.png)

