### PR TITLE
[Doc] fix React Testing Library example

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -201,12 +201,12 @@ Here's an example of using `react-testing-library` and `jest-dom` for testing th
 
 ```js
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import App from './App';
 
 it('renders welcome message', () => {
-  const { getByText } = render(<App />);
-  expect(getByText('Learn React')).toBeInTheDocument();
+  render(<App />);
+  expect(screen.getByText('Learn React')).toBeInTheDocument();
 });
 ```
 


### PR DESCRIPTION
The React Testing Library has been modified to use the screen api in [v9.4.0](https://github.com/testing-library/react-testing-library/releases/tag/v9.4.0).

I think the documentation should also be changed to the recommended api.