### PR TITLE
chore: Update .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,5 @@
 {
   "arrowParens": "avoid",
-  "trailingComma": "es5",
   "singleQuote": true,
   "semi": true
 }


### PR DESCRIPTION
`es5` is the default value for `trailingComma` since `prettier@2.x`