### PR TITLE
package.json defines main entry to template.json

### DIFF
--- a/docusaurus/docs/custom-templates.md
+++ b/docusaurus/docs/custom-templates.md
@@ -44,6 +44,14 @@ cra-template-[template-name]/
       index.js (or index.tsx)
 ```
 
+Ensure that `package.json` declares its main entry point to `template.json`. On the other hand, the template won't work.
+
+```json
+{
+  "main": "template.json'
+}
+```
+
 ### Testing a template
 
 To test a template locally, pass the file path to the directory of your template source using the `file:` prefix.


### PR DESCRIPTION
Added description to make sure that new template packages includes in their `packages.json` the main prop pointing to `template.json`.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
