### PR TITLE
Set tsconfig include as per TS docs

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -227,9 +227,9 @@ function verifyTypeScriptSetup() {
 
   // tsconfig will have the merged "include" and "exclude" by this point
   if (parsedTsConfig.include == null) {
-    appTsConfig.include = ['src'];
+    appTsConfig.include = ['src/**/*'];
     messages.push(
-      `${chalk.cyan('include')} should be ${chalk.cyan.bold('src')}`
+      `${chalk.cyan('include')} should be ${chalk.cyan.bold('src/**/*')}`
     );
   }
 


### PR DESCRIPTION
The [typescipt docs for `include`](https://www.typescriptlang.org/tsconfig#include) suggest we should use a glob pattern `src/**/*` instead of `src`.

This appears to resolve the problem [described here](https://greatrexpectations.com/2020/08/13/vscode-auto-typescript-import) where imports in VSCode are not available automatically for newly-created files:

1. Add new file
2. Type const `MyComponent: FC`. Get a prompt to import `FC` from `react`. Do it.
3. Add the rest of the line: `const MyComponent: FC = () => <ExistingComponent />`
4. No auto import for `ExistingComponent` 😢
5. Manually add the import
6. Now future auto imports work fine