### PR TITLE
Move ESLint cache file into node_modules

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -10,6 +10,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const getPublicUrlOrPath = require('react-dev-utils/getPublicUrlOrPath');
 
 // Make sure any symlinks in the project folder are resolved:
@@ -56,6 +57,13 @@ const resolveModule = (resolveFn, filePath) => {
   return resolveFn(`${filePath}.js`);
 };
 
+let cachePath = resolveApp('node_modules/.cache');
+try {
+  fs.accessSync(cachePath, fs.constants.W_OK | fs.constants.R_OK);
+} catch (_) {
+  cachePath = os.tmpdir();
+}
+
 // config after eject: we're in ./config/
 module.exports = {
   dotenv: resolveApp('.env'),
@@ -73,7 +81,7 @@ module.exports = {
   proxySetup: resolveApp('src/setupProxy.js'),
   appNodeModules: resolveApp('node_modules'),
   swSrc: resolveModule(resolveApp, 'src/service-worker'),
-  cachePath: resolveApp('node_modules/.cache'),
+  cachePath,
   publicUrlOrPath,
 };
 
@@ -97,7 +105,7 @@ module.exports = {
   proxySetup: resolveApp('src/setupProxy.js'),
   appNodeModules: resolveApp('node_modules'),
   swSrc: resolveModule(resolveApp, 'src/service-worker'),
-  cachePath: resolveApp('node_modules/.cache'),
+  cachePath,
   publicUrlOrPath,
   // These properties only exist before ejecting:
   ownPath: resolveOwn('.'),
@@ -134,7 +142,7 @@ if (
     proxySetup: resolveOwn(`${templatePath}/src/setupProxy.js`),
     appNodeModules: resolveOwn('node_modules'),
     swSrc: resolveModule(resolveOwn, `${templatePath}/src/service-worker`),
-    cachePath: resolveApp('node_modules/.cache'),
+    cachePath,
     publicUrlOrPath,
     // These properties only exist before ejecting:
     ownPath: resolveOwn('.'),

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -73,6 +73,7 @@ module.exports = {
   proxySetup: resolveApp('src/setupProxy.js'),
   appNodeModules: resolveApp('node_modules'),
   swSrc: resolveModule(resolveApp, 'src/service-worker'),
+  cachePath: resolveApp('node_modules/.cache'),
   publicUrlOrPath,
 };
 
@@ -96,6 +97,7 @@ module.exports = {
   proxySetup: resolveApp('src/setupProxy.js'),
   appNodeModules: resolveApp('node_modules'),
   swSrc: resolveModule(resolveApp, 'src/service-worker'),
+  cachePath: resolveApp('node_modules/.cache'),
   publicUrlOrPath,
   // These properties only exist before ejecting:
   ownPath: resolveOwn('.'),
@@ -132,6 +134,7 @@ if (
     proxySetup: resolveOwn(`${templatePath}/src/setupProxy.js`),
     appNodeModules: resolveOwn('node_modules'),
     swSrc: resolveModule(resolveOwn, `${templatePath}/src/service-worker`),
+    cachePath: resolveApp('node_modules/.cache'),
     publicUrlOrPath,
     // These properties only exist before ejecting:
     ownPath: resolveOwn('.'),

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -10,7 +10,6 @@
 
 const path = require('path');
 const fs = require('fs');
-const os = require('os');
 const getPublicUrlOrPath = require('react-dev-utils/getPublicUrlOrPath');
 
 // Make sure any symlinks in the project folder are resolved:
@@ -57,13 +56,6 @@ const resolveModule = (resolveFn, filePath) => {
   return resolveFn(`${filePath}.js`);
 };
 
-let cachePath = resolveApp('node_modules/.cache');
-try {
-  fs.accessSync(cachePath, fs.constants.W_OK | fs.constants.R_OK);
-} catch (_) {
-  cachePath = os.tmpdir();
-}
-
 // config after eject: we're in ./config/
 module.exports = {
   dotenv: resolveApp('.env'),
@@ -81,7 +73,6 @@ module.exports = {
   proxySetup: resolveApp('src/setupProxy.js'),
   appNodeModules: resolveApp('node_modules'),
   swSrc: resolveModule(resolveApp, 'src/service-worker'),
-  cachePath,
   publicUrlOrPath,
 };
 
@@ -105,7 +96,6 @@ module.exports = {
   proxySetup: resolveApp('src/setupProxy.js'),
   appNodeModules: resolveApp('node_modules'),
   swSrc: resolveModule(resolveApp, 'src/service-worker'),
-  cachePath,
   publicUrlOrPath,
   // These properties only exist before ejecting:
   ownPath: resolveOwn('.'),
@@ -142,7 +132,6 @@ if (
     proxySetup: resolveOwn(`${templatePath}/src/setupProxy.js`),
     appNodeModules: resolveOwn('node_modules'),
     swSrc: resolveModule(resolveOwn, `${templatePath}/src/service-worker`),
-    cachePath,
     publicUrlOrPath,
     // These properties only exist before ejecting:
     ownPath: resolveOwn('.'),

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -753,6 +753,7 @@ module.exports = function (webpackEnv) {
         eslintPath: require.resolve('eslint'),
         context: paths.appSrc,
         cache: true,
+        cacheLocation: paths.cachePath,
         // ESLint class options
         cwd: paths.appPath,
         resolvePluginsRelativeTo: __dirname,

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -753,7 +753,10 @@ module.exports = function (webpackEnv) {
         eslintPath: require.resolve('eslint'),
         context: paths.appSrc,
         cache: true,
-        cacheLocation: path.resolve(paths.cachePath, '.eslintcache'),
+        cacheLocation: path.resolve(
+          paths.appNodeModules,
+          '.cache/.eslintcache'
+        ),
         // ESLint class options
         cwd: paths.appPath,
         resolvePluginsRelativeTo: __dirname,

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -753,7 +753,7 @@ module.exports = function (webpackEnv) {
         eslintPath: require.resolve('eslint'),
         context: paths.appSrc,
         cache: true,
-        cacheLocation: paths.cachePath,
+        cacheLocation: path.resolve(paths.cachePath, '.eslintcache'),
         // ESLint class options
         cwd: paths.appPath,
         resolvePluginsRelativeTo: __dirname,


### PR DESCRIPTION
Fix #9970
Fix #10161

As mentioned in https://github.com/facebook/create-react-app/pull/9977#discussion_r515618643, likewise `eslint-loader`, we need to support non-existing OR inaccessible path fallback for cache folder into `os.tempdir`, as current(new) eslint plugin doesn't support the fallback.

**TEST PLAN:**

To test how **permission issue** folder fallback works:
1. under the `node_module`
    - Remove the `.cache` folder content, if folder exists.
    - Or, create `.cache` folder
2. run `chmod u=r--,g=r--,o=r-- node_modules/.cache`
3. run `npm start`
4. `ls node_modules/.cache` should not show the `.eslintcache` file

To test how **non-existent** folder fallback works:
1. under the `node_module`
    - Remove the `.cache` folder content, if folder exists
2. run `npm start`
3. `ls node_modules/.cache` should not show the `.eslintcache` file

To test how **normal flow** of caching works:
1. under the `node_module`
    1. Make sure the `.cache` folder exists
    2. Make sure there is enough access to the folder `.cache`:  `chmod u=rwx,g=r-x,o=r-x node_modules/.cache`
2. run `npm start`
3. `ls node_modules/.cache` should show the `.eslintcache` file