### PR TITLE
chore: Add runtime option to @babel/preset-react config

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -98,6 +98,7 @@ module.exports = function (api, opts, env) {
           // Will use the native built-in instead of trying to polyfill
           // behavior for any plugins that require one.
           useBuiltIns: true,
+          runtime: 'classic',
         },
       ],
       isTypeScriptEnabled && [require('@babel/preset-typescript').default],


### PR DESCRIPTION
Babel 8 changes the default JSX runtime from `classic` to `automatic`. Since `create-react-app` does not specify the runtime option, the e2e tests fail. See https://github.com/babel/babel/pull/11436 and https://github.com/babel/babel/pull/11436#issuecomment-650371495 for more information.
