### PR TITLE
fix: disable esModule on file-loader and url-loader to fix require() issues

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -383,6 +383,7 @@ module.exports = function (webpackEnv) {
                 limit: imageInlineSizeLimit,
                 mimetype: 'image/avif',
                 name: 'static/media/[name].[hash:8].[ext]',
+                esModule: false,
               },
             },
             // "url" loader works like "file" loader except that it embeds assets
@@ -394,6 +395,7 @@ module.exports = function (webpackEnv) {
               options: {
                 limit: imageInlineSizeLimit,
                 name: 'static/media/[name].[hash:8].[ext]',
+                esModule: false,
               },
             },
             // Process application JS with Babel.
@@ -586,6 +588,7 @@ module.exports = function (webpackEnv) {
               exclude: [/\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
               options: {
                 name: 'static/media/[name].[hash:8].[ext]',
+                esModule: false,
               },
             },
             // ** STOP ** Are you adding a new loader?


### PR DESCRIPTION
In https://github.com/facebook/create-react-app/pull/8950,  

There is a breaking change in [`file-loader`](https://github.com/webpack-contrib/file-loader/blob/master/CHANGELOG.md#500-2019-11-22) and [`url-loader`](https://github.com/webpack-contrib/url-loader/blob/master/CHANGELOG.md#breaking-changes) (`esModule` enable by default). This causes `require(..)` returns an object instead of a string, and it will break projects that upgrade from `v3` to `v4`. 

This PR will disable `esModule` for those loaders to preserve the require behavior as in `v3`

### Verify step

Both statements below should work.

```js
const image = require('./lmage.png');
import image from './image.png';
```

--- 

I don't know if it is an intention to enable `esModule` in the loader or not. If so, we probably need to add it as a breaking break of `v4` as well.


---
fix #9721, fix #9831

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
