### PR TITLE
feat(private git templates): addresses #8166 and builds on #8167

### DIFF
--- a/packages/create-react-app/__tests__/getTemplateInstallPackage.test.js
+++ b/packages/create-react-app/__tests__/getTemplateInstallPackage.test.js
@@ -21,9 +21,9 @@ describe('getTemplateInstallPackage', () => {
   });
 
   it('cra-template-typescript gives cra-template-typescript', async () => {
-    await expect(getTemplateInstallPackage('cra-template-typescript')).resolves.toBe(
-      'cra-template-typescript'
-    );
+    await expect(
+      getTemplateInstallPackage('cra-template-typescript')
+    ).resolves.toBe('cra-template-typescript');
   });
 
   it('typescript gives cra-template-typescript', async () => {
@@ -33,9 +33,9 @@ describe('getTemplateInstallPackage', () => {
   });
 
   it('typescript@next gives cra-template-typescript@next', async () => {
-    await expect(getTemplateInstallPackage('cra-template-typescript@next')).resolves.toBe(
-      'cra-template-typescript@next'
-    );
+    await expect(
+      getTemplateInstallPackage('cra-template-typescript@next')
+    ).resolves.toBe('cra-template-typescript@next');
   });
 
   it('cra-template@next gives cra-template@next', async () => {
@@ -45,9 +45,9 @@ describe('getTemplateInstallPackage', () => {
   });
 
   it('cra-template-typescript@next gives cra-template-typescript@next', async () => {
-    await expect(getTemplateInstallPackage('cra-template-typescript@next')).resolves.toBe(
-      'cra-template-typescript@next'
-    );
+    await expect(
+      getTemplateInstallPackage('cra-template-typescript@next')
+    ).resolves.toBe('cra-template-typescript@next');
   });
 
   it('@iansu gives @iansu/cra-template', async () => {
@@ -69,14 +69,20 @@ describe('getTemplateInstallPackage', () => {
   });
 
   it('@iansu/cra-template-typescript@next gives @iansu/cra-template-typescript@next', async () => {
-    await expect(getTemplateInstallPackage('@iansu/cra-template-typescript@next')).resolves.toBe(
-      '@iansu/cra-template-typescript@next'
-    );
+    await expect(
+      getTemplateInstallPackage('@iansu/cra-template-typescript@next')
+    ).resolves.toBe('@iansu/cra-template-typescript@next');
   });
 
   it('http://example.com/cra-template.tar.gz gives http://example.com/cra-template.tar.gz', async () => {
     await expect(
       getTemplateInstallPackage('http://example.com/cra-template.tar.gz')
     ).resolves.toBe('http://example.com/cra-template.tar.gz');
+  });
+
+  it('iansu/repo gives iansu/cra-template-repo (for installing from private github repos)', async () => {
+    await expect(getTemplateInstallPackage('iansu/repo')).resolves.toBe(
+      'iansu/cra-template-repo'
+    );
   });
 });

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -641,7 +641,7 @@ function getTemplateInstallPackage(template, originalDirectory) {
     } else {
       // Add prefix 'cra-template-' to non-prefixed templates, leaving any
       // @scope/ and @version intact.
-      const packageMatch = template.match(/^(@[^/]+\/)?([^@]+)?(@.+)?$/);
+      const packageMatch = template.match(/^(@?[^/]+\/)?([^@]+)?(@.+)?$/);
       const scope = packageMatch[1] || '';
       const templateName = packageMatch[2] || '';
       const version = packageMatch[3] || '';

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -113,6 +113,10 @@ module.exports = function (
     return;
   }
 
+  if (!templateName.startsWith('@') && templateName.includes('/')) {
+    templateName = templateName.slice(templateName.indexOf('/') + 1);
+  }
+
   const templatePath = path.dirname(
     require.resolve(`${templateName}/package.json`, { paths: [appPath] })
   );


### PR DESCRIPTION
- Attempting to address #8166 and building on the feedback provided in #8167.
- Added a test to show that the `getTemplateInstallPackage` actually returns what is expected.
- Getting some errors when actually trying to install a private package from github, however, and could use some guidance on how best to troubleshoot:

```
Require stack:
- /Users/jasonhodges/Documents/apps-tools/testCRA/test-cra2/node_modules/react-scripts/scripts/init.js
- /Users/jasonhodges/Documents/apps-tools/testCRA/test-cra2/[eval]
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:965:15)
    at Function.resolve (internal/modules/cjs/helpers.js:78:19)
    at module.exports (/Users/jasonhodges/Documents/apps-tools/testCRA/test-cra2/node_modules/react-scripts/scripts/init.js:110:13)
    at [eval]:3:14
    at Script.runInThisContext (vm.js:120:18)
    at Object.runInThisContext (vm.js:309:38)
    at Object.<anonymous> ([eval]-wrapper:10:26)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at evalScript (internal/process/execution.js:94:25)
    at internal/main/eval_string.js:23:3 {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/jasonhodges/Documents/apps-tools/testCRA/test-cra2/node_modules/react-scripts/scripts/init.js',
    '/Users/jasonhodges/Documents/apps-tools/testCRA/test-cra2/[eval]'
  ]
}
```

It's worth noting that I also tried pointing create-react-app at a tarball template as one of the unit test suggests, which could be an alternative solution to #8166, but that yielded an error of "A template was not provided." So I'm not sure if this is all behaving as intended.