### PR TITLE
bump webpack-dev-server to 3.11.0

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -79,7 +79,7 @@
     "ts-pnp": "1.2.0",
     "url-loader": "2.3.0",
     "webpack": "4.43.0",
-    "webpack-dev-server": "3.10.3",
+    "webpack-dev-server": "3.11.0",
     "webpack-manifest-plugin": "2.2.0",
     "workbox-webpack-plugin": "4.3.1"
   },


### PR DESCRIPTION
Resolves `yargs-parser` vulnerability mentioned in https://github.com/facebook/create-react-app/issues/8529