### PR TITLE
Fix indentation in react-app.d.ts

### DIFF
--- a/packages/react-scripts/lib/react-app.d.ts
+++ b/packages/react-scripts/lib/react-app.d.ts
@@ -35,8 +35,8 @@ declare module '*.png' {
 }
 
 declare module '*.webp' {
-    const src: string;
-    export default src;
+  const src: string;
+  export default src;
 }
 
 declare module '*.svg' {


### PR DESCRIPTION
Only the `*.webp` module in react-app.d.ts was indented with 4 spaces, everything else is 2 spaces. Introduced in #5978.