### PR TITLE
Add `.d.ts` to Jest's moduleFileExtensions

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -41,6 +41,7 @@ const moduleFileExtensions = [
   'json',
   'web.jsx',
   'jsx',
+  'd.ts',
 ];
 
 // Resolve file paths in the same order as webpack


### PR DESCRIPTION
Without it test fails when you try to import `.d.ts` modules using shorten form (eg. `import {TODO_ANY} from 'src/react-app-env';`)

Reproduction:

1. Create basic TypeScript CRA app
2. Add `import './react-app-env'` to `src/App.tsx`.
3. `npm run test`

**Error:**
```
> react-ts-app@0.1.0 test /react-ts-app
> react-scripts test
 FAIL  src/App.test.tsx
  ● Test suite failed to run

    Cannot find module './react-app-env' from 'App.tsx'

    However, Jest was able to find:
        './react-app-env.d.ts'

    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['web.js', 'js', 'web.ts', 'ts', 'web.tsx', 'tsx', 'json', 'web.jsx', 'jsx', 'node'].

    See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string

    However, Jest was able to find:
        './App.css'
        './App.test.tsx'
        './App.tsx'

    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['web.js', 'js', 'web.ts', 'ts', 'web.tsx', 'tsx', 'json', 'web.jsx', 'jsx', 'node'].
```

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
