### PR TITLE
Allow specifying Dart Sass implementation

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -53,6 +53,8 @@ const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
 
 const isExtendingEslintConfig = process.env.EXTEND_ESLINT === 'true';
 
+const shouldUseDartSass = process.env.USE_DART_SASS === 'true';
+
 const imageInlineSizeLimit = parseInt(
   process.env.IMAGE_INLINE_SIZE_LIMIT || '10000'
 );
@@ -143,6 +145,7 @@ module.exports = function (webpackEnv) {
           loader: require.resolve(preProcessor),
           options: {
             sourceMap: true,
+            ...(shouldUseDartSass ? { implementation: require('sass') } : {}),
           },
         }
       );


### PR DESCRIPTION
### Description
For cases where you're not able to completely remove `node-sass`, causing `sass-loader` to pick it up, you can now explicitly specify you want to use Dart Sass through `USE_DART_SASS=true` env variable.

### Testing strategy

Manually tested it by doing the following

1. Created a new app with `yarn create-react-app my-app`
2. Added a few sass files with `@use` directive (only supported by Dart Sass)
3. Added `sass` dependnecy
4. Ran `yarn start`. **Comiplation succeeded**
5. Added `node-sass` dependency (we now have both)
6. Ran `yarn start`. **Compilation failed**
7. Ran `USE_DART_SASS=true yarn start`. **Comiplation succeeded**

Missing:
 - [ ] Find a way to automate a test similar to the one described above