### PR TITLE
Use process.execPath to spawn node subprocess

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -45,7 +45,7 @@ function getBrowserEnv() {
 
 function executeNodeScript(scriptPath, url) {
   const extraArgs = process.argv.slice(2);
-  const child = spawn('node', [scriptPath, ...extraArgs, url], {
+  const child = spawn(process.execPath, [scriptPath, ...extraArgs, url], {
     stdio: 'inherit',
   });
   child.on('close', code => {

--- a/packages/react-scripts/bin/react-scripts.js
+++ b/packages/react-scripts/bin/react-scripts.js
@@ -26,7 +26,7 @@ const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : [];
 
 if (['build', 'eject', 'start', 'test'].includes(script)) {
   const result = spawn.sync(
-    'node',
+    process.execPath,
     nodeArgs
       .concat(require.resolve('../scripts/' + script))
       .concat(args.slice(scriptIndex + 1)),


### PR DESCRIPTION
Instead of requiring Node to be on the system PATH.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Currently, `react-scripts` spawns scripts such as `test`, `build` by specifying an executable name, `node`. This requires `node` to be on the system PATH. Some users (like me) may not have it on the system PATH and normally don't have problems since an IDE like Webstorm configured with a node interpreter mostly runs tests and builds without any problem. However, this doesn't work with `create-react-app` because it expects `node` on the PATH.

Luckily, there is an easy way of getting an absolute path to the current interpreter binary so we can use it and remove the requirement that `node` is on the system PATH.

I have verified that before this change, running tests in Webstorm failed with this

```
'node' is not recognized as an internal or external command,
operable program or batch file.
```

while after the change, tests run.

I ran `yarn run format` which pulled in an unrelated file. Hope it's ok to update it so people don't keep on running into it when sending a change.