### PR TITLE
Fix chained npm scripts yarn

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -22,6 +22,7 @@ const spawn = require('react-dev-utils/crossSpawn');
 const { defaultBrowsers } = require('react-dev-utils/browsersHelper');
 const os = require('os');
 const verifyTypeScriptSetup = require('./utils/verifyTypeScriptSetup');
+const replaceNpmScriptsWithYarn = require('./utils/replaceNpmScriptsWithYarn');
 
 function isInGitRepository() {
   try {
@@ -200,13 +201,7 @@ module.exports = function (
 
   // Update scripts for Yarn users
   if (useYarn) {
-    appPackage.scripts = Object.entries(appPackage.scripts).reduce(
-      (acc, [key, value]) => ({
-        ...acc,
-        [key]: value.replace(/(npm run |npm )/g, 'yarn '),
-      }),
-      {}
-    );
+    appPackage.scripts = replaceNpmScriptsWithYarn(appPackage.scripts);
   }
 
   // Setup the eslint config

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -203,7 +203,7 @@ module.exports = function (
     appPackage.scripts = Object.entries(appPackage.scripts).reduce(
       (acc, [key, value]) => ({
         ...acc,
-        [key]: value.replace(/(npm run |npm )/, 'yarn '),
+        [key]: value.replace(/(npm run |npm )/g, 'yarn '),
       }),
       {}
     );

--- a/packages/react-scripts/scripts/utils/__tests__/replaceNpmScriptsWithYarn.test.js
+++ b/packages/react-scripts/scripts/utils/__tests__/replaceNpmScriptsWithYarn.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const replaceNpmScriptsWithYarn = require('../replaceNpmScriptsWithYarn');
+
+describe('replaceNpmScriptsWithYarn util function', () => {
+  test('replaces single npm scripts with yarn', () => {
+    const scripts = {
+      test: 'npm run test',
+      example: 'npm example',
+    };
+
+    const actual = replaceNpmScriptsWithYarn(scripts);
+    const expected = {
+      test: 'yarn test',
+      example: 'yarn example',
+    };
+
+    expect(actual).toEqual(expected);
+  });
+
+  test('replaces chained npm scripts with yarn', () => {
+    const scripts = {
+      'pre-commit': 'npm run prettier && npm run lint && npm test',
+    };
+
+    const actual = replaceNpmScriptsWithYarn(scripts);
+    const expected = {
+      'pre-commit': 'yarn prettier && yarn lint && yarn test',
+    };
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/packages/react-scripts/scripts/utils/replaceNpmScriptsWithYarn.js
+++ b/packages/react-scripts/scripts/utils/replaceNpmScriptsWithYarn.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const replaceNpmScriptsWithYarn = scripts => {
+  return Object.entries(scripts).reduce(
+    (acc, [key, value]) => ({
+      ...acc,
+      [key]: value.replace(/(npm run |npm )/g, 'yarn '),
+    }),
+    {}
+  );
+};
+
+module.exports = replaceNpmScriptsWithYarn;


### PR DESCRIPTION
This PR adds a small fix to ensure that all npm scripts in `template.json` are converted to yarn correctly. Previously with scripts that had chained commands (i.e. `npm run this && npm run that`) only the first instance of `npm`/`npm run` would be replaced with `yarn`. This is to address #8795 (which has since been closed/locked as I forgot to keep it alive with another comment - sorry for any inconvenience!).

- 1st commit adds a global flag to the regex that handles the replacing to fix this issue
- 2nd commit splits the replace function out into a util and adds some tests, as I felt a bit cheeky making a 1 char PR :)

N.B. the tests in the second commit have been placed near the code in question, but I’m happy to move them to wherever suits. I could only get these tests to run by passing the path to jest specifically, so I get the feeling that they sit outside of the normal test setup of this repo.

To run tests from root dir I used:

```
npx jest ./packages/react-scripts/scripts/utils/__tests__/replaceNpmScriptsWithYarn.test.js
```

Result:
![image](https://user-images.githubusercontent.com/10071110/82726001-02fa0f00-9cd9-11ea-859d-516655bdcb5a.png)

(reverting to the original code without the `g` flag breaks the second test as expected)