### PR TITLE
fix: use default modules option from `preset-env`

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -83,8 +83,6 @@ module.exports = function (api, opts, env) {
           useBuiltIns: 'entry',
           // Set the corejs version we are using to avoid warnings in console
           corejs: 3,
-          // Do not transform modules to CJS
-          modules: false,
           // Exclude transforms that make all code slower
           exclude: ['transform-typeof-symbol'],
         },

--- a/packages/babel-preset-react-app/dependencies.js
+++ b/packages/babel-preset-react-app/dependencies.js
@@ -74,8 +74,6 @@ module.exports = function (api, opts) {
           targets: {
             node: 'current',
           },
-          // Do not transform modules to CJS
-          modules: false,
           // Exclude transforms that make all code slower
           exclude: ['transform-typeof-symbol'],
         },
@@ -89,8 +87,6 @@ module.exports = function (api, opts) {
           // Set the corejs version we are using to avoid warnings in console
           // This will need to change once we upgrade to corejs@3
           corejs: 3,
-          // Do not transform modules to CJS
-          modules: false,
           // Exclude transforms that make all code slower
           exclude: ['transform-typeof-symbol'],
         },


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
This PR removes `modules: false` option and resorts to the defaults of `@babel/preset-env`: `{ modules: "auto" }`.

See https://github.com/babel/website/pull/2301 for the differences between `{ modules: "auto" }` and `{ modules: false }`.

Since Babel 7.11 (https://github.com/babel/babel/pull/11849), `{ modules: false }` could result to unwanted behaviour when `export * as ns` is used in test environment on Node 14, where Babel will skip `proposal-export-ns-from` because Node 14 has native `export * as ns` support but Webpack 4 will throw because it does not support `export * as ns`.

When `{ modules: "auto" }` is specified, Babel will determine whether it should be transformed from the caller data passed by `babel-loader`.

This change is not breaking change given that `webpack 4 + babel-loader 8` used in CRA yields same results between `modules: "auto"` and `modules: false`.