### PR TITLE
Widen eslint-config-react-app peer dependency versions

### DIFF
--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-import": "2.x",
     "eslint-plugin-jsx-a11y": "6.x",
     "eslint-plugin-react": "7.x",
-    "eslint-plugin-react-hooks": "1.x || 2.x"
+    "eslint-plugin-react-hooks": "1.x || 2.x || 3.x"
   },
   "dependencies": {
     "confusing-browser-globals": "^1.0.9"


### PR DESCRIPTION
See #7790 for a previous similar PR.

I don't believe it is a breaking change to widen the peer dependency version, it merely lets people using the newer 3.x version of `eslint-plugin-react-hooks` use it with this ESLint config (e.g. if they're not using `react-scripts`). `react-scripts` will continue installing `^1.6.1` as it did before.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
