### PR TITLE
Update links to Flow and Typescript

### DIFF
--- a/docusaurus/docs/supported-browsers-features.md
+++ b/docusaurus/docs/supported-browsers-features.md
@@ -17,7 +17,7 @@ This project supports a superset of the latest JavaScript standard. In addition 
 - [Object Rest/Spread Properties](https://github.com/tc39/proposal-object-rest-spread) (ES2018).
 - [Dynamic import()](https://github.com/tc39/proposal-dynamic-import) (stage 4 proposal)
 - [Class Fields and Static Properties](https://github.com/tc39/proposal-class-public-fields) (part of stage 3 proposal).
-- [JSX](https://facebook.github.io/react/docs/introducing-jsx.html), [Flow](./adding-flow) and [TypeScript](./adding-typescript).
+- [JSX](https://facebook.github.io/react/docs/introducing-jsx.html), [Flow](./adding-flow.md) and [TypeScript](./adding-typescript.md).
 
 Learn more about [different proposal stages](https://tc39.github.io/process-document/).
 


### PR DESCRIPTION
The links to flow and typescript were not working, probably because the linked files missed '.md' in the link. 
This commit fixes the issue by adding '.md' at the end of the file names.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
