### PR TITLE
Syntax update for including `style-loader`

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -91,7 +91,9 @@ module.exports = function (webpackEnv) {
   // common function to get style loaders
   const getStyleLoaders = (cssOptions, preProcessor) => {
     const loaders = [
-      isEnvDevelopment && require.resolve('style-loader'),
+      isEnvDevelopment && {
+        loader: require.resolve('style-loader'),
+      },
       isEnvProduction && {
         loader: MiniCssExtractPlugin.loader,
         // css is located in `static/css`, use '../../' to locate index.html folder


### PR DESCRIPTION
Cleaned up PR (original reference #9076, stale PR #9100 )

-------------------------------------------------

This simple syntax change will allow for other CRA extension utilities (like customize-cra) to add options to the ['style-loader](https://webpack.js.org/loaders/style-loader/)'. Specifically the "insert" prop (fka "insertInto") can be quite useful.

E.g. https://github.com/arackaf/customize-cra/blob/master/api.md#adjuststyleloaderscallback

It's possible that preventing overrides to the 'style-loader' configuration was intentional as a way to prevent downstream webpack/hot-update bugs, but I haven't run into any when running this update in an ejected create-react-app. So would appreciate any veteran thoughts on whether this is safe to update.