### PR TITLE
fix: update no-const-assign to error

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -104,7 +104,7 @@ module.exports = {
     'no-array-constructor': 'warn',
     'no-caller': 'warn',
     'no-cond-assign': ['warn', 'except-parens'],
-    'no-const-assign': 'warn',
+    'no-const-assign': 'error',
     'no-control-regex': 'warn',
     'no-delete-var': 'warn',
     'no-dupe-args': 'warn',


### PR DESCRIPTION
eslint rule no-const-assign should be set to error ,due to this will be a runtime error.

refer: airbnb/javascript#559