### PR TITLE
plugin-syntax-jsx fix for Simple tasks

### DIFF
--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -263,6 +263,7 @@ echo yes | npm run eject
 test -n "$(git diff --staged --name-only)"
 
 # Test the build
+yarn add @babel/plugin-syntax-jsx
 yarn build
 # Check for expected output
 exists build/*.html


### PR DESCRIPTION
The `plugin-syntax-jsx` is missing for the Simple tasks, which makes the build broken while running the task script.