### PR TITLE
feat: remove unused React imports

### DIFF
--- a/packages/cra-template/template/src/App.js
+++ b/packages/cra-template/template/src/App.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 

--- a/packages/cra-template/template/src/App.test.js
+++ b/packages/cra-template/template/src/App.test.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 


### PR DESCRIPTION
I'm not sure if this change should go out in 4.0, but any new installations will have the required support for this - and it might be good to lead by example.

Anyone scaffolding a new project should have no issues with this, unless they were using an old `react-scripts` version - but I feel we can consider that edge-case, and they could also specify an old template version if they really need it.

The TypeScript template is blocked by #9734, which is waiting on TypeScript 4.1 to be released.