### PR TITLE
Explicitly exclude node_modules/ in ESLint configuration

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -52,6 +52,10 @@ module.exports = {
     },
   },
 
+  ignorePatterns: [
+    "node_modules/"
+  ],
+
   overrides: [
     {
       files: ['**/*.ts?(x)'],


### PR DESCRIPTION
Although ESLint excludes `node_modules/` by default when actually linting, the `overrides` rule for TypeScript *does* scan the dependencies when looking for TypeScript files (using `files: '**/*.ts?(x)'`). That means that, even if the linted code contains no TypeScript at all, the override triggers. An attempt to load `@typescript-eslint/parser` is made, which fails due to TypeScript not being installed.

This PR adds an explicit top-level ignore for `node_modules/`, which appears to prevent this (tested with a vanilla app made using `npx create-react-app@latest`).

Fixes #8745, #8936.