### PR TITLE
Added "ie 11" in the "browserslist"

### DIFF
--- a/docusaurus/docs/supported-browsers-features.md
+++ b/docusaurus/docs/supported-browsers-features.md
@@ -43,6 +43,7 @@ Here is an example `browserslist` that is specified in `package.json`:
     "not op_mini all"
   ],
   "development": [
+    "ie 11",
     "last 1 chrome version",
     "last 1 firefox version",
     "last 1 safari version"


### PR DESCRIPTION
If we do not add "ie 11" in the `browserslist`, it does not work in internet explorer 11 browser. Adding "ie 11" in "browserslist" fixes the IE 11 compatible issue with React app.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
