### PR TITLE
fix: fast refresh is enabled if `FAST_REFRESH` environment variable is not defined

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -93,11 +93,10 @@ function getClientEnvironment(publicUrl) {
         WDS_SOCKET_HOST: process.env.WDS_SOCKET_HOST,
         WDS_SOCKET_PATH: process.env.WDS_SOCKET_PATH,
         WDS_SOCKET_PORT: process.env.WDS_SOCKET_PORT,
-        // Whether or not react-refresh is enabled.
-        // react-refresh is not 100% stable at this time,
-        // which is why it's disabled by default.
+        // react-refresh is enabled by default.
+        // It can be disabled by setting `FAST_REFRESH` to `false`.
         // It is defined here so it is available in the webpackHotDevClient.
-        FAST_REFRESH: process.env.FAST_REFRESH && process.env.FAST_REFRESH !== 'false',
+        FAST_REFRESH: process.env.FAST_REFRESH !== 'false',
       }
     );
   // Stringify all values so we can feed into webpack DefinePlugin

--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -97,7 +97,7 @@ function getClientEnvironment(publicUrl) {
         // react-refresh is not 100% stable at this time,
         // which is why it's disabled by default.
         // It is defined here so it is available in the webpackHotDevClient.
-        FAST_REFRESH: process.env.FAST_REFRESH !== 'false',
+        FAST_REFRESH: process.env.FAST_REFRESH && process.env.FAST_REFRESH !== 'false',
       }
     );
   // Stringify all values so we can feed into webpack DefinePlugin


### PR DESCRIPTION
As pointed out here: https://github.com/facebook/create-react-app/issues/9913#issuecomment-716879695

The comment in the code clearly states `// which is why it's disabled by default.` suggesting `react-refresh` should be disabled by default.
But if the environment variable `FAST_REFRESH` is not set at all, the condition `process.env.FAST_REFRESH !== 'false'` evaluates to `true` (as `undefined !== 'false'`), enabling `react-refresh`.