### PR TITLE
Increase Workbox's maximumFileSizeToCacheInBytes

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -714,6 +714,10 @@ module.exports = function (webpackEnv) {
           swSrc,
           dontCacheBustURLsMatching: /\.[0-9a-f]{8}\./,
           exclude: [/\.map$/, /asset-manifest\.json$/, /LICENSE/],
+          // Bump up the default maximum size (2mb) that's precached,
+          // to make lazy-loading failure scenarios less likely.
+          // See https://github.com/cra-template/pwa/issues/13#issuecomment-722667270
+          maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
         }),
       // TypeScript type checking
       useTypeScript &&


### PR DESCRIPTION
By default, any asset that is larger than 2mb won't be precached when using Workbox in your service worker with the PWA template. This will bump up that limit to 5mb.

There's a tradeoff here—you can easily end up accidentally precaching, e.g., very large media files by mistake if this limit is too high—but based on https://github.com/cra-template/pwa/issues/13#issuecomment-722667270, it's fairly easy to hit the 2mb limit on lazy-loaded JavaScript chunks. 5mb seems like a decent compromise.