### PR TITLE
Bump major versions of ESLint config's README

### DIFF
--- a/packages/eslint-config-react-app/README.md
+++ b/packages/eslint-config-react-app/README.md
@@ -19,7 +19,7 @@ If you want to use this ESLint configuration in a project not built with Create 
 First, install this package, ESLint and the necessary plugins.
 
 ```sh
-npm install --save-dev eslint-config-react-app @typescript-eslint/eslint-plugin@3.x @typescript-eslint/parser@3.x babel-eslint@10.x eslint@7.x eslint-plugin-flowtype@5.2.0 eslint-plugin-import@2.22.0 eslint-plugin-jsx-a11y@6.3.1 eslint-plugin-react@7.20.3 eslint-plugin-react-hooks@4.0.8
+npm install --save-dev eslint-config-react-app @typescript-eslint/eslint-plugin@^3.0.0 @typescript-eslint/parser@^3.0.0 babel-eslint@^10.0.0 eslint@^7.0.0 eslint-plugin-flowtype@^5.2.0 eslint-plugin-import@^2.22.0 eslint-plugin-jsx-a11y@^6.3.1 eslint-plugin-react@^7.20.3 eslint-plugin-react-hooks@^4.0.8
 ```
 
 Then create a file named `.eslintrc.json` with following contents in the root folder of your project:

--- a/packages/eslint-config-react-app/README.md
+++ b/packages/eslint-config-react-app/README.md
@@ -19,7 +19,7 @@ If you want to use this ESLint configuration in a project not built with Create 
 First, install this package, ESLint and the necessary plugins.
 
 ```sh
-npm install --save-dev eslint-config-react-app @typescript-eslint/eslint-plugin@2.x @typescript-eslint/parser@2.x babel-eslint@10.x eslint@6.x eslint-plugin-flowtype@4.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-react@7.x eslint-plugin-react-hooks@2.x
+npm install --save-dev eslint-config-react-app @typescript-eslint/eslint-plugin@3.x @typescript-eslint/parser@3.x babel-eslint@10.x eslint@7.x eslint-plugin-flowtype@5.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-react@7.x eslint-plugin-react-hooks@4.x
 ```
 
 Then create a file named `.eslintrc.json` with following contents in the root folder of your project:

--- a/packages/eslint-config-react-app/README.md
+++ b/packages/eslint-config-react-app/README.md
@@ -19,7 +19,7 @@ If you want to use this ESLint configuration in a project not built with Create 
 First, install this package, ESLint and the necessary plugins.
 
 ```sh
-npm install --save-dev eslint-config-react-app @typescript-eslint/eslint-plugin@3.x @typescript-eslint/parser@3.x babel-eslint@10.x eslint@7.x eslint-plugin-flowtype@5.x eslint-plugin-import@2.x eslint-plugin-jsx-a11y@6.x eslint-plugin-react@7.x eslint-plugin-react-hooks@4.x
+npm install --save-dev eslint-config-react-app @typescript-eslint/eslint-plugin@3.x @typescript-eslint/parser@3.x babel-eslint@10.x eslint@7.x eslint-plugin-flowtype@5.2.0 eslint-plugin-import@2.22.0 eslint-plugin-jsx-a11y@6.3.1 eslint-plugin-react@7.20.3 eslint-plugin-react-hooks@4.0.8
 ```
 
 Then create a file named `.eslintrc.json` with following contents in the root folder of your project:


### PR DESCRIPTION
The installation steps from the README of `eslint-config-react-app` did not get updated [after bumping the major versions](https://github.com/facebook/create-react-app/pull/9307) in the [`package.json`](https://github.com/facebook/create-react-app/blob/master/packages/eslint-config-react-app/package.json), this PR fixes that.

![image](https://user-images.githubusercontent.com/29319414/90423867-8602e980-e0bd-11ea-921e-3d212c45b518.png)
