### PR TITLE
#9739 Set proxy setting from environment variables, falling back to p…

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -126,7 +126,7 @@ checkBrowsers(paths.appPath, isInteractive)
       webpack,
     });
     // Load proxy config
-    const proxySetting = require(paths.appPackageJson).proxy;
+    const proxySetting = process.env.PROXY || require(paths.appPackageJson).proxy;
     const proxyConfig = prepareProxy(
       proxySetting,
       paths.appPublic,


### PR DESCRIPTION
Implements #9739 allowing the proxy target to be set using environment variables and falling back to package.json if none exists.

Tested by running a project with the change applied.
1. Ran with no proxy environment variable, but with proxy in package.json. Result: Used proxy from package.json
2. Ran with proxy environment variable and package.json. Result: Used proxy from environment variable
3. Ran with proxy environment variable and none in package.json. Result: Used proxy from environment variable
