### PR TITLE
Documentation fix from create react-app to create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ _`npm init <initializer>` is available in npm 6+_
 ### Yarn
 
 ```sh
-yarn create react-app my-app
+yarn create-react-app my-app
 ```
 
 _[`yarn create <starter-kit-package>`](https://yarnpkg.com/lang/en/docs/cli/create/) is available in Yarn 0.25+_


### PR DESCRIPTION
<!--
The README.md file had instruction as 'yarn create react-app my-app' whereas it should be 'yarn create-react-app my-app'.
![Screenshot from 2020-08-03 07-50-54](https://user-images.githubusercontent.com/56554465/89140152-71234380-d55e-11ea-8927-98c3185d5ff6.png)

-->
