### PR TITLE
Bump resolve-url-loader version

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -73,7 +73,7 @@
     "react-dev-utils": "^10.2.1",
     "react-refresh": "^0.8.3",
     "resolve": "1.17.0",
-    "resolve-url-loader": "3.1.1",
+    "resolve-url-loader": "3.1.2",
     "sass-loader": "8.0.2",
     "semver": "7.3.2",
     "style-loader": "1.2.1",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -73,7 +73,7 @@
     "react-dev-utils": "^10.2.1",
     "react-refresh": "^0.8.3",
     "resolve": "1.17.0",
-    "resolve-url-loader": "3.1.2",
+    "resolve-url-loader": "^3.1.2",
     "sass-loader": "8.0.2",
     "semver": "7.3.2",
     "style-loader": "1.2.1",


### PR DESCRIPTION
Currently, `npm audit` fails because of `react-scripts > resolve-url-loader > adjust-sourcemap-loader  > object-path`.
See https://github.com/facebook/create-react-app/issues/9840 for details.

This PR bumps the `resolve-url-loader` version from 3.1.1 to 3.1.2
