### PR TITLE
docs: several changes/fixes related to code blocks with yarn/npm/npx commands

### DIFF
--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -41,7 +41,6 @@ This will allow you to do imports like
 To use imports relative to a path you specify, and from `node_modules` without adding the `~` prefix, you can add a [`.env` file](https://github.com/facebook/create-react-app/blob/master/docusaurus/docs/adding-custom-environment-variables.md#adding-development-environment-variables-in-env) at the project root with the variable `SASS_PATH=node_modules:src`. To specify more directories you can add them to `SASS_PATH` separated by a `:` like `path1:path2:path3`.
 
 If you set `SASS_PATH=node_modules:src`, this will allow you to do imports like
-
 ```scss
 @import 'styles/colors'; // assuming a styles directory under src/, where _colors.scss partial file exists.
 @import 'nprogress/nprogress'; // importing a css file from the nprogress node module

--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -13,13 +13,13 @@ Following this rule often makes CSS preprocessors less useful, as features like 
 To use Sass, first install `node-sass` using `npm`:
 
 ```sh
-$ npm install node-sass --save
+npm install node-sass --save
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-$ yarn add node-sass
+yarn add node-sass
 ```
 
 Now you can rename `src/App.css` to `src/App.scss` and update `src/App.js` to import `src/App.scss`.

--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -10,11 +10,15 @@ Generally, we recommend that you don’t reuse the same CSS classes across diffe
 
 Following this rule often makes CSS preprocessors less useful, as features like mixins and nesting are replaced by component composition. You can, however, integrate a CSS preprocessor if you find it valuable.
 
-To use Sass, first install `node-sass`:
+To use Sass, first install `node-sass` using `npm`:
 
 ```sh
 $ npm install node-sass --save
-$ # or
+```
+
+Alternatively you may use `yarn`:
+
+```sh
 $ yarn add node-sass
 ```
 
@@ -37,6 +41,7 @@ This will allow you to do imports like
 To use imports relative to a path you specify, and from `node_modules` without adding the `~` prefix, you can add a [`.env` file](https://github.com/facebook/create-react-app/blob/master/docusaurus/docs/adding-custom-environment-variables.md#adding-development-environment-variables-in-env) at the project root with the variable `SASS_PATH=node_modules:src`. To specify more directories you can add them to `SASS_PATH` separated by a `:` like `path1:path2:path3`.
 
 If you set `SASS_PATH=node_modules:src`, this will allow you to do imports like
+
 ```scss
 @import 'styles/colors'; // assuming a styles directory under src/, where _colors.scss partial file exists.
 @import 'nprogress/nprogress'; // importing a css file from the nprogress node module

--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -9,13 +9,15 @@ title: Adding TypeScript
 
 ## Installation
 
-To start a new Create React App project with [TypeScript](https://www.typescriptlang.org/), you can run:
+To start a new Create React App project with [TypeScript](https://www.typescriptlang.org/), you can run using `npx`:
 
 ```sh
 npx create-react-app my-app --template typescript
+```
 
-# or
+Alternatively you may use `yarn`:
 
+```sh
 yarn create react-app my-app --template typescript
 ```
 
@@ -23,13 +25,15 @@ yarn create react-app my-app --template typescript
 >
 > Global installs of `create-react-app` are no longer supported.
 
-To add [TypeScript](https://www.typescriptlang.org/) to an existing Create React App project, first install it:
+To add [TypeScript](https://www.typescriptlang.org/) to an existing Create React App project, first install it using `npm`:
 
 ```sh
 npm install --save typescript @types/node @types/react @types/react-dom @types/jest
+```
 
-# or
+Alternatively you may use `yarn`:
 
+```sh
 yarn add typescript @types/node @types/react @types/react-dom @types/jest
 ```
 

--- a/docusaurus/docs/analyzing-the-bundle-size.md
+++ b/docusaurus/docs/analyzing-the-bundle-size.md
@@ -33,7 +33,16 @@ Then in `package.json`, add the following line to `scripts`:
 Then to analyze the bundle run the production build then run the analyze
 script.
 
+Using `npm`:
+
 ```sh
 npm run build
 npm run analyze
+```
+
+Alternatively you may use `yarn`:
+
+```sh
+npm build
+npm analyze
 ```

--- a/docusaurus/docs/debugging-tests.md
+++ b/docusaurus/docs/debugging-tests.md
@@ -18,10 +18,16 @@ Add the following to the `scripts` section in your project's `package.json`
   }
 ```
 
-Place `debugger;` statements in any test and run:
+Place `debugger;` statements in any test and run using `npm`:
 
 ```sh
 npm run test:debug
+```
+
+Alternatively you may use `yarn`:
+
+```sh
+yarn test:debug
 ```
 
 This will start running your Jest tests, but pause before executing to allow a debugger to attach to the process.

--- a/docusaurus/docs/debugging-tests.md
+++ b/docusaurus/docs/debugging-tests.md
@@ -21,7 +21,7 @@ Add the following to the `scripts` section in your project's `package.json`
 Place `debugger;` statements in any test and run:
 
 ```sh
-$ npm run test:debug
+npm run test:debug
 ```
 
 This will start running your Jest tests, but pause before executing to allow a debugger to attach to the process.

--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -141,10 +141,12 @@ For example, to create a build environment for a staging environment:
 
 1. Create a file called `.env.staging`
 1. Set environment variables as you would any other `.env` file (e.g. `REACT_APP_API_URL=http://api-staging.example.com`)
-1. Install [env-cmd](https://www.npmjs.com/package/env-cmd)
+1. Install [env-cmd](https://www.npmjs.com/package/env-cmd) using `npm`
    ```sh
    $ npm install env-cmd --save
-   $ # or
+   ```
+   Alternatively you may use `yarn`:
+   ```sh
    $ yarn add env-cmd
    ```
 1. Add a new script to your `package.json`, building with your new environment:

--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -143,11 +143,11 @@ For example, to create a build environment for a staging environment:
 1. Set environment variables as you would any other `.env` file (e.g. `REACT_APP_API_URL=http://api-staging.example.com`)
 1. Install [env-cmd](https://www.npmjs.com/package/env-cmd) using `npm`
    ```sh
-   $ npm install env-cmd --save
+   npm install env-cmd --save
    ```
    Alternatively you may use `yarn`:
    ```sh
-   $ yarn add env-cmd
+   yarn add env-cmd
    ```
 1. Add a new script to your `package.json`, building with your new environment:
    ```json

--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -74,11 +74,15 @@ If the `proxy` option is **not** flexible enough for you, you can get direct acc
 
 You can use this feature in conjunction with the `proxy` property in `package.json`, but it is recommended you consolidate all of your logic into `src/setupProxy.js`.
 
-First, install `http-proxy-middleware` using npm or Yarn:
+First, install `http-proxy-middleware` using `npm`:
 
 ```sh
 $ npm install http-proxy-middleware --save
-$ # or
+```
+
+Alternatively you may use `yarn`:
+
+```sh
 $ yarn add http-proxy-middleware
 ```
 
@@ -87,7 +91,7 @@ Next, create `src/setupProxy.js` and place the following contents in it:
 ```js
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-module.exports = function(app) {
+module.exports = function (app) {
   // ...
 };
 ```
@@ -97,7 +101,7 @@ You can now register proxies as you wish! Here's an example using the above `htt
 ```js
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-module.exports = function(app) {
+module.exports = function (app) {
   app.use(
     '/api',
     createProxyMiddleware({

--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -91,7 +91,7 @@ Next, create `src/setupProxy.js` and place the following contents in it:
 ```js
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-module.exports = function (app) {
+module.exports = function(app) {
   // ...
 };
 ```
@@ -101,7 +101,7 @@ You can now register proxies as you wish! Here's an example using the above `htt
 ```js
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
-module.exports = function (app) {
+module.exports = function(app) {
   app.use(
     '/api',
     createProxyMiddleware({

--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -77,13 +77,13 @@ You can use this feature in conjunction with the `proxy` property in `package.js
 First, install `http-proxy-middleware` using `npm`:
 
 ```sh
-$ npm install http-proxy-middleware --save
+npm install http-proxy-middleware --save
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-$ yarn add http-proxy-middleware
+yarn add http-proxy-middleware
 ```
 
 Next, create `src/setupProxy.js` and place the following contents in it:

--- a/packages/cra-template-typescript/README.md
+++ b/packages/cra-template-typescript/README.md
@@ -4,13 +4,15 @@ This is the official TypeScript template for [Create React App](https://github.c
 
 To use this template, add `--template typescript` when creating a new app.
 
-For example:
+For example, using `npx`:
 
 ```sh
 npx create-react-app my-app --template typescript
+```
 
-# or
+Alternatively you may use `yarn`:
 
+```sh
 yarn create react-app my-app --template typescript
 ```
 


### PR DESCRIPTION
The changes and the reasoning behind them:
* Seperate yarn and npm/npx code blocks.
    * To allow easier copying using the copy button in the code blocks.
        Previously if you copied using the button, it would copy both yarn and npm/npx commands.
        After this change it will copy only one of them.
* Add yarn as alternative where missing.
* Remove leading $ sign from commands.
    * When copying, this actually prevents you from running the command without deleting the $ by yourself.

The common reasoning behind all of the changes I made, is to be consistent with the rest of the docs.

NOTE: Most of the changes were made to the docs, and one change was made to cra-template-typescript/README.md for consistency.