### PR TITLE
SVGs as ReactComponent must follow PascalCasing

### DIFF
--- a/docusaurus/docs/adding-images-fonts-and-files.md
+++ b/docusaurus/docs/adding-images-fonts-and-files.md
@@ -62,6 +62,6 @@ function App() {
 }
 ```
 
-This is handy if you don't want to load SVG as a separate file. Don't forget the curly braces in the import! The `ReactComponent` import name is significant and tells Create React App that you want a React component that renders an SVG, rather than its filename.
+This is handy if you don't want to load SVG as a separate file. Don't forget the curly braces in the import! The `ReactComponent` import name is significant and tells Create React App that you want a React component that renders an SVG, rather than its filename. Ensure PascalCasing of the component name (`Logo` in the above example).
 
 > **Tip:** The imported SVG React Component accepts a `title` prop along with other props that a `svg` element accepts. Use this prop to add an accessible title to your svg component.


### PR DESCRIPTION
While you can import an SVG as `import { ReactComponent as someRandomName} from './logo.svg';`, it is worth noting that in order to use `someRandomName` , we will have to PascalCase this component (say be creating a new reference as `const SomePascalCasedName = someRandomName;`).
In summary, we have to ensure "PascalCasing" of the reference.

This change request just adds in that little piece of information.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
