### PR TITLE
docs: fix codeblock text spacing

### DIFF
--- a/docusaurus/docs/using-https-in-development.md
+++ b/docusaurus/docs/using-https-in-development.md
@@ -13,7 +13,7 @@ To do this, set the `HTTPS` environment variable to `true`, then start the dev s
 ### Windows (cmd.exe)
 
 ```cmd
-set HTTPS=true&&npm start
+set HTTPS=true && npm start
 ```
 
 (Note: the lack of whitespace is intentional.)


### PR DESCRIPTION
Fixes the spacing between texts in example for `Windows (cmd.exe)` codeblock

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
