### PR TITLE
Remove isExtendingEslintConfig variable on eject

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -51,7 +51,9 @@ const webpackDevClientEntry = require.resolve(
 // makes for a smoother build process.
 const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
 
+// @remove-on-eject-begin
 const isExtendingEslintConfig = process.env.EXTEND_ESLINT === 'true';
+// @remove-on-eject-end
 
 const imageInlineSizeLimit = parseInt(
   process.env.IMAGE_INLINE_SIZE_LIMIT || '10000'


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

The part of webpack config that use `isExtendingEslintConfig` will be removed on eject, the variable itself hasn't been removed yet. This PR makes the variable to be removed on eject as well.

The code block that use this variable:
```js
// @remove-on-eject-begin
ignore: isExtendingEslintConfig,
baseConfig: isExtendingEslintConfig
  ? undefined
  : {
      extends: [require.resolve('eslint-config-react-app')],
    },
useEslintrc: isExtendingEslintConfig,
// @remove-on-eject-end
```
