### PR TITLE
Do not check for interactive session to shut down dev server

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -165,7 +165,7 @@ checkBrowsers(paths.appPath, isInteractive)
       });
     });
 
-    if (isInteractive || process.env.CI !== 'true') {
+    if (process.env.CI !== 'true') {
       // Gracefully exit when stdin ends
       process.stdin.on('end', function() {
         devServer.close();


### PR DESCRIPTION
Fixes #8688

As discussed in #8868, Docker sessions shut down the dev server before it gets a chance to use it because Docker appears to be "interactive" and then closes `stdin` immediately. The workarounds were to set `CI=true` (which worked in some cases but not others) or to configure the Docker container to maintain an open TTY.

This shouldn't be necessary and is affecting both CI deployments and other environments.

The problem is a change in #7203, which intended to close the development server when `stdin` closed because otherwise it was left hanging open. That now is closing prematurely in cases where it's used in Docker.

During development of #7203, the check for an interactive session was added to fix it crashing in CRA's CI. However that didn't resolve the issue for some uses of Phoenix development watcher, which was fixed by checking that the CI environment variable is not set. The latter check should resolve the issue for CRA CI by itself — most CI systems set that variable.

While I couldn't figure out how to test a branch as an installed module (because of the monorepo nature), I did test this by hacking my Circle CI configuration to apply the patch and verified that resolved the CI issue for me:

```
sed -i '/process.env.CI/ s/isInteractive [|]*//' node_modules/react-scripts/scripts/start.js
```

I'm opening this PR in the hopes that it runs the CRA CI and will verify if this does not introduce a CI crash.