### PR TITLE
Upgrade sass-loader

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -75,7 +75,7 @@
     "react-refresh": "^0.8.3",
     "resolve": "1.18.1",
     "resolve-url-loader": "^3.1.2",
-    "sass-loader": "8.0.2",
+    "sass-loader": "^10.0.5",
     "semver": "7.3.2",
     "style-loader": "1.3.0",
     "terser-webpack-plugin": "4.2.3",


### PR DESCRIPTION
Fix #9986 
With the current `node-sass` version (v5), `react-script` won't survive.

**TEST PLAN**

With the `sass-loader` version upgrade and new version of `node-sass`:
1. `npx create-react-app sass-error-compilation`
1. `cd sass-error-compilation`
1. `yarn add node-sass@5.0.0`
1. Modify App.css to App.scss. Change extension in App.js as well.
1. change the sass-loader version in `node_modules/react-scripts/package.json` to `^10.0.5`
1. `yarn add sass-loader@10.0.5`
1. `yarn start`
1. Should work successfully

With the `sass-loader` version upgrade and old version of `node-sass`:
1. `npx create-react-app sass-error-compilation`
1. `cd sass-error-compilation`
1. `yarn add node-sass@4.14.1`
1. Modify App.css to App.scss. Change extension in App.js as well.
1. change the sass-loader version in `node_modules/react-scripts/package.json` to `^10.0.5`
1. `yarn add sass-loader@10.0.5`
1. `yarn start`
1. Should work successfully

Without the version upgrade and and new version of `node-sass`:
1. `npx create-react-app sass-error-compilation`
1. `cd sass-error-compilation`
1. `yarn add node-sass@5.0.0`
1. Modify App.css to App.scss. Change extension in App.js as well.
1. `yarn start`
1. Should fail to run with version incompatibility error
