### PR TITLE
Specify what files are served form a bare local copy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ All functionality must be retained (and configuration given to the user) if they
 
 2. Run `yarn` in the root `create-react-app` folder.
 
-Once it is done, you can modify any file locally and run `yarn start`, `yarn test` or `yarn build` like you can in a generated project.
+Once it is done, you can modify any file locally and run `yarn start`, `yarn test` or `yarn build` like you can in a generated project. It will serve the application from the files located in `packages/cra-template/template`.
 
 If you want to try out the end-to-end flow with the global CLI, you can do this too:
 


### PR DESCRIPTION
Hello,

In CONTRIBUTING.md, adding the path of the files being served by yarn start on a bare copy (git clone) of create-react-app.

