### PR TITLE
feat: better refresh plugin integration

### DIFF
--- a/packages/react-dev-utils/refreshOverlayInterop.js
+++ b/packages/react-dev-utils/refreshOverlayInterop.js
@@ -1,0 +1,19 @@
+// @remove-on-eject-begin
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @remove-on-eject-end
+'use strict';
+
+const {
+  dismissRuntimeErrors,
+  reportRuntimeError,
+} = require('react-error-overlay');
+
+module.exports = {
+  clearRuntimeErrors: dismissRuntimeErrors,
+  handleRuntimeError: reportRuntimeError,
+};

--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -51,7 +51,7 @@ export function reportBuildError(error: string) {
 
 export function reportRuntimeError(
   error: Error,
-  options?: RuntimeReportingOption = {}
+  options: RuntimeReportingOptions = {}
 ) {
   currentRuntimeErrorOptions = options;
   crashWithFrames(handleRuntimeError(options))(error);

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -634,7 +634,7 @@ module.exports = function (webpackEnv) {
       // during a production build.
       // Otherwise React will be compiled in the very slow development mode.
       new webpack.DefinePlugin(env.stringified),
-      // This is necessary to emit hot updates (currently CSS only):
+      // This is necessary to emit hot updates (CSS and Fast Refresh):
       isEnvDevelopment && new webpack.HotModuleReplacementPlugin(),
       // Experimental hot reloading for React .
       // https://github.com/facebook/react/tree/master/packages/react-refresh
@@ -643,6 +643,12 @@ module.exports = function (webpackEnv) {
         new ReactRefreshWebpackPlugin({
           overlay: {
             entry: webpackDevClientEntry,
+            // The expected exports are slightly different from what the overlay exports,
+            // so an interop is included here to enable feedback on module-level errors.
+            module: require.resolve('react-dev-utils/refreshOverlayInterop'),
+            // Since we ship a custom dev client and overlay integration,
+            // the bundled socket handling logic can be eliminated.
+            sockIntegration: false,
           },
         }),
       // Watcher doesn't work well if you mistype casing in a path so we use

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -29,7 +29,7 @@
   "types": "./lib/react-app.d.ts",
   "dependencies": {
     "@babel/core": "7.10.5",
-    "@pmmmwh/react-refresh-webpack-plugin": "0.4.0-beta.8",
+    "@pmmmwh/react-refresh-webpack-plugin": "0.4.1",
     "@svgr/webpack": "5.4.0",
     "@typescript-eslint/eslint-plugin": "^3.3.0",
     "@typescript-eslint/parser": "^3.3.0",


### PR DESCRIPTION
I've just released `0.4.x` stable for the fast refresh plugin, and didn't want CRA to release 4.0 depending on a beta version, so I decided to PR the related changes 😺 

### Changes

- Bumped `@pmmmwh/react-refresh-webpack-plugin` from `0.4.0-beta.8` to `0.4.1` (latest stable)
- Added interop to enable the plugin to use `react-error-overlay` instead of the bundled overlay, unifying the error experience for CRA users
  - This is needed because only the plugin will be able to catch module initialization errors (during HMR);
  - I think keeping a cohesive experience throughout the usage of CRA is a good thing;
  - This would save a few kilobytes since the plugin will not inject the bundled stuff ([overlay files](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/main/overlay) and [socket files](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/main/sockets)).
- Fixed a longstanding flow issue in the overlay

### Verification/Testing

1. Create a new CRA project with both the current and this patched version
2. Start the app, make sure it is fully loaded
3. Throw an error during module initialisation in `App.js` (i.e. outside of the `App` function component)

**Before**

![Error overlay before changes](https://user-images.githubusercontent.com/9338255/88649347-5d10b980-d0fa-11ea-82c6-b6dc1a37e72f.png)

**After**

![Error overlay after changes](https://user-images.githubusercontent.com/9338255/88649362-613cd700-d0fa-11ea-9d12-411040e3f616.png)

### Questions

One thing I'm not sure is where to put the overlay interop - I assumed it is OK to put in `react-dev-utils` (since I also see `immer` there), but I'm open to moving it anywhere.

Excited for CRA v4 to ship with fast refresh enabled by default 🥰 !