### PR TITLE
fix: `React is not defined` compilation error after ejected

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -406,9 +406,6 @@ module.exports = function (webpackEnv) {
                 customize: require.resolve(
                   'babel-preset-react-app/webpack-overrides'
                 ),
-                // @remove-on-eject-begin
-                babelrc: false,
-                configFile: false,
                 presets: [
                   [
                     require.resolve('babel-preset-react-app'),
@@ -417,6 +414,9 @@ module.exports = function (webpackEnv) {
                     },
                   ],
                 ],
+                // @remove-on-eject-begin
+                babelrc: false,
+                configFile: false,
                 // Make sure we have a unique cache identifier, erring on the
                 // side of caution.
                 // We remove this when the user ejects because the default


### PR DESCRIPTION
fix #9882

Eject the app will cause `React is not defined`, This is due to the Babel's configuration for JSX runtime gets removed during ejecting.

## Change

- Keep `runtime` configuration on ejection

## Verify Steps

- `yarn create-react-app test-ejecting-app`
- `cd test-eject-app`
- `yarn eject`
- `yarn start` and app should gets compiled successfully

