### PR TITLE
Use "paths" in tsconfig.json and jsconfig.json

### DIFF
--- a/docusaurus/docs/importing-a-component.md
+++ b/docusaurus/docs/importing-a-component.md
@@ -73,4 +73,34 @@ Now that you've configured your project to support absolute imports, if you want
 import Button from 'components/Button';
 ```
 
+### Path Mapping
+
+If you require more fine-grained import paths you can set up extra path mappings. This enables you to create shorter import paths to file locations that may normally require long paths. Below is an example `jsconfig.json` showing how you could do this:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "base/*": ["./components/base/*"],
+      "pages/*": ["./components/pages/*"],
+      "actions/*": ["./state/actions/*"]
+    }
+  },
+  "include": ["src"]
+}
+```
+
+> Even though `jsconfig.json` and `tsconfig.json` allow using multiple locations as "fallbacks", this feature is not currently available in `create-react-app`.
+
+Setting up your `jsconfig.json` or `tsconfig.json` as above enables you to do imports like this:
+
+```js
+import Button from 'components/Button';
+import MainPage from 'pages/Main';
+import addUser from 'actions/addUser';
+```
+
+The import for `Button` still works as the `baseUrl` is still set as `src`. However, we now have more paths available to reach modules that may be quite a few folders deep in our project. This may be useful for larger projects that have more elaborate filesystem layouts.
+
 For more information on these configuration files, see the [jsconfig.json reference](https://code.visualstudio.com/docs/languages/jsconfig) and [tsconfig.json reference](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) documentation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29948,15 +29948,6 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.3.0",
         "eslint-config-react-app": "^7.0.0",
-<<<<<<< HEAD
-=======
-=======
-<<<<<<< HEAD
->>>>>>> f21e2137 (Publish)
-=======
->>>>>>> 9f8d75e5 (chore(lint): lint all files)
->>>>>>> fb003998 (chore(lint): lint all files)
->>>>>>> f301bfe4 (chore(lint): lint all files)
         "flow-bin": "^0.116.0",
         "html-entities": "^2.3.2",
         "jest": "^27.4.3",
@@ -47337,19 +47328,8 @@
         "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
         "cross-env": "^7.0.3",
-<<<<<<< HEAD
         "eslint": "^8.3.0",
         "eslint-config-react-app": "^7.0.0",
-=======
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-        "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
-=======
->>>>>>> 9f8d75e5 (chore(lint): lint all files)
->>>>>>> fb003998 (chore(lint): lint all files)
->>>>>>> f301bfe4 (chore(lint): lint all files)
         "flow-bin": "^0.116.0",
         "html-entities": "^2.3.2",
         "jest": "^27.4.3",

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -259,10 +259,12 @@ function verifyTypeScriptSetup() {
     );
   }
 
-  if (parsedTsConfig.paths != null && parsedTsConfig.baseUrl == null) {
-    messages.push(
-      `${chalk.cyan('paths')} requires ${chalk.cyan('baseUrl')} to be set`
-    );
+  if (parsedTsConfig.paths != null) {
+    if (semver.lt(ts.version, '4.1.0') && parsedTsConfig.baseUrl == null) {
+      messages.push(
+        `${chalk.cyan('paths')} requires ${chalk.cyan('baseUrl')} to be set`
+      );
+    }
   }
 
   if (messages.length > 0) {

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -259,6 +259,12 @@ function verifyTypeScriptSetup() {
     );
   }
 
+  if (parsedTsConfig.paths != null && parsedTsConfig.baseUrl == null) {
+    messages.push(
+      `${chalk.cyan('paths')} requires ${chalk.cyan('baseUrl')} to be set`
+    );
+  }
+
   if (messages.length > 0) {
     if (firstTimeSetup) {
       console.log(

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -260,18 +260,18 @@ function verifyTypeScriptSetup() {
     );
   }
 
-  if (parsedTsConfig.compilerOptions.paths != null) {
+  if (appTsConfig.compilerOptions.paths != null) {
     if (
       semver.lt(ts.version, '4.1.0') &&
-      parsedTsConfig.compilerOptions.baseUrl == null
+      appTsConfig.compilerOptions.baseUrl == null
     ) {
       errors.push(
         `${chalk.cyan('paths')} requires ${chalk.cyan('baseUrl')} to be set`
       );
     }
     // Webpack 4 cannot support multiple locations
-    for (const path of Object.keys(parsedTsConfig.compilerOptions.paths)) {
-      const values = parsedTsConfig.compilerOptions.paths[path];
+    for (const path of Object.keys(appTsConfig.compilerOptions.paths)) {
+      const values = appTsConfig.compilerOptions.paths[path];
 
       if (!Array.isArray(values) || values.length > 1) {
         errors.push(

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -156,7 +156,6 @@ function verifyTypeScriptSetup() {
           : 'react',
       reason: 'to support the new JSX transform in React 17',
     },
-    paths: { value: undefined, reason: 'aliased imports are not supported' },
   };
 
   const formatDiagnosticHost = {


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Adds support for `compilerOptions.paths` in both `tsconfig.json` and `jsconfig.json` so that [path mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) can be used:

```json
"compilerOptions": {
  "baseUrl": "src",
  "paths": {
    "base/*": ["./components/base/*"],
    "pages/*": ["./components/pages/*"],
    "actions/*": ["./state/actions/*"]
  }
}
```

- [x] Parse paths and add to Jest aliases
- [x] Parse paths and add to Webpack aliases
- [x] Show error when `paths` is used without `baseUrl` for [TypeScript before 4.1](https://devblogs.microsoft.com/typescript/announcing-typescript-4-1-rc/#paths-without-baseurl)
- [x] Show error when `paths` is used improperly (has to be like example above with only one possible location; no extra fallbacks as Webpack 4 can't handle it)
- [x] Add docs

I've tried different combinations of paths in both JavaScript and TypeScript projects but no doubt there are still some bugs. I'd just like to get some early feedback and find out what the appropriate level of testing is.

Closes #5645
Closes #9406
Closes #9999