### PR TITLE
Fixed typo in the directory tree section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ my-app
     ├── index.css
     ├── index.js
     ├── logo.svg
-    └── serviceWorker.js
+    ├── serviceWorker.js
     └── setupTests.js
 ```
 


### PR DESCRIPTION
Fixed a typo in the directory tree section of README.