### PR TITLE
set react-error-overlay iframe ID

### DIFF
--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -137,6 +137,7 @@ function update() {
   // We need to schedule the first render.
   isLoadingIframe = true;
   const loadingIframe = window.document.createElement('iframe');
+  loadingIframe.id = 'react-error-overlay';
   applyStyles(loadingIframe, iframeStyle);
   loadingIframe.onload = function () {
     const iframeDocument = loadingIframe.contentDocument;


### PR DESCRIPTION
This will make it easier to style (`#react-error-overlay { display: none; }`)

Closes #6530

Verified the changes locally:

![image](https://user-images.githubusercontent.com/1500684/88107294-16ecb080-cb64-11ea-8f3b-331f1efd9fd0.png)
