### PR TITLE
fix: react-scripts version

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts",
-  "version": "3.4.1",
+  "version": "4.0.0-next.98",
   "description": "Configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
PR for: https://github.com/facebook/create-react-app/issues/9816
#9816 
Updating react-scripts so that it works by default on @next.
I am not sure how to target the @next flag directly so hoping a maintainer can give advice there?

Note that the react-scripts upgrade is pointing to a -next flag itself, however, as react-scripts states that it should always be backwards compatible this should be okay?

