### PR TITLE
Pass server to user provided proxy middleware.

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -108,6 +108,22 @@ module.exports = function(app) {
 };
 ```
 
+Example proxy configuration for target service exposing websocket connections:
+
+```js
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function(app, server) {
+  const proxy = createProxyMiddleware({
+    target: 'http://localhost:5000',
+    changeOrigin: true,
+    ws: true
+  })
+  app.use('/api', proxy);
+  server.on('upgrade', proxy.upgrade);
+};
+```
+
 > **Note:** You do not need to import this file anywhere. It is automatically registered when you start the development server.
 
 > **Note:** This file only supports Node's JavaScript syntax. Be sure to only use supported language features (i.e. no support for Flow, ES Modules, etc).

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -120,7 +120,7 @@ module.exports = function (proxy, allowedHost) {
 
       if (fs.existsSync(paths.proxySetup)) {
         // This registers user provided middleware for proxy reasons
-        require(paths.proxySetup)(app);
+        require(paths.proxySetup)(app, server);
       }
     },
     after(app) {


### PR DESCRIPTION
Currently when using custom proxy with `src/setupProxy.js` there is no way to manually register protocol upgrade for target services providing websocket connections.

This means that if the first request to the proxy happens to be a websocket connection, the request will hang.

This PR adds backward compatible `server` as 2nd parameter to proxy setup provided by the user. This allows to register protocol upgrade handler manually and avoid problems with first proxy request being websocket connection request.

Currently not pretty workarounds are required [1] or:

```js
const http = require('http')
const { createProxyMiddleware } = require('http-proxy-middleware')

module.exports = function (app) {

  app.use(
    '/api',
    createProxyMiddleware({
      target: `http://localhost:${process.env.REACT_APP_MY_BACKEND_PORT}`,
      changeOrigin: true,
      ws: true,
      pathRewrite: {
        '^/api': ''
      }
    })
  )

  // HACK: http-proxy-middleware relies on a initial http request in order to listen to the http upgrade event.
  const retry = () => {
    setTimeout(() => {
      http.get(`http://localhost:${process.env.PORT || 3000}/api/health-or-something-else`, res => {
        const { statusCode } = res
        if (statusCode !== 200) {
          retry()
        }
      })
    }, 1000)
  }
  retry()

}
```

With this patch applied, proxy setup can manually register protocol upgrade handler:

```js
const { createProxyMiddleware } = require('http-proxy-middleware');

module.exports = function(app, server) {
  const proxy = createProxyMiddleware({
    target: 'http://localhost:5000',
    changeOrigin: true,
    ws: true
  })
  app.use('/api', proxy);
  server.on('upgrade', proxy.upgrade);
};
```

[1] https://github.com/chimurai/http-proxy-middleware/issues/432