### PR TITLE
Yet another attempt to get a way for overriding webpack config

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -83,7 +83,8 @@
     "webpack": "4.44.1",
     "webpack-dev-server": "3.11.0",
     "webpack-manifest-plugin": "2.2.0",
-    "workbox-webpack-plugin": "5.1.4"
+    "workbox-webpack-plugin": "5.1.4",
+    "yargs": "^16.0.3"
   },
   "devDependencies": {
     "react": "^16.12.0",

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -32,6 +32,8 @@ verifyTypeScriptSetup();
 // @remove-on-eject-end
 
 const fs = require('fs');
+const path = require('path');
+const { argv } = require('yargs');
 const chalk = require('react-dev-utils/chalk');
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
@@ -46,7 +48,7 @@ const {
 const openBrowser = require('react-dev-utils/openBrowser');
 const semver = require('semver');
 const paths = require('../config/paths');
-const configFactory = require('../config/webpack.config');
+let configFactory = require('../config/webpack.config');
 const createDevServerConfig = require('../config/webpackDevServer.config');
 const getClientEnvironment = require('../config/env');
 const react = require(require.resolve('react', { paths: [paths.appPath] }));
@@ -79,6 +81,22 @@ if (process.env.HOST) {
     `Learn more here: ${chalk.yellow('https://cra.link/advanced-config')}`
   );
   console.log();
+}
+
+const webpackOverride = argv['webpack-override'];
+if (webpackOverride) {
+  const configOverride = require(path.resolve(paths.appPath, webpackOverride));
+  if (typeof configOverride === 'function') {
+    const defaultConfigFactory = configFactory;
+    configFactory = webpackEnv => {
+      const defaultConfig = defaultConfigFactory(webpackEnv);
+      return configOverride(defaultConfig);
+    };
+  } else {
+    console.warn(
+      `'${webpackOverride}' module must return a function to override webpack config`
+    );
+  }
 }
 
 // We require that you explicitly set browsers and do not fall back to


### PR DESCRIPTION
This can allow using react-scripts for non CRA apps. For example, building chrome extensions :)

TODO:
* [  ] adjust build command to apply config override

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/facebook/create-react-app/9779)
<!-- Reviewable:end -->
