### PR TITLE
Support process.env.PROXY

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -121,7 +121,7 @@ checkBrowsers(paths.appPath, isInteractive)
       webpack,
     });
     // Load proxy config
-    const proxySetting = require(paths.appPackageJson).proxy;
+    const proxySetting = process.env.PROXY || require(paths.appPackageJson).proxy;
     const proxyConfig = prepareProxy(
       proxySetting,
       paths.appPublic,


### PR DESCRIPTION
Provide a more flexible way to customize `proxy` instead of specifying just a single value in `package.json`.  This change allow overriding PROXY via process.env; giving us the following capability to customize `proxy`:
* command line
```
> PROXY=http://proxy-hostname:port/ npm start
```
* `.env` specific files
```
HOST=http://proxy-hostname:port
```

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
