### PR TITLE
fix: resolve ESLint config from appPath

### DIFF
--- a/packages/eslint-config-react-app/base.js
+++ b/packages/eslint-config-react-app/base.js
@@ -43,5 +43,6 @@ module.exports = {
   rules: {
     'react/jsx-uses-react': 'warn',
     'react/jsx-uses-vars': 'warn',
+    'react/react-in-jsx-scope': 'error',
   },
 };

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -253,7 +253,6 @@ module.exports = {
     'react/no-direct-mutation-state': 'warn',
     'react/no-is-mounted': 'warn',
     'react/no-typos': 'error',
-    'react/react-in-jsx-scope': 'error',
     'react/require-render-return': 'error',
     'react/style-prop-object': 'warn',
 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -361,6 +361,7 @@ module.exports = function (webpackEnv) {
             {
               options: {
                 cache: true,
+                cwd: paths.appPath,
                 formatter: require.resolve('react-dev-utils/eslintFormatter'),
                 eslintPath: require.resolve('eslint'),
                 resolvePluginsRelativeTo: __dirname,


### PR DESCRIPTION
This resolves an issue where the ESLint config is not resolved from the project root correctly.

It also moves a rule to the new `base` config, to prevent potential user errors.