### PR TITLE
fix: improve DefinePlugin config

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -101,12 +101,10 @@ function getClientEnvironment(publicUrl) {
       }
     );
   // Stringify all values so we can feed into webpack DefinePlugin
-  const stringified = {
-    'process.env': Object.keys(raw).reduce((env, key) => {
-      env[key] = JSON.stringify(raw[key]);
-      return env;
-    }, {}),
-  };
+  const stringified = Object.keys(raw).reduce((env, key) => {
+    env[`process.env.${key}`] = JSON.stringify(raw[key]);
+    return env;
+  }, {});
 
   return { raw, stringified };
 }


### PR DESCRIPTION
This configuration is used in webpack's DefinePlugin which prefers keys
that look like `process.env.REACT_APP_MY_ENV_VAR` instead of a nested
object: https://webpack.js.org/plugins/define-plugin/

Prior to this change, webpack would replace all occurrences of
`process.env` with a JS object containing every key in the environment
that begins with `REACT_APP`.

The expected behavior is that a reference to
`process.env.REACT_APP_MY_ENV_VAR` is replaced with the value of just
that environment variable.

