### PR TITLE
Improve vendor chunk names in development

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -305,7 +305,7 @@ module.exports = function (webpackEnv) {
       // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
       splitChunks: {
         chunks: 'all',
-        name: false,
+        name: isEnvDevelopment,
       },
       // Keep the runtime chunk separated to enable long term caching
       // https://twitter.com/wSokra/status/969679223278505985


### PR DESCRIPTION
Out of the box today, CRA produces [numbered vendor chunks](https://create-react-app.dev/docs/production-build). They look like this in production:

```
File sizes after gzip:

  146.17 KB       build/static/js/7.f5a20c19.chunk.js
  39.39 KB        build/static/js/8.5cf7927d.chunk.js
```

And like this in development:

![image](https://user-images.githubusercontent.com/164652/91651355-cbc69700-ea59-11ea-8aef-c9d83dbe4f24.png)

This is a good default for production, following [webpack's guidance](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunksname) (`splitChunks.name: false`) to create stable, cacheable names.

In development, though, when I'm trying to understand exactly what code is delivered when, I'd like to know more about what goes in to those chunks.

This PR sets `splitChunks.name` to `true` in development, producing vendor chunk names like this:

![image](https://user-images.githubusercontent.com/164652/91651384-1ba55e00-ea5a-11ea-82da-20f1e1b5041c.png)

Is this something others would be interested in?

Related issues:
https://github.com/facebook/create-react-app/issues/4769
https://github.com/facebook/create-react-app/issues/6155
https://github.com/facebook/create-react-app/issues/6240