### PR TITLE
Allow testMatch for jest config

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -87,6 +87,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'resetModules',
     'restoreMocks',
     'snapshotSerializers',
+    'testMatch',
     'transform',
     'transformIgnorePatterns',
     'watchPathIgnorePatterns',


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Resolves #8637. 

Tested locally with these steps:
1. `cd packages/react-scripts`
2. `yarn link`
3. In another project: `yarn link "react-scripts"`
4. Running `SKIP_PREFLIGHT_CHECKS=true yarn test`
5. Verifying that nothing changed from before symlinking modules
![image](https://user-images.githubusercontent.com/4019718/83903346-42efd600-a75e-11ea-9244-792cecfe81ad.png)
6. Add `testMatch` key to `package.json` Jest config
7. Running `SKIP_PREFLIGHT_CHECKS=true yarn test` again
8. Verifying that only filed matching specified pattern are being included for testing
![image](https://user-images.githubusercontent.com/4019718/83903385-5307b580-a75e-11ea-9bcd-3076a6f5d291.png)

For further reasoning as to why this option should be added please refer to #8637. 

