### PR TITLE
Add a note about Sass package

### DIFF
--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -61,3 +61,12 @@ If you set `SASS_PATH=node_modules:src`, this will allow you to do imports like
 > module.file_ext=.sass
 > module.file_ext=.scss
 > ```
+
+> **Note:** If you are using `@use`, `@forward` syntax to handle your css modules, you can import `Sass` package instead.
+
+Install Sass package:
+```sh
+$ npm install sass --save
+$ # or
+$ yarn add sass
+```


### PR DESCRIPTION
Node-sass doesn't seem to compile syntax such as `@use "./variables" as V;`
When trying to integrate an existing set of sass modules into a React app, it can be a bit misleading (at least for me it was) to see only node-sass mentioned in the Doc

Sorry if my english isn't perfect, I'm happy to reword it if necessary

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
