### PR TITLE
docs(development): adds React Styleguidist demo

### DIFF
--- a/docusaurus/docs/developing-components-in-isolation.md
+++ b/docusaurus/docs/developing-components-in-isolation.md
@@ -14,13 +14,13 @@ Usually, it’s hard to see these states without running a sample app or some ex
 
 Create React App doesn’t include any tools for this by default, but you can add [Storybook for React](https://storybook.js.org) ([source](https://github.com/storybooks/storybook)) or [React Styleguidist](https://react-styleguidist.js.org/) ([source](https://github.com/styleguidist/react-styleguidist)) to your project. **These are third-party tools that let you develop components and see all their states in isolation from your app**.
 
-![Storybook for React Demo](https://i.imgur.com/7CIAWpB.gif)
-
 You can also deploy your Storybook or style guide as a static app. This way, everyone in your team can view and review different states of UI components without starting a backend server or creating an account in your app.
 
 ## Getting Started with Storybook
 
 Storybook is a development environment for React UI components. It allows you to browse a component library, view the different states of each component, and interactively develop and test components.
+
+![Storybook for React Demo](https://i.imgur.com/7CIAWpB.gif)
 
 Run the following command inside your app’s directory:
 

--- a/docusaurus/docs/developing-components-in-isolation.md
+++ b/docusaurus/docs/developing-components-in-isolation.md
@@ -41,6 +41,8 @@ Learn more about React Storybook:
 
 Styleguidist combines a style guide, where all your components are presented on a single page with their props documentation and usage examples, with an environment for developing components in isolation, similar to Storybook. In Styleguidist you write examples in Markdown, where each code snippet is rendered as a live editable playground.
 
+![React Styleguidist Demo](https://user-images.githubusercontent.com/1703219/74945569-51c6ad00-543b-11ea-8351-f4d86860893a.gif)
+
 First, install Styleguidist:
 
 ```sh


### PR DESCRIPTION
Noticed Storybook had a demo but StyleGuidist did not. Adds React Styleguidist demo found in https://github.com/styleguidist/react-styleguidist/blob/v11.1.0/Readme.md

![React Styleguidist Demo](https://user-images.githubusercontent.com/1703219/74945569-51c6ad00-543b-11ea-8351-f4d86860893a.gif)
