### PR TITLE
update Netlify deployment language

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -424,7 +424,7 @@ npm install netlify-cli -g
 netlify deploy
 ```
 
-Choose `build` as the path to deploy.
+Set `build` as the Publish Directory.
 
 **To setup continuous delivery:**
 


### PR DESCRIPTION
I have updated the Netlify deployment language to be inline with the CLI's prompt. 

Attached is a screenshot showing the CLI deploying a project. Of note here is that the CLI asks for a 'Publish Directory' and not a 'path to deploy' as was previously outlined in the docs. I have updated the docs to reflect this change.

<img width="562" alt="netlifyPR" src="https://user-images.githubusercontent.com/18297826/88487292-c6a19400-cf51-11ea-8178-6576b7e1d296.png">