### PR TITLE
[add] adjust webpack config feature

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -165,7 +165,7 @@ module.exports = function (webpackEnv) {
     return loaders;
   };
 
-  return {
+  const config = {
     mode: isEnvProduction ? 'production' : isEnvDevelopment && 'development',
     // Stop compilation early in production
     bail: isEnvProduction,
@@ -790,4 +790,12 @@ module.exports = function (webpackEnv) {
     // our own hints via the FileSizeReporter
     performance: false,
   };
+
+  if (appPackageJson.adjustWebpackConfig) {
+    const adjustWebpackConfigPath = path.join(path.dirname(paths.appPackageJson), appPackageJson.adjustWebpackConfig)
+    const adjustWebpackConfig = require(adjustWebpackConfigPath);
+    return adjustWebpackConfig(config);
+  }
+
+  return config;
 };


### PR DESCRIPTION
For testing, I've installed react-scripts and react-dev-utils from my local copy of the code.

This change is adding a small feature which will let users to not eject from react-scripts for just a tiny webpack modification. In my case, I needed to change the `config.target` only and I didn't want to get rid of react-scripts for that.

I hope we can discuss the way you want this and we can have it in the next release :)