### PR TITLE
[#8829] Ensure all build errors are retained for logging when a build fails

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -188,11 +188,6 @@ function build(previousFileSizes) {
         );
       }
       if (messages.errors.length) {
-        // Only keep the first error. Others are often indicative
-        // of the same problem, but confuse the reader with noise.
-        if (messages.errors.length > 1) {
-          messages.errors.length = 1;
-        }
         return reject(new Error(messages.errors.join('\n\n')));
       }
       if (


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Fixes #8829 by removing the error truncation and leaving the full error list intact.

Very little to verify here as it's a simple change which impacts only the error reporting process. Verified by wrecking the hell out of my source code and viewing the various errors in all their glory before repairing and building successfully.
