### PR TITLE
Add log when development server is terminated on stdin end

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -168,6 +168,7 @@ checkBrowsers(paths.appPath, isInteractive)
     if (isInteractive || process.env.CI !== 'true') {
       // Gracefully exit when stdin ends
       process.stdin.on('end', function() {
+        console.log("Closing server as stdin ends...");
         devServer.close();
         process.exit();
       });


### PR DESCRIPTION
I'm a user of Play framework(Scala) and React, and I usually start react app with [PlayRunHook](https://www.playframework.com/documentation/2.7.x/sbtCookbook#Hooking-into-Plays-dev-mode) that executes `react-scripts` as a part of the run process.

By default scala does not provide stdin for [Process](https://www.scala-lang.org/api/current/scala/sys/process/ProcessBuilder.html). This start up process worked fine for me until [this update](https://github.com/facebook/create-react-app/pull/7203). I spent some time to find the cause since in this case the development server is closed immediately without logging.

This PR adds a log when dev server is closed when stdin ends, I believe this can help debugging greatly for those who have similar start up issue as I have.
