### PR TITLE
Use simplified import of @testing-library/jest-dom

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -194,7 +194,7 @@ Similar to `enzyme` you can create a `src/setupTests.js` file to avoid boilerpla
 ```js
 // react-testing-library renders your components to document.body,
 // this adds jest-dom's custom assertions
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 ```
 
 Here's an example of using `react-testing-library` and `jest-dom` for testing that the `<App />` component renders "Welcome to React".


### PR DESCRIPTION
As of https://github.com/testing-library/jest-dom/pull/175, setting up `@testing-library/jest-dom` is now a bit easier, it's enough to import `@testing-library/jest-dom`.