### PR TITLE
allow homepage to provide a full URL in production

### DIFF
--- a/packages/react-dev-utils/__tests__/getPublicUrlOrPath.test.js
+++ b/packages/react-dev-utils/__tests__/getPublicUrlOrPath.test.js
@@ -58,6 +58,12 @@ const tests = [
     homepage: '/path',
     expect: '/test/',
   },
+  {
+    dev: true,
+    publicUrl: '/path',
+    homepage: 'https://create-react-app.dev/test',
+    expect: '/path/',
+  },
 
   // PRODUCTION with homepage
   { dev: false, homepage: '/', expect: '/' },
@@ -67,11 +73,15 @@ const tests = [
   { dev: false, homepage: '../', expect: '../' },
   { dev: false, homepage: '../test', expect: '../test/' },
   { dev: false, homepage: './test/path', expect: './test/path/' },
-  { dev: false, homepage: 'https://create-react-app.dev/', expect: '/' },
+  {
+    dev: false,
+    homepage: 'https://create-react-app.dev/',
+    expect: 'https://create-react-app.dev/',
+  },
   {
     dev: false,
     homepage: 'https://create-react-app.dev/test',
-    expect: '/test/',
+    expect: 'https://create-react-app.dev/test/',
   },
   // PRODUCTION with publicUrl
   { dev: false, publicUrl: '/', expect: '/' },
@@ -115,6 +125,12 @@ const tests = [
     publicUrl: 'https://create-react-app.dev/test',
     homepage: '/path',
     expect: 'https://create-react-app.dev/test/',
+  },
+  {
+    dev: false,
+    publicUrl: '/path',
+    homepage: 'https://create-react-app.dev/test',
+    expect: '/path/',
   },
 ];
 

--- a/packages/react-dev-utils/getPublicUrlOrPath.js
+++ b/packages/react-dev-utils/getPublicUrlOrPath.js
@@ -49,16 +49,14 @@ function getPublicUrlOrPath(isEnvDevelopment, homepage, envPublicUrl) {
     homepage = homepage.endsWith('/') ? homepage : homepage + '/';
 
     // validate if `homepage` is a URL or path like and use just pathname
-    const validHomepagePathname = new URL(homepage, stubDomain).pathname;
+    const validHomepage = new URL(homepage, stubDomain);
     return isEnvDevelopment
       ? homepage.startsWith('.')
         ? '/'
-        : validHomepagePathname
+        : validHomepage.pathname
       : // Some apps do not use client-side routing with pushState.
-      // For these, "homepage" can be set to "." to enable relative asset paths.
-      homepage.startsWith('.')
-      ? homepage
-      : validHomepagePathname;
+        // For these, "homepage" can be set to "." to enable relative asset paths.
+        homepage;
   }
 
   return '/';


### PR DESCRIPTION
Fixes #8813

To test this I first did went into `packages/react-dev-utils` in this branch and ran `yarn link`. Then in another folder I ran:

```
npx create-react-app testing
cd testing
```

Next I added `"homepage": "https://example.com"` to package.json and ran `yarn build`.

The output contained this:
```
The project was built assuming it is hosted at /.
You can control this with the homepage field in your package.json.
```

I then ran:
```
yarn link react-dev-utils
yarn build
```

which contained this output:
```
The project was built assuming it is hosted at https://example.com/.
You can control this with the homepage field in your package.json.
```

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
