### PR TITLE
Update updating-to-new-releases.md

### DIFF
--- a/docusaurus/docs/updating-to-new-releases.md
+++ b/docusaurus/docs/updating-to-new-releases.md
@@ -18,3 +18,5 @@ To update an existing project to a new version of `react-scripts`, [open the cha
 In most cases bumping the `react-scripts` version in `package.json` and running `npm install` (or `yarn install`) in this folder should be enough, but it’s good to consult the [changelog](https://github.com/facebook/create-react-app/blob/master/CHANGELOG.md) for potential breaking changes.
 
 We commit to keeping the breaking changes minimal so you can upgrade `react-scripts` painlessly.
+
+Over the course of development and new releases, improvements are made to the starter templates offered by `create-react-app`. These include useful utilities that many projects could benefit from. To this end, when updating the version of `react-scripts` it is also worth checking the most recent version of the template you used as a base (e.g. `cra-template`) to see if you want to include any of these changes in your existing project.


### PR DESCRIPTION
I was just updating an existing older project that was built with CRA. Following the changelog to get migration instructions for newer versions of `react-scripts` was a breeze - thanks for this!

One thing that did occur to me however, is that since I first created this project the official `cra-template` has changed quite a bit and now includes things like `src/setupTests.js` and wrapping the app in `<React.StrictMode>`. I looked back over the changelog and saw these changes as enhancements upon closer inspection, but I thought a note in the docs to give users a nudge on this would be useful.

Might be something here about suggesting updates to `react`/`react-dom` as well if possible?