### PR TITLE
Changed `proxyConfig.context` to return a bool when `headers.accept` is undeclared.

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -422,10 +422,11 @@ function prepareProxy(proxy, appPublicFolder, servedPathname) {
       // If this heuristic doesn’t work well for you, use `src/setupProxy.js`.
       context: function(pathname, req) {
         return (
-          req.method !== 'GET' ||
-          (mayProxy(pathname) &&
+          !(
+            req.method === 'GET' &&
             req.headers.accept &&
-            req.headers.accept.indexOf('text/html') === -1)
+            req.headers.accept.indexOf('text/html') !== -1
+          ) && mayProxy(pathname)
         );
       },
       onProxyReq: proxyReq => {

--- a/packages/react-dev-utils/__tests__/prepareProxy.test.js
+++ b/packages/react-dev-utils/__tests__/prepareProxy.test.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const { prepareProxy } = require('../WebpackDevServerUtils');
+
+const requests = [
+  {
+    pathname: '/',
+    req: {
+      method: 'GET',
+      headers: {
+        accept: 'text/html',
+      },
+    },
+    expect: false,
+  },
+  {
+    pathname: '/about',
+    req: {
+      method: 'GET',
+      headers: {
+        accept: 'text/html',
+      },
+    },
+    expect: false,
+  },
+  {
+    pathname: '/api/fetch',
+    req: {
+      method: 'GET',
+      headers: {
+        accept: '*/*',
+      },
+    },
+    expect: true,
+  },
+  {
+    pathname: '/api/create',
+    req: {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+      },
+    },
+    expect: true,
+  },
+  {
+    pathname: '/socket/proxy',
+    req: {
+      method: 'GET',
+      headers: {},
+    },
+    expect: true,
+  },
+];
+
+describe('follows proxy heuristics', () => {
+  let proxy = null;
+
+  beforeAll(() => {
+    proxy = prepareProxy('http://localhost:3001', '/public', '/')[0];
+  });
+
+  requests.forEach(t => {
+    test(`proxies ${t.pathname}`, () => {
+      const filter = proxy.context;
+      const actual = filter(t.pathname, t.req);
+      expect(actual).toBe(t.expect);
+    });
+  });
+});


### PR DESCRIPTION
Hi 👋,

I had some issues with using the default proxy heuristics with my own websocket server. So I did some digging and as far as I can tell the `proxyConfig.context` function returns `undefined` if the `accept` header is missing.

So I added a quick test `prepareProxy.test.js` that uses `proxyConfig.context` to filter a few mocked requests to check if they get proxied (returns true to proxy, false otherwise). And sure enough when testing path name `/socket/proxy` without an `accept` header it results in `undefined`. I expect it to be true since since it should be proxied according to the default heuristics described in your documentation / comments.

So I changed `proxyConfig.context` to ensure that both the `method: GET` and `Accept: text/html` check always returns a bool, and if they're `false` only then calling `mayProxy()` for a final check!

Passes the new tests and closes #5280 