### PR TITLE
Add back in --stats output from webpack.

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -37,6 +37,7 @@
     "babel-loader": "8.1.0",
     "babel-plugin-named-asset-import": "^0.3.6",
     "babel-preset-react-app": "^9.1.2",
+    "bfj": "^7.0.2",
     "camelcase": "^5.3.1",
     "case-sensitive-paths-webpack-plugin": "2.3.0",
     "css-loader": "3.4.2",


### PR DESCRIPTION
This commit is a manual revert of the following commits:
https://github.com/facebook/create-react-app/commit/e7a427ad161b7b58868409d99307d8b68fad1335
https://github.com/facebook/create-react-app/commit/140e182e7d7fbeb8d507b6be4813a4ce0bf9b6d8

And a re-introduction of
https://github.com/facebook/create-react-app/commit/7c8593845830c585a780f4e40268e7b4f442c7a4

Fixes: https://github.com/facebook/create-react-app/issues/8789
Fixes: https://github.com/facebook/create-react-app/issues/6904

Tested:

Manually ran yarn link and then ran yarn build from a 3.x version of CRA
with react-scripts linked in from this patch.

Verification:
Saw that a bundle-stats.json file was written out where as before in the
pre-linked version it was not.
