### PR TITLE
Fix type for PUBLIC_URL in cra-template-typescript

### DIFF
--- a/packages/cra-template-typescript/template/src/serviceWorker.ts
+++ b/packages/cra-template-typescript/template/src/serviceWorker.ts
@@ -29,7 +29,7 @@ export function register(config?: Config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(
-      process.env.PUBLIC_URL,
+      process.env.PUBLIC_URL as string,
       window.location.href
     );
     if (publicUrl.origin !== window.location.origin) {


### PR DESCRIPTION
I don't know if it's intentional or not, but I when I ran my code, TS yelled at me that there was typescript error saying the statement below for `serviceWorker.ts`.

```ts
Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
  Type 'undefined' is not assignable to type 'string'.
```