### PR TITLE
Replace npm with yarn to match screencast

### DIFF
--- a/docusaurus/docs/getting-started.md
+++ b/docusaurus/docs/getting-started.md
@@ -11,7 +11,7 @@ applications. It offers a modern build setup with no configuration.
 ```sh
 npx create-react-app my-app
 cd my-app
-npm start
+yarn start
 ```
 
 > If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that `npx` always uses the latest version.
@@ -23,7 +23,7 @@ Then open [http://localhost:3000/](http://localhost:3000/) to see your app.
 When you’re ready to deploy to production, create a minified bundle with `npm run build`.
 
 <p align='center'>
-<img src='https://cdn.jsdelivr.net/gh/facebook/create-react-app@27b42ac7efa018f2541153ab30d63180f5fa39e0/screencast.svg' width='600' alt='npm start' />
+<img src='https://cdn.jsdelivr.net/gh/facebook/create-react-app@27b42ac7efa018f2541153ab30d63180f5fa39e0/screencast.svg' width='600' alt='yarn start' />
 </p>
 
 ### Get Started Immediately


### PR DESCRIPTION
Since yarn is typically recommended over npm (and also used in the text in the `npx create-react-app` step), replace `npm start` with `yarn start` in the getting started documentation.
