### PR TITLE
Add .cjs and .mjs files support to test runner

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -40,16 +40,16 @@ module.exports = (resolve, rootDir, isEjecting) => {
     ],
     testEnvironment: 'jest-environment-jsdom-fourteen',
     transform: {
-      '^.+\\.(js|jsx|ts|tsx)$': isEjecting
+      '^.+\\.(js|jsx|mjs|cjs|ts|tsx)$': isEjecting
         ? '<rootDir>/node_modules/babel-jest'
         : resolve('config/jest/babelTransform.js'),
       '^.+\\.css$': resolve('config/jest/cssTransform.js'),
-      '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': resolve(
+      '^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|json)$)': resolve(
         'config/jest/fileTransform.js'
       ),
     },
     transformIgnorePatterns: [
-      '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$',
+      '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$',
       '^.+\\.module\\.(css|sass|scss)$',
     ],
     modulePaths: modules.additionalModulePaths || [],


### PR DESCRIPTION
Node.js added new [`.cjs` and `.mjs`](https://nodejs.org/api/esm.html#esm_enabling) file extensions for dual ESM/CJS packages.

This PR adds `.cjs` and `.mjs` files from `node_modules` support to test runner.

## Context

I have popular dual [CJS/ESM package](https://github.com/ai/nanoid/).

```json
  "type": "module",
  "main": "index.cjs",
  "module": "index.js",
  "browser": {
    "./index.js": "./index.browser.js"
  },
  "exports": {
    ".": {
      "require": "./index.cjs",
      "import": "./index.js",
      "browser": "./index.browser.js"
    },
```

Everythings works in Create React App `npm start`:

```js
import { nanoid } from 'nanoid'
```

But Jest can’t load my library during `npm test`:

```
TypeError: (0 , _nanoid.nanoid) is not a function
```

Here is issue in my repo: https://github.com/ai/nanoid/issues/205

## The Way to Reproduce the Problem

1. Create an empty CRA project
2. `npm i nanoid`
3. Create test:
   ```js
   import * as nanoid from 'nanoid'
   console.log(nanoid)
   ```

Right now output will be:

```
{ default: 'index.cjs' }
```

With this pull request the result will be correct:

```
{ nanoid: [Function nanoid], urlAlphabet: …, customAlphabet: …, customRandom: … }
```