### PR TITLE
Bump style-loader to 1.2.1

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -74,7 +74,7 @@
     "resolve-url-loader": "3.1.1",
     "sass-loader": "8.0.2",
     "semver": "6.3.0",
-    "style-loader": "0.23.1",
+    "style-loader": "1.2.0",
     "terser-webpack-plugin": "2.3.5",
     "ts-pnp": "1.1.6",
     "url-loader": "2.3.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -74,7 +74,7 @@
     "resolve-url-loader": "3.1.1",
     "sass-loader": "8.0.2",
     "semver": "6.3.0",
-    "style-loader": "1.2.0",
+    "style-loader": "1.2.1",
     "terser-webpack-plugin": "2.3.5",
     "ts-pnp": "1.1.6",
     "url-loader": "2.3.0",


### PR DESCRIPTION
Previously #8378 we rollback `style-loader` to v0.23.1 because CSS hot reload not worked with newer versions. Today it was fixed https://github.com/webpack-contrib/style-loader/pull/466 and we can safely upgrade it back and close #7665 
