### PR TITLE
Pin babel-preset-react-app to to core-js minor version and add a peer dependency

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -82,7 +82,7 @@ module.exports = function (api, opts, env) {
           // Allow importing core-js in entrypoint and use browserlist to select polyfills
           useBuiltIns: 'entry',
           // Set the corejs version we are using to avoid warnings in console
-          corejs: 3,
+          corejs: 3.5,
           // Do not transform modules to CJS
           modules: false,
           // Exclude transforms that make all code slower

--- a/packages/babel-preset-react-app/dependencies.js
+++ b/packages/babel-preset-react-app/dependencies.js
@@ -87,8 +87,7 @@ module.exports = function (api, opts) {
           // Allow importing core-js in entrypoint and use browserlist to select polyfills
           useBuiltIns: 'entry',
           // Set the corejs version we are using to avoid warnings in console
-          // This will need to change once we upgrade to corejs@3
-          corejs: 3,
+          corejs: 3.5,
           // Do not transform modules to CJS
           modules: false,
           // Exclude transforms that make all code slower

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -36,5 +36,8 @@
     "@babel/runtime": "7.9.6",
     "babel-plugin-macros": "2.8.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24"
+  },
+  "peerDependencies": {
+    "core-js": "^3.5.0"
   }
 }


### PR DESCRIPTION
- Specified the minor version as recommended by core-js docs
- Removed comment about core-js@3 upgrade
- Added peer dependency on core-js from babel-preset-react-app.

Did some due dilligence and see react-error-overlay and react-scripts both directly depend on babel-preset-react-app but do not have a direct dependency on core-js. They do both have direct dependencies on react-app-polyfill that in turn depends on core-js. 

From my testing:
- npm doesn't complain about the peer depenency being unmet, guessing because it sees core-js in the dependency tree from react-app-polyfill
- yarn does warn about the peer dependency being unmet, this seems more correct than npm's behaviour. 

Forgive my ignorance but I don't know if babel-preset-react-app is expected to be usable without core-js? If not does that suggest react-scripts and react-error-overlay should have a direct dependency on core-js too?

closes #8875 #8779 