### PR TITLE
Set margin and padding 0 for error overlay iframe

### DIFF
--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -117,6 +117,8 @@ const iframeStyle = {
   width: '100%',
   height: '100%',
   border: 'none',
+  margin: '0',
+  padding: '0',
   'z-index': 2147483647,
 };
 


### PR DESCRIPTION
If there is a global iframe style with margin set, that makes the error overlay look a bit weird. This PR simply ensures margin and padding is always zero. Reasonable I think, what do you think?