### PR TITLE
Publish refreshOverlayInterop with react-dev-utils 

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -46,6 +46,7 @@
     "printBuildError.js",
     "printHostingInstructions.js",
     "redirectServedPathMiddleware.js",
+    "refreshOverlayInterop.js",
     "typescriptFormatter.js",
     "WatchMissingNodeModulesPlugin.js",
     "WebpackDevServerUtils.js",


### PR DESCRIPTION
Getting errors when trying out fast refresh with the react-scripts **next** release as refreshOverlayInterop.js was not included with react-dev-utils.
