### PR TITLE
docs(typescript): add note on global.d.ts for ambient modules

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -37,6 +37,8 @@ Next, rename any file to be a TypeScript file (e.g. `src/index.js` to `src/index
 
 Type errors will show up in the same console as the build one. You'll have to fix these type errors before you continue development or build your project. For advanced configuration, [see here](advanced-configuration.md).
 
+You can declare ambient modules in a `src/global.d.ts` file. That is the only `.d.ts` file recognized by the TypeScript configuration.
+
 ## Getting Started with TypeScript and React
 
 You are not required to make a [`tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html), one will be made for you. You are allowed to edit the generated TypeScript configuration.


### PR DESCRIPTION
This PR includes a documentation update to note that the `src/global.d.ts` is recognized by default for type declarations. 


---

While working with TypeScript and create-react-app, I ran into a scenario where I needed to declare an ambient module. I created a `src/types.d.ts` file to declare my module only to find out that the file is not recognized. 

Through my research, I found this issue:
 https://github.com/facebook/create-react-app/issues/6553

The suggestion was to modify the `tsconfig` which didn't seem like a great solution. 

Found this thread: 
https://stackoverflow.com/questions/54949876/create-react-app-typescript-does-not-load-d-ts-file

That thread recommended using a `src/global.d.ts` file which solved my problem. 
