### PR TITLE
fix: handle templates without main package field

### DIFF
--- a/packages/cra-template-typescript/package.json
+++ b/packages/cra-template-typescript/package.json
@@ -8,7 +8,6 @@
     "typescript"
   ],
   "description": "The base TypeScript template for Create React App.",
-  "main": "template.json",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/create-react-app.git",

--- a/packages/cra-template/package.json
+++ b/packages/cra-template/package.json
@@ -7,7 +7,6 @@
     "template"
   ],
   "description": "The base template for Create React App.",
-  "main": "template.json",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/create-react-app.git",

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -106,9 +106,8 @@ module.exports = function(
     return;
   }
 
-  const templatePath = path.join(
-    require.resolve(templateName, { paths: [appPath] }),
-    '..'
+  const templatePath = path.dirname(
+    require.resolve(`${templateName}/package.json`, { paths: [appPath] })
   );
 
   let templateJsonPath;


### PR DESCRIPTION
Some users have hit an issue when creating templates and omitting the `main` field. As `main` is not required in `package.json`, we've simplified the implementation to remove this requirement.

Solution provided by @ianschmitz. Resolves #8560.
