### PR TITLE
Update terser-webpack-plugin version

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -76,7 +76,7 @@
     "sass-loader": "8.0.2",
     "semver": "7.3.2",
     "style-loader": "1.2.1",
-    "terser-webpack-plugin": "4.1.0",
+    "terser-webpack-plugin": "3.1.0",
     "ts-pnp": "1.2.0",
     "url-loader": "4.1.0",
     "webpack": "4.43.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -76,7 +76,7 @@
     "sass-loader": "8.0.2",
     "semver": "7.3.2",
     "style-loader": "1.2.1",
-    "terser-webpack-plugin": "3.0.7",
+    "terser-webpack-plugin": "3.1.0",
     "ts-pnp": "1.2.0",
     "url-loader": "4.1.0",
     "webpack": "4.43.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -76,7 +76,7 @@
     "sass-loader": "8.0.2",
     "semver": "7.3.2",
     "style-loader": "1.2.1",
-    "terser-webpack-plugin": "3.1.0",
+    "terser-webpack-plugin": "4.1.0",
     "ts-pnp": "1.2.0",
     "url-loader": "4.1.0",
     "webpack": "4.43.0",


### PR DESCRIPTION
Older versions of terser-webpack-plugin are using a highly vulnerable version of serialize-javascript. In order to fix this, we need to update the terser-webpack-plugin which has now addressed this vulnerability.

More info on the vulnerability [located here](https://www.npmjs.com/advisories/1548)

### Screenshot:

![Vulnerability](https://user-images.githubusercontent.com/12701185/89943722-a7ab2f00-dbec-11ea-95f2-3a078964ee9a.png)

