### PR TITLE
fix: correct JsxEmit value typo from ReactJsx to ReactJSX

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -148,7 +148,7 @@ function verifyTypeScriptSetup() {
     jsx: {
       parsedValue:
         hasJsxRuntime && semver.gte(ts.version, '4.1.0-beta')
-          ? ts.JsxEmit.ReactJsx
+          ? ts.JsxEmit.ReactJSX
           : ts.JsxEmit.React,
       value:
         hasJsxRuntime && semver.gte(ts.version, '4.1.0-beta')


### PR DESCRIPTION
- Correct `ts.JsxEmit` typo from `ReactJsx` to `ReactJSX` per https://github.com/microsoft/TypeScript/blob/261d03b8ed317475b34cd782d21710f2020a6312/src/compiler/commandLineParser.ts#L5-L11

### Verify steps

- yarn create-react-app my-app --template typescript
- cd my-app
- yarn add typescript@4.1.0-beta
- yarn start 
