### PR TITLE
Drop console messages from production build

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -233,6 +233,7 @@ module.exports = function (webpackEnv) {
               ecma: 8,
             },
             compress: {
+              drop_console: true,
               ecma: 5,
               warnings: false,
               // Disabled because of an issue with Uglify breaking seemingly valid code:


### PR DESCRIPTION
console messages (such as `console.log`) should not be included in the production build.

This change has been requested previously: https://github.com/facebook/create-react-app/issues/1491
It's discussed in a number of times on stackoverflow, including at:
https://stackoverflow.com/questions/56276325/how-can-remove-console-log-in-the-production-build-of-a-react-application-create/
https://stackoverflow.com/questions/47839311/removing-log-statements-in-create-react-app-without-ejecting