### PR TITLE
WP5 - Update IgnorePlugin signature

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -705,7 +705,12 @@ module.exports = function (webpackEnv) {
       // solution that requires the user to opt into importing specific locales.
       // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
       // You can remove this if you don't use Moment.js:
-      new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+      webpack.version.startsWith('5.')
+        ? new webpack.IgnorePlugin({
+            resourceRegExp: /^\.\/locale$/,
+            contextRegExp: /moment$/,
+          })
+        : new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
       // Generate a service worker script that will precache, and keep up to date,
       // the HTML & assets that are part of the webpack build.
       isEnvProduction &&


### PR DESCRIPTION
Support Webpack 4+5 IgnorePlugin signature

Reference:
* https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales

Part of making way for Webpack 5 #9994 

`yarn docker:e2e --test-suite simple` not yet tested but done manual QA on development and build*