### PR TITLE
fix: page doesn't get refreshed when FAST_REFRESH=false

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -243,7 +243,7 @@ function tryApplyUpdates(onHotUpdateSuccess) {
   }
 
   function handleApplyUpdates(err, updatedModules) {
-    const hasReactRefresh = process.env.FAST_REFRESH !== 'false';
+    const hasReactRefresh = process.env.FAST_REFRESH;
     const wantsForcedReload = err || !updatedModules || hadRuntimeError;
     // React refresh can handle hot-reloading over errors.
     if (!hasReactRefresh && wantsForcedReload) {

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -243,6 +243,7 @@ function tryApplyUpdates(onHotUpdateSuccess) {
   }
 
   function handleApplyUpdates(err, updatedModules) {
+    // NOTE: This var is injected by Webpack's DefinePlugin, and is a boolean instead of string.
     const hasReactRefresh = process.env.FAST_REFRESH;
     const wantsForcedReload = err || !updatedModules || hadRuntimeError;
     // React refresh can handle hot-reloading over errors.


### PR DESCRIPTION
Page doesn't get refreshed when disabling `FAST_REFRESH`. This is because the `process.env.FAST_REFRESH` in `webpackHotDevClient` is a boolean value, comparing `!== 'false'` will always return `true`.

### Verify steps

- `yarn create-react-app my-app`
- `yarn start`
- Modify `App.js` content
- The app gets updated through Fast Refresh

`FAST_REFRESH=false`

- Start the app by using `FAST_REFRESH=false yarn start`
- Modify `App.js`
- The app should do a full reload
