### PR TITLE
docs: add React Testing Library as a library requiring jsdom

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -321,7 +321,7 @@ To help you make up your mind, here is a list of APIs that **need jsdom**:
 - [`ReactDOM.render()`](https://facebook.github.io/react/docs/top-level-api.html#reactdom.render)
 - [`TestUtils.renderIntoDocument()`](https://facebook.github.io/react/docs/test-utils.html#renderintodocument) ([a shortcut](https://github.com/facebook/react/blob/34761cf9a252964abfaab6faf74d473ad95d1f21/src/test/ReactTestUtils.js#L83-L91) for the above)
 - [`mount()`](https://airbnb.io/enzyme/docs/api/mount.html) in [Enzyme](https://airbnb.io/enzyme/index.html)
-- [`render`](https://testing-library.com/docs/react-testing-library/api/#render) in [Testing Library](https://testing-library.com/)
+- [`render()`](https://testing-library.com/docs/react-testing-library/api/#render) in [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)
 
 In contrast, **jsdom is not needed** for the following APIs:
 

--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -321,6 +321,7 @@ To help you make up your mind, here is a list of APIs that **need jsdom**:
 - [`ReactDOM.render()`](https://facebook.github.io/react/docs/top-level-api.html#reactdom.render)
 - [`TestUtils.renderIntoDocument()`](https://facebook.github.io/react/docs/test-utils.html#renderintodocument) ([a shortcut](https://github.com/facebook/react/blob/34761cf9a252964abfaab6faf74d473ad95d1f21/src/test/ReactTestUtils.js#L83-L91) for the above)
 - [`mount()`](https://airbnb.io/enzyme/docs/api/mount.html) in [Enzyme](https://airbnb.io/enzyme/index.html)
+- [`render`](https://testing-library.com/docs/react-testing-library/api/#render) in [Testing Library](https://testing-library.com/)
 
 In contrast, **jsdom is not needed** for the following APIs:
 


### PR DESCRIPTION
As the *React Testing library* requires a dom to execute their assertions, I'm adding it to the list of libraries requiring it on the documentation.

here's a screenshot of a test failing by using the node environment.
![image](https://user-images.githubusercontent.com/100741/98657458-2f1a5280-2342-11eb-8553-e50fdcf2ccbe.png)

