### PR TITLE
check if descriptionFileRoot is not undefined

### DIFF
--- a/packages/react-dev-utils/ModuleScopePlugin.js
+++ b/packages/react-dev-utils/ModuleScopePlugin.js
@@ -27,9 +27,10 @@ class ModuleScopePlugin {
           return callback();
         }
         if (
+          (typeof request.descriptionFileRoot !== 'undefined' &&
           // If this resolves to a node_module, we don't care what happens next
-          request.descriptionFileRoot.indexOf('/node_modules/') !== -1 ||
-          request.descriptionFileRoot.indexOf('\\node_modules\\') !== -1 ||
+          (request.descriptionFileRoot.indexOf('/node_modules/') !== -1 ||
+          request.descriptionFileRoot.indexOf('\\node_modules\\') !== -1)) ||
           // Make sure this request was manual
           !request.__innerRequest_request
         ) {


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
## Problem
I'm currently building a project using [nx monorepo](https://github.com/nrwl/nx) tool, they have its own react config, but the bundle is bigger and doesn't have the cool way to show eslint errors like here. But it has some conflicts when have a package.json inside the project.

## Solution
I ejected a create-react-app project and made the required changes to don't use the package.json, but in this file that I changed the `descriptionFileRoot` was getting `undefined`. So I just checked if was not undefined and then started working on the project without a package.json file.
