### PR TITLE
Bump @babel/preset-react to 7.9.4

### DIFF
--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -31,7 +31,7 @@
     "@babel/plugin-transform-react-display-name": "7.8.3",
     "@babel/plugin-transform-runtime": "7.9.0",
     "@babel/preset-env": "7.9.0",
-    "@babel/preset-react": "7.9.1",
+    "@babel/preset-react": "7.9.4",
     "@babel/preset-typescript": "7.9.0",
     "@babel/runtime": "7.9.0",
     "babel-plugin-macros": "2.8.0",


### PR DESCRIPTION
`@mdx-js/loader` complains about `pragmaFrag` not being set. 7.9.4 solves this issue.

https://github.com/babel/babel/pull/11295/files