### PR TITLE
Fix broken links

### DIFF
--- a/packages/react-dev-utils/FileSizeReporter.js
+++ b/packages/react-dev-utils/FileSizeReporter.js
@@ -92,12 +92,12 @@ function printFileSizesAfterBuild(
     );
     console.log(
       chalk.yellow(
-        'Consider reducing it with code splitting: https://goo.gl/9VhYWB'
+        'Consider reducing it with code splitting: https://create-react-app.dev/docs/code-splitting/'
       )
     );
     console.log(
       chalk.yellow(
-        'You can also analyze the project dependencies: https://goo.gl/LeUzfb'
+        'You can also analyze the project dependencies: https://create-react-app.dev/docs/analyzing-the-bundle-size/'
       )
     );
   }


### PR DESCRIPTION
The shortened google links for code splitting and bundle size analysis are no longer working. 

They now take you to an empty page that redirects you to another page with many links, so you have to read and click to yet another page to get to the docs you need. This is a pain and doesn't seem in the spirit of CRA.

The actual links aren't actually much shorter than the shortened ones, so let's just link to the actual documentation and safe everyone some time.

Related: https://github.com/facebook/create-react-app/issues/8188

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
