### PR TITLE
Fix noFallthroughCasesInSwitch/jsx object is not extensible

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -221,7 +221,7 @@ function verifyTypeScriptSetup() {
   } else {
     // This is bug fix code of https://github.com/facebook/create-react-app/issues/9868
     // Bellow code release variable from non-extensible and freeze status.
-    appTsConfig.compilerOptions = { ...appTsConfig.compilerOptions };
+    appTsConfig.compilerOptions = JSON.parse(JSON.stringify(appTsConfig.compilerOptions));
 
     // Original appTsConfig.compilerOptions status
     // Object.isExtensible(appTsConfig.compilerOptions) output: false

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -148,7 +148,7 @@ function verifyTypeScriptSetup() {
     jsx: {
       parsedValue:
         hasJsxRuntime && semver.gte(ts.version, '4.1.0-beta')
-          ? ts.JsxEmit.ReactJsx
+          ? ts.JsxEmit.ReactJSX
           : ts.JsxEmit.React,
       value:
         hasJsxRuntime && semver.gte(ts.version, '4.1.0-beta')
@@ -218,6 +218,14 @@ function verifyTypeScriptSetup() {
   if (appTsConfig.compilerOptions == null) {
     appTsConfig.compilerOptions = {};
     firstTimeSetup = true;
+  } else {
+    // This is bug fix code of https://github.com/facebook/create-react-app/issues/9868
+    // Bellow code release variable from non-extensible and freeze status.
+    appTsConfig.compilerOptions = { ...appTsConfig.compilerOptions };
+
+    // Original appTsConfig.compilerOptions status
+    // Object.isExtensible(appTsConfig.compilerOptions) output: false
+    // Object.isFrozen(appTsConfig.compilerOptions) output: true
   }
 
   for (const option of Object.keys(compilerOptions)) {


### PR DESCRIPTION
Relative Issues https://github.com/facebook/create-react-app/issues/9868 https://github.com/facebook/create-react-app/issues/9429

I fixed broken `yarn start` that cause react-scripts can't handle correctly `noFallthroughCasesInSwitch` and `jsx` compileOptions.

![Oct-27-2020 16-12-58](https://user-images.githubusercontent.com/5501268/97268701-9ed30c80-186f-11eb-8f0b-e37f38bd4409.gif)

Thank you for your decent review 😀