### PR TITLE
Patch 2

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -83,7 +83,7 @@ module.exports = function(api, opts, env) {
           useBuiltIns: 'entry',
           // Set the corejs version we are using to avoid warnings in console
           // This will need to change once we upgrade to corejs@3
-          corejs: 3,
+          corejs: '3.5',
           // Do not transform modules to CJS
           modules: false,
           // Exclude transforms that make all code slower

--- a/packages/babel-preset-react-app/dependencies.js
+++ b/packages/babel-preset-react-app/dependencies.js
@@ -88,7 +88,7 @@ module.exports = function(api, opts) {
           useBuiltIns: 'entry',
           // Set the corejs version we are using to avoid warnings in console
           // This will need to change once we upgrade to corejs@3
-          corejs: 3,
+          corejs: '3.5',
           // Do not transform modules to CJS
           modules: false,
           // Exclude transforms that make all code slower


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Closes #8875 

Changed to babel preset env `corejs` option to '3.5' to match the version that `react-app-polyfill` depends on, as recommended by [core-js](https://github.com/zloirock/core-js#babelpreset-env). 