### PR TITLE
feat(react-scripts): allow reporters for jest config

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -83,6 +83,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'globalSetup',
     'globalTeardown',
     'moduleNameMapper',
+    'reporters',
     'resetMocks',
     'resetModules',
     'restoreMocks',


### PR DESCRIPTION
Resolves #9019 

Steps to verify
1. Prior to making this change, add `"jest": { "reporters": [] }` to `packages/react-scripts/package.json`
2. Run `yarn test` - This will fail with a message that indicates the `reporters` option is not supported
3. Apply these changes
4. Re-run `yarn test` -- This will pass and will also print no test results as we have not specified the default reporter. 

This also complements the `coverageReporters` option: https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/scripts/utils/createJestConfig.js#L79