### PR TITLE
Fix #9880

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -20,7 +20,7 @@ function formatMessage(message) {
 
   if (typeof message === 'string' || message instanceof String) {
     lines = message.split('\n');
-  } else if ('message' in Object.keys(message)) {
+  } else if ('message' in message) {
     lines = message['message'].split('\n');
   }
   

--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -16,8 +16,14 @@ function isLikelyASyntaxError(message) {
 
 // Cleans up webpack error messages.
 function formatMessage(message) {
-  let lines = message.split('\n');
+  let lines = [];
 
+  if (typeof message === 'string' || message instanceof String) {
+    lines = message.split('\n');
+  } else if ('message' in Object.keys(message)) {
+    lines = message['message'].split('\n');
+  }
+  
   // Strip webpack-added headers off errors/warnings
   // https://github.com/webpack/webpack/blob/master/lib/ModuleError.js
   lines = lines.filter(line => !/Module [A-z ]+\(from/.test(line));


### PR DESCRIPTION
Fix formatting error on webpack v5, as described here: #9880

Specifically in [this link](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#minor-changes), on the item that says:

Stats json errors and warnings no longer contain strings but objects with information splitted into properties.
MIGRATION: Access the information on the properties. i. e. message
