### PR TITLE
Upgrade whatwg-fetch

### DIFF
--- a/packages/react-app-polyfill/package.json
+++ b/packages/react-app-polyfill/package.json
@@ -26,6 +26,6 @@
     "promise": "^8.0.3",
     "raf": "^3.4.1",
     "regenerator-runtime": "^0.13.3",
-    "whatwg-fetch": "^3.2.0"
+    "whatwg-fetch": "^3.3.1"
   }
 }

--- a/packages/react-app-polyfill/package.json
+++ b/packages/react-app-polyfill/package.json
@@ -26,6 +26,6 @@
     "promise": "^8.0.3",
     "raf": "^3.4.1",
     "regenerator-runtime": "^0.13.3",
-    "whatwg-fetch": "^3.0.0"
+    "whatwg-fetch": "^3.2.0"
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Updates the polyfill for whatwg-fetch to include https://github.com/github/fetch/commit/ff32363d6e136dd4878b7ce28a424e69a415922b which will allow fetch-mock to work in IE11. Prevents the need for a user to have two versions of the polyfill in their in package.lock aswell