### PR TITLE
fix(docs): change Manifest Guide URL

### DIFF
--- a/docusaurus/docs/making-a-progressive-web-app.md
+++ b/docusaurus/docs/making-a-progressive-web-app.md
@@ -99,7 +99,7 @@ details specific to your web application.
 When a user adds a web app to their homescreen using Chrome or Firefox on
 Android, the metadata in [`manifest.json`](https://github.com/facebook/create-react-app/blob/master/packages/cra-template/template/public/manifest.json) determines what
 icons, names, and branding colors to use when the web app is displayed.
-[The Web App Manifest guide](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/)
+[The Web App Manifest guide](https://web.dev/add-manifest/)
 provides more context about what each field means, and how your customizations
 will affect your users' experience.
 


### PR DESCRIPTION
The link that is supposed to send to the Web Manifest Guide is not working anymore, sending the user to https://developers.google.com/web/fundamentals. I changed it to send to an [article](https://web.dev/add-manifest/) under the same organization (Google) that explains in detail the `manifest.json` file.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
