### PR TITLE
Mention sass alternative to node-sass

### DIFF
--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -12,6 +12,8 @@ Following this rule often makes CSS preprocessors less useful, as features like 
 
 To use Sass, first install `node-sass`:
 
+> Note: if you prefer you can install `sass` instead with `npm install node-sass@npm:sass`.
+
 ```sh
 $ npm install node-sass --save
 $ # or


### PR DESCRIPTION
There are [valid reasons](https://dev.to/limal/node-sass-considered-harmful-4fjb) to prefer [sass](https://www.npmjs.com/package/sass) over [node-sass](https://www.npmjs.com/package/node-sass). 

It would be informative to the users to know that they can use this alternative.

Thanks to the package resolution `node-sass@npm:sass` a Create React App doesn't have to be ejected to support `sass` library. It will work transparently without any additional steps from a user.
