### PR TITLE
Add info on `skipWaiting()` to service worker docs

### DIFF
--- a/docusaurus/docs/making-a-progressive-web-app.md
+++ b/docusaurus/docs/making-a-progressive-web-app.md
@@ -22,8 +22,6 @@ serviceWorker.unregister();
 As the comment states, switching `serviceWorker.unregister()` to
 `serviceWorker.register()` will opt you in to using the service worker.
 
-
-
 ## Why Opt-in?
 
 Offline-first Progressive Web Apps are faster and more reliable than traditional web pages, and provide an engaging mobile experience:


### PR DESCRIPTION
CRA is on purpose very conservative when it comes to service worker updates. Under some  circumstances ([example](https://github.com/excalidraw/excalidraw/pull/1588)), it may be fine, though, to update immediately. This PR adds documentation how to apply `skipWaiting()` in such cases.