### PR TITLE
Bump typescript template to 3.8 

### DIFF
--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -8,7 +8,7 @@
       "@types/react": "^16.9.0",
       "@types/react-dom": "^16.9.0",
       "@types/jest": "^24.0.0",
-      "typescript": "~3.7.2"
+      "typescript": "3.8"
     }
   }
 }

--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -8,7 +8,7 @@
       "@types/react": "^16.9.0",
       "@types/react-dom": "^16.9.0",
       "@types/jest": "^24.0.0",
-      "typescript": "^3.8"
+      "typescript": "^3.8.0"
     }
   }
 }

--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -8,7 +8,7 @@
       "@types/react": "^16.9.0",
       "@types/react-dom": "^16.9.0",
       "@types/jest": "^24.0.0",
-      "typescript": "3.8"
+      "typescript": "^3.8"
     }
   }
 }


### PR DESCRIPTION
### Description

It looks like @testing-library dependency currently relies on type-only imports which conflicts with the version of Typescript used in the cra template, preventing it from building straight after starting a new project.

<img width="1439" alt="Screenshot 2020-03-25 at 20 42 13" src="https://user-images.githubusercontent.com/38016720/77579131-173cae00-6eda-11ea-81b1-ac7357a85bcc.png">
