### PR TITLE
Add TypeScript 4.x as peerDependency to react-scripts

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -94,7 +94,7 @@
     "fsevents": "^2.1.3"
   },
   "peerDependencies": {
-    "typescript": "^3.2.1"
+    "typescript": "^3.2.1 || ^4"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
CRA is supposed to officially support TypeScript 4 as of [4.0.0](https://github.com/facebook/create-react-app/releases/tag/v4.0.0) but `react-scripts` is still set at only allowing TypeScript as `^3.2.1`. As the CRA TypeScript template comes with TypeScript 4 I think this is causing an install error for users on npm 7 as it now attempts to install peerDependencies by default but the TypeScript versions conflict.

If CRA now supports TypeScript 4 I think this is the correct change to make things right.

Closes #9892 
Closes #9764 (not really related to this but it can close after this)
Closes #9995