### PR TITLE
docs: add missing override options for Jest config

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -272,12 +272,13 @@ Note that tests run much slower with coverage so it is recommended to run it sep
 
 ### Configuration
 
-The default Jest coverage configuration can be overridden by adding any of the following supported keys to a Jest config in your package.json.
+The [default configuration](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/scripts/utils/createJestConfig.js) that Create React App uses for Jest can be overridden by adding any of the following supported keys to a Jest config in your package.json.
 
 Supported overrides:
 
 - [`clearMocks`](https://jestjs.io/docs/en/configuration.html#clearmocks-boolean)
 - [`collectCoverageFrom`](https://jestjs.io/docs/en/configuration.html#collectcoveragefrom-array)
+- [`coveragePathIgnorePatterns`](https://jestjs.io/docs/en/configuration#coveragepathignorepatterns-arraystring)
 - [`coverageReporters`](https://jestjs.io/docs/en/configuration.html#coveragereporters-array-string)
 - [`coverageThreshold`](https://jestjs.io/docs/en/configuration.html#coveragethreshold-object)
 - [`displayName`](https://jestjs.io/docs/en/configuration.html#displayname-string-object)
@@ -287,7 +288,9 @@ Supported overrides:
 - [`moduleNameMapper`](https://jestjs.io/docs/en/configuration.html#modulenamemapper-object-string-string)
 - [`resetMocks`](https://jestjs.io/docs/en/configuration.html#resetmocks-boolean)
 - [`resetModules`](https://jestjs.io/docs/en/configuration.html#resetmodules-boolean)
+- [`restoreMocks`](https://jestjs.io/docs/en/configuration#restoremocks-boolean)
 - [`snapshotSerializers`](https://jestjs.io/docs/en/configuration.html#snapshotserializers-array-string)
+- [`testMatch`](https://jestjs.io/docs/en/configuration#testmatch-arraystring)
 - [`transform`](https://jestjs.io/docs/en/configuration.html#transform-object-string-pathtotransformer-pathtotransformer-object)
 - [`transformIgnorePatterns`](https://jestjs.io/docs/en/configuration.html#transformignorepatterns-array-string)
 - [`watchPathIgnorePatterns`](https://jestjs.io/docs/en/configuration.html#watchpathignorepatterns-array-string)


### PR DESCRIPTION
Hi 👋

I've noticed that the [documentation for overriding CRA's default Jest configuration](https://create-react-app.dev/docs/running-tests/#configuration) has gone out of sync with the actual implementation:
https://github.com/facebook/create-react-app/blob/5e703a568a687dacdc45f1211355ce4b1b586625/packages/react-scripts/scripts/utils/createJestConfig.js#L75-L94

This PR fixes that!