### PR TITLE
clean formatMessage usage

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -106,12 +106,8 @@ function formatMessage(message) {
 }
 
 function formatWebpackMessages(json) {
-  const formattedErrors = json.errors.map(function (message) {
-    return formatMessage(message, true);
-  });
-  const formattedWarnings = json.warnings.map(function (message) {
-    return formatMessage(message, false);
-  });
+  const formattedErrors = json.errors.map(formatMessage);
+  const formattedWarnings = json.warnings.map(formatMessage);
   const result = { errors: formattedErrors, warnings: formattedWarnings };
   if (result.errors.some(isLikelyASyntaxError)) {
     // If there are any syntax errors, show just them.


### PR DESCRIPTION
[`formatMessage` function](https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/formatWebpackMessages.js#L18) accepts only one argument. This pull request cleans up the extra argument passed to it.