### PR TITLE
Refactored template to ES6+ syntax

### DIFF
--- a/packages/cra-template/template/src/App.js
+++ b/packages/cra-template/template/src/App.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, {Component} from 'react';
 import logo from './logo.svg';
 import './App.css';
 
-function App() {
+class App extends Component {
+  render(){
   return (
     <div className="App">
       <header className="App-header">
@@ -21,6 +22,7 @@ function App() {
       </header>
     </div>
   );
+  }
 }
 
 export default App;


### PR DESCRIPTION


I refactored the code for the default react template from ES5 syntax to ES6 syntax
![Screenshot (73)](https://user-images.githubusercontent.com/48049908/89916222-4afd4380-dbef-11ea-8346-8e794abe912c.png)


