### PR TITLE
Replace npx with npm init

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -87,7 +87,7 @@ labels: 'issue: bug report, needs triage'
   Run the following command in your React app's folder in terminal.
   Note: The result is copied to your clipboard directly.
 
-  `npx create-react-app --info`
+  `npm init react-app --info`
 
   Paste the output of the command in the section below.
 -->

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -506,7 +506,7 @@ Create React App 2.1 adds support for TypeScript! Read [the documentation](https
 New applications can be created using TypeScript by running:
 
 ```sh
-$ npx create-react-app my-app --typescript
+$ npm init react-app my-app --typescript
 ```
 
 #### :rocket: New Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,7 +281,7 @@ We've published our existing templates as [`cra-template`](https://github.com/fa
 The below command shows how you can create a new app with `cra-template-typescript`.
 
 ```sh
-npx create-react-app my-app --template typescript
+npm init react-app my-app --template typescript
 ```
 
 Note that you can omit the prefix `cra-template-` when specifying which template you would like. For TypeScript users, we're deprecating `--typescript` in favour of `--template typescript`.

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ If you have questions or need help, please ask in [GitHub Discussions](https://g
 ## Quick Overview
 
 ```sh
-npx create-react-app my-app
+npm init react-app my-app
 cd my-app
 npm start
 ```
 
-If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that npx always uses the latest version.
+If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that npm always uses the latest version.
 
-_([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))_
+_`npm init <initializer>` is available in npm 6+, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f)_
 
 Then open [http://localhost:3000/](http://localhost:3000/) to see your app.<br>
 When you’re ready to deploy to production, create a minified bundle with `npm run build`.
@@ -41,21 +41,13 @@ Create a project, and you’re good to go.
 
 To create a new app, you may choose one of the following methods:
 
-### npx
-
-```sh
-npx create-react-app my-app
-```
-
-_([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) is a package runner tool that comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))_
-
 ### npm
 
 ```sh
 npm init react-app my-app
 ```
 
-_`npm init <initializer>` is available in npm 6+_
+_`npm init <initializer>` is available in npm 6+, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f)_
 
 ### Yarn
 

--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -12,14 +12,14 @@ title: Adding TypeScript
 To start a new Create React App project with [TypeScript](https://www.typescriptlang.org/), you can run:
 
 ```sh
-npx create-react-app my-app --template typescript
+npm init react-app my-app --template typescript
 
 # or
 
 yarn create react-app my-app --template typescript
 ```
 
-> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that `npx` always uses the latest version.
+> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that npm always uses the latest version.
 >
 > Global installs of `create-react-app` are no longer supported.
 
@@ -47,7 +47,7 @@ You are not required to make a [`tsconfig.json` file](https://www.typescriptlang
 
 ## Troubleshooting
 
-If your project is not created with TypeScript enabled, npx may be using a cached version of `create-react-app`. Remove previously installed versions with `npm uninstall -g create-react-app` (see [#6119](https://github.com/facebook/create-react-app/issues/6119#issuecomment-451614035)).
+If your project is not created with TypeScript enabled, npm may be using a cached version of `create-react-app`. Remove previously installed versions with `npm uninstall -g create-react-app` (see [#6119](https://github.com/facebook/create-react-app/issues/6119#issuecomment-451614035)).
 
 If you are currently using [create-react-app-typescript](https://github.com/wmonk/create-react-app-typescript/), see [this blog post](https://vincenttunru.com/migrate-create-react-app-typescript-to-create-react-app/) for instructions on how to migrate to Create React App.
 

--- a/docusaurus/docs/custom-templates.md
+++ b/docusaurus/docs/custom-templates.md
@@ -12,7 +12,7 @@ You'll notice that Custom Templates are always named in the format `cra-template
 Scoped templates are also supported, under the name `@[scope-name]/cra-template` or `@[scope-name]/cra-template-[template-name]`, which can be installed via `@[scope]` and `@[scope]/[template-name]` respectively.
 
 ```sh
-npx create-react-app my-app --template [template-name]
+npm init react-app my-app --template [template-name]
 ```
 
 ## Finding custom templates
@@ -49,7 +49,7 @@ cra-template-[template-name]/
 To test a template locally, pass the file path to the directory of your template source using the `file:` prefix.
 
 ```sh
-npx create-react-app my-app --template file:../path/to/your/template/cra-template-[template-name]
+npm init react-app my-app --template file:../path/to/your/template/cra-template-[template-name]
 ```
 
 ### The `template` folder

--- a/docusaurus/docs/getting-started.md
+++ b/docusaurus/docs/getting-started.md
@@ -9,14 +9,14 @@ applications. It offers a modern build setup with no configuration.
 ## Quick Start
 
 ```sh
-npx create-react-app my-app
+npm init react-app my-app
 cd my-app
 npm start
 ```
 
-> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that `npx` always uses the latest version.
+> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` to ensure that npm always uses the latest version.
 
-_([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))_
+_`npm init <initializer>` is available in npm 6+, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f)_
 
 Then open [http://localhost:3000/](http://localhost:3000/) to see your app.
 
@@ -38,21 +38,13 @@ Create a project, and you’re good to go.
 
 To create a new app, you may choose one of the following methods:
 
-### npx
-
-```sh
-npx create-react-app my-app
-```
-
-_([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))_
-
 ### npm
 
 ```sh
 npm init react-app my-app
 ```
 
-_`npm init <initializer>` is available in npm 6+_
+_`npm init <initializer>` is available in npm 6+, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f)_
 
 ### Yarn
 
@@ -71,7 +63,7 @@ If you don't select a template, we'll create your project with our base template
 Templates are always named in the format `cra-template-[template-name]`, however you only need to provide the `[template-name]` to the creation command.
 
 ```sh
-npx create-react-app my-app --template [template-name]
+npm init react-app my-app --template [template-name]
 ```
 
 > You can find a list of available templates by searching for ["cra-template-\*"](https://www.npmjs.com/search?q=cra-template-*) on npm.
@@ -83,7 +75,7 @@ Our [Custom Templates](custom-templates.md) documentation describes how you can 
 You can start a new TypeScript app using templates. To use our provided TypeScript template, append `--template typescript` to the creation command.
 
 ```sh
-npx create-react-app my-app --template typescript
+npm init react-app my-app --template typescript
 ```
 
 If you already have a project and would like to add TypeScript, see our [Adding TypeScript](adding-typescript.md) documentation.
@@ -93,7 +85,7 @@ If you already have a project and would like to add TypeScript, see our [Adding 
 When you create a new app, the CLI will use [Yarn](https://yarnpkg.com/) to install dependencies (when available). If you have Yarn installed, but would prefer to use npm, you can append `--use-npm` to the creation command. For example:
 
 ```sh
-npx create-react-app my-app --use-npm
+npm init react-app my-app --use-npm
 ```
 
 ## Output

--- a/docusaurus/docs/updating-to-new-releases.md
+++ b/docusaurus/docs/updating-to-new-releases.md
@@ -8,8 +8,9 @@ Create React App is divided into two packages:
 - `create-react-app` is a global command-line utility that you use to create new projects.
 - `react-scripts` is a development dependency in the generated projects (including this one).
 
-When you run `npx create-react-app my-app` it automatically installs the latest version of Create React App.  
-> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, please visit [Getting Started](getting-started.md) to learn about current installation steps. 
+When you run `npm init react-app my-app` it automatically installs the latest version of Create React App.
+
+> If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, please visit [Getting Started](getting-started.md) to learn about current installation steps.
 
 Create React App creates the project with the latest version of `react-scripts` so you’ll get all the new features and improvements in newly created apps automatically.
 

--- a/docusaurus/website/src/pages/index.js
+++ b/docusaurus/website/src/pages/index.js
@@ -92,7 +92,7 @@ function Home() {
                 To create a project called <i>my-app</i>, run this command:
               </p>
               <CodeBlock className="language-sh">
-                npx create-react-app my-app
+                npm init react-app my-app
               </CodeBlock>
               <br />
             </div>

--- a/packages/cra-template-typescript/README.md
+++ b/packages/cra-template-typescript/README.md
@@ -7,7 +7,7 @@ To use this template, add `--template typescript` when creating a new app.
 For example:
 
 ```sh
-npx create-react-app my-app --template typescript
+npm init react-app my-app --template typescript
 
 # or
 

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -102,14 +102,14 @@ startLocalRegistry "$root_path"/tasks/verdaccio.yaml
 publishToLocalRegistry
 
 echo "Create React App Version: "
-npx create-react-app --version
+npm init react-app --version
 
 # ******************************************************************************
 # Test --scripts-version with a distribution tag
 # ******************************************************************************
 
 cd "$temp_app_path"
-npx create-react-app test-app-dist-tag --scripts-version=@latest
+npm init react-app test-app-dist-tag --scripts-version=@latest
 cd test-app-dist-tag
 
 # Check corresponding scripts version is installed and no TypeScript is present.
@@ -124,7 +124,7 @@ checkDependencies
 # ******************************************************************************
 
 cd "$temp_app_path"
-npx create-react-app test-app-version-number --scripts-version=1.0.17
+npm init react-app test-app-version-number --scripts-version=1.0.17
 cd test-app-version-number
 
 # Check corresponding scripts version is installed.
@@ -137,7 +137,7 @@ checkDependencies
 # ******************************************************************************
 
 cd "$temp_app_path"
-npx create-react-app test-use-npm-flag --use-npm --scripts-version=1.0.17
+npm init react-app test-use-npm-flag --use-npm --scripts-version=1.0.17
 cd test-use-npm-flag
 
 # Check corresponding scripts version is installed.
@@ -151,7 +151,7 @@ checkDependencies
 # ******************************************************************************
 
 cd "$temp_app_path"
-npx create-react-app test-app-typescript --template typescript
+npm init react-app test-app-typescript --template typescript
 cd test-app-typescript
 
 # Check corresponding template is installed.
@@ -189,7 +189,7 @@ CI=true yarn test
 # ******************************************************************************
 
 cd "$temp_app_path"
-npx create-react-app test-app-tarball-url --scripts-version=https://registry.npmjs.org/react-scripts/-/react-scripts-1.0.17.tgz
+npm init react-app test-app-tarball-url --scripts-version=https://registry.npmjs.org/react-scripts/-/react-scripts-1.0.17.tgz
 cd test-app-tarball-url
 
 # Check corresponding scripts version is installed.
@@ -202,7 +202,7 @@ checkDependencies
 # ******************************************************************************
 
 cd "$temp_app_path"
-npx create-react-app test-app-fork --scripts-version=react-scripts-fork
+npm init react-app test-app-fork --scripts-version=react-scripts-fork
 cd test-app-fork
 
 # Check corresponding scripts version is installed.
@@ -214,7 +214,7 @@ exists node_modules/react-scripts-fork
 
 cd "$temp_app_path"
 # we will install a non-existing package to simulate a failed installation.
-npx create-react-app test-app-should-not-exist --scripts-version=`date +%s` || true
+npm init react-app test-app-should-not-exist --scripts-version=`date +%s` || true
 # confirm that the project files were deleted
 test ! -e test-app-should-not-exist/package.json
 test ! -d test-app-should-not-exist/node_modules
@@ -227,7 +227,7 @@ cd "$temp_app_path"
 mkdir test-app-should-remain
 echo '## Hello' > ./test-app-should-remain/README.md
 # we will install a non-existing package to simulate a failed installation.
-npx create-react-app test-app-should-remain --scripts-version=`date +%s` || true
+npm init react-app test-app-should-remain --scripts-version=`date +%s` || true
 # confirm the file exist
 test -e test-app-should-remain/README.md
 # confirm only README.md and error log are the only files in the directory
@@ -241,7 +241,7 @@ fi
 
 cd $temp_app_path
 curl "https://registry.npmjs.org/@enoah_netzach/react-scripts/-/react-scripts-0.9.0.tgz" -o enoah-scripts-0.9.0.tgz
-npx create-react-app test-app-scoped-fork-tgz --scripts-version=$temp_app_path/enoah-scripts-0.9.0.tgz
+npm init react-app test-app-scoped-fork-tgz --scripts-version=$temp_app_path/enoah-scripts-0.9.0.tgz
 cd test-app-scoped-fork-tgz
 
 # Check corresponding scripts version is installed.
@@ -256,20 +256,20 @@ cd "$temp_app_path"
 mkdir test-app-nested-paths-t1
 cd test-app-nested-paths-t1
 mkdir -p test-app-nested-paths-t1/aa/bb/cc/dd
-npx create-react-app test-app-nested-paths-t1/aa/bb/cc/dd
+npm init react-app test-app-nested-paths-t1/aa/bb/cc/dd
 cd test-app-nested-paths-t1/aa/bb/cc/dd
 yarn start --smoke-test
 
 # Testing a path that does not exist
 cd "$temp_app_path"
-npx create-react-app test-app-nested-paths-t2/aa/bb/cc/dd
+npm init react-app test-app-nested-paths-t2/aa/bb/cc/dd
 cd test-app-nested-paths-t2/aa/bb/cc/dd
 yarn start --smoke-test
 
 # Testing a path that is half exists
 cd "$temp_app_path"
 mkdir -p test-app-nested-paths-t3/aa
-npx create-react-app test-app-nested-paths-t3/aa/bb/cc/dd
+npm init react-app test-app-nested-paths-t3/aa/bb/cc/dd
 cd test-app-nested-paths-t3/aa/bb/cc/dd
 yarn start --smoke-test
 
@@ -277,7 +277,7 @@ yarn start --smoke-test
 # Test when PnP is enabled
 # ******************************************************************************
 cd "$temp_app_path"
-npx create-react-app test-app-pnp --use-pnp
+npm init react-app test-app-pnp --use-pnp
 cd test-app-pnp
 ! exists node_modules
 exists .pnp.js

--- a/tasks/e2e-kitchensink-eject.sh
+++ b/tasks/e2e-kitchensink-eject.sh
@@ -93,7 +93,7 @@ publishToLocalRegistry
 
 # Install the app in a temporary location
 cd $temp_app_path
-npx create-react-app test-kitchensink --template=file:"$root_path"/packages/react-scripts/fixtures/kitchensink
+npm init react-app test-kitchensink --template=file:"$root_path"/packages/react-scripts/fixtures/kitchensink
 
 # Install the test module
 cd "$temp_module_path"

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -93,7 +93,7 @@ publishToLocalRegistry
 
 # Install the app in a temporary location
 cd $temp_app_path
-npx create-react-app test-kitchensink --template=file:"$root_path"/packages/react-scripts/fixtures/kitchensink
+npm init react-app test-kitchensink --template=file:"$root_path"/packages/react-scripts/fixtures/kitchensink
 
 # Install the test module
 cd "$temp_module_path"

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -147,7 +147,7 @@ publishToLocalRegistry
 
 # Install the app in a temporary location
 cd $temp_app_path
-npx create-react-app test-app
+npm init react-app test-app
 
 # TODO: verify we installed prerelease
 

--- a/tasks/screencast.sh
+++ b/tasks/screencast.sh
@@ -11,8 +11,8 @@
 set -e
 
 printf '\e[32m%s\e[m' "λ "
-echo "npx create-react-app my-app" | pv -qL $[10+(-2 + RANDOM%5)]
-npx create-react-app my-app
+echo "npm init react-app my-app" | pv -qL $[10+(-2 + RANDOM%5)]
+npm init react-app my-app
 
 printf '\e[32m%s\e[m' "λ "
 sleep 1


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

`npx create-react-app` is now `npx init react-app`


## Rationale
- Shorter and easier to type (no accidental `npm create-react-app`)
- [Officially suggested by npm changelog](https://github.com/npm/cli/blob/latest/CHANGELOG.md#extended-npm-init-scaffolding)
- npm 6, which this was introduced in, is now over 2 years old and is very likely to already be installed
- More consistent with old school `npm init` and the more recent `yarn create`
- Uses the same syntax as other `create-` packages