### PR TITLE
express.static overrides the route handler

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -38,7 +38,7 @@ const express = require('express');
 const path = require('path');
 const app = express();
 
-app.use(express.static(path.join(__dirname, 'build')));
+app.use(express.static(path.join(__dirname, 'build'), { index: false }));
 
 app.get('/', function(req, res) {
   res.sendFile(path.join(__dirname, 'build', 'index.html'));
@@ -60,7 +60,7 @@ If you use routers that use the HTML5 [`pushState` history API](https://develope
 This is because when there is a fresh page load for a `/todos/42`, the server looks for the file `build/todos/42` and does not find it. The server needs to be configured to respond to a request to `/todos/42` by serving `index.html`. For example, we can amend our Express example above to serve `index.html` for any unknown paths:
 
 ```diff
- app.use(express.static(path.join(__dirname, 'build')));
+ app.use(express.static(path.join(__dirname, 'build'), { index: false }));
 
 -app.get('/', function (req, res) {
 +app.get('/*', function (req, res) {


### PR DESCRIPTION
I just spend some time debugging an inexplicable error where my route handler was not being called but the site continued working. Turns out, express.static will override a `/` route when the `index.html` file is found in the static root. No server example (this included until now) of serving a CRA app has made note of this. Setting `index: false` on the static middleware turns off this behaviour and returns control to the route handler.

I ran into this using Express v4.17.1 and using no other Express middeware than express.static.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
