### PR TITLE
Add postcss to package.json to prevent faulty upgrade

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -64,6 +64,7 @@
     "mini-css-extract-plugin": "0.11.2",
     "optimize-css-assets-webpack-plugin": "5.0.4",
     "pnp-webpack-plugin": "1.6.4",
+    "postcss": "7.0.32",
     "postcss-flexbugs-fixes": "4.2.1",
     "postcss-loader": "3.0.0",
     "postcss-normalize": "8.0.1",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Added postcss version number as the upstream postcss deps have wildcard versioning, causing a failure in cra/react-scripts as per #9655. The fix was originally from #9658 , so I am reopening this pull request.