### PR TITLE
Reverse order of isInteractive / process.env.CI arguments to allow for override

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -165,7 +165,7 @@ checkBrowsers(paths.appPath, isInteractive)
       });
     });
 
-    if (isInteractive || process.env.CI !== 'true') {
+    if (process.env.CI !== 'true' || isInteractive) {
       // Gracefully exit when stdin ends
       process.stdin.on('end', function() {
         devServer.close();


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

This patch reverses the order of the conditional introduced in https://github.com/facebook/create-react-app/pull/7203 so that `process.env.CI` can be set manually in the event one would want to override `process.env.CI` and have that honored.  The current implementation would not allow for that override.
