### PR TITLE
[v4] Fallback to full reload if React version doesn't support Fast Refresh

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -243,7 +243,7 @@ function tryApplyUpdates(onHotUpdateSuccess) {
   }
 
   function handleApplyUpdates(err, updatedModules) {
-    const hasReactRefresh = process.env.FAST_REFRESH !== 'false';
+    const hasReactRefresh = process.env.FAST_REFRESH;
     const wantsForcedReload = err || !updatedModules || hadRuntimeError;
     // React refresh can handle hot-reloading over errors.
     if (!hasReactRefresh && wantsForcedReload) {

--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -11,6 +11,8 @@
 const fs = require('fs');
 const path = require('path');
 const paths = require('./paths');
+const semver = require('semver');
+const react = require(require.resolve('react', { paths: [paths.appPath] }));
 
 // Make sure that including paths.js after env.js will read .env variables.
 delete require.cache[require.resolve('./paths')];
@@ -94,10 +96,12 @@ function getClientEnvironment(publicUrl) {
         WDS_SOCKET_PATH: process.env.WDS_SOCKET_PATH,
         WDS_SOCKET_PORT: process.env.WDS_SOCKET_PORT,
         // Whether or not react-refresh is enabled.
-        // react-refresh is not 100% stable at this time,
-        // which is why it's disabled by default.
         // It is defined here so it is available in the webpackHotDevClient.
-        FAST_REFRESH: process.env.FAST_REFRESH !== 'false',
+        // Fast Refresh is available in React 16.10.0 or greater
+        // For older versions will fallback to full reload
+        FAST_REFRESH:
+          semver.gte(react.version, '16.10.0') &&
+          process.env.FAST_REFRESH !== 'false',
       }
     );
   // Stringify all values so we can feed into webpack DefinePlugin

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -44,14 +44,10 @@ const {
   prepareUrls,
 } = require('react-dev-utils/WebpackDevServerUtils');
 const openBrowser = require('react-dev-utils/openBrowser');
-const semver = require('semver');
 const paths = require('../config/paths');
 const configFactory = require('../config/webpack.config');
 const createDevServerConfig = require('../config/webpackDevServer.config');
-const getClientEnvironment = require('../config/env');
-const react = require(require.resolve('react', { paths: [paths.appPath] }));
 
-const env = getClientEnvironment(paths.publicUrlOrPath.slice(0, -1));
 const useYarn = fs.existsSync(paths.yarnLockFile);
 const isInteractive = process.stdout.isTTY;
 
@@ -145,14 +141,6 @@ checkBrowsers(paths.appPath, isInteractive)
       }
       if (isInteractive) {
         clearConsole();
-      }
-
-      if (env.raw.FAST_REFRESH && semver.lt(react.version, '16.10.0')) {
-        console.log(
-          chalk.yellow(
-            `Fast Refresh requires React 16.10 or higher. You are using React ${react.version}.`
-          )
-        );
       }
 
       console.log(chalk.cyan('Starting the development server...\n'));


### PR DESCRIPTION
fix #9807

### Changes

Fallback to the full reload if React version doesn't support Fast Refresh

- Overwrite `FAST_REFRESH` to `false` if the current react version doesn't support (< `16.10.0`)
- Fix the site won't get full reloaded when `FAST_REFRESH` got disabled
- Remove Fast Refresh warning on the older react version since we will automatically fallback to do full reload.

### Verify steps

Default setup

- `yarn create-react-app my-app`
- `yarn start`
- Modify `App.js` content
- The app gets updated through Fast Refresh

`FAST_REFRESH=false`

- Start the app by using `FAST_REFRESH=false yarn start`
- Modify `App.js`
- The app should do a full reload

React version that Fast Refresh is unavailable (e.g. 15)

- Change React version to `15.7.0` 
  - `yarn add react@15.7.0 react-dom@15.7.0`
  - Remove `<React.StrictMode>` from `index.js`
- `yarn start` and 
- Modify `App.js`
- The app should do a full reload

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
