### PR TITLE
feat: support custom hosts ending with .localhost

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -62,7 +62,14 @@ if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
 
 // Tools like Cloud9 rely on this.
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
-const HOST = process.env.HOST || '0.0.0.0';
+let HOST = process.env.HOST || '0.0.0.0';
+// Convert hosts ending with ".localhost" so that resolution works internally,
+// while keeping the full host to be printed in the terminal and used to open
+// the browser.
+const fullHost = HOST;
+if (HOST.endsWith('.localhost')) {
+  HOST = 'localhost';
+}
 
 if (process.env.HOST) {
   console.log(
@@ -104,7 +111,7 @@ checkBrowsers(paths.appPath, isInteractive)
     const tscCompileOnError = process.env.TSC_COMPILE_ON_ERROR === 'true';
     const urls = prepareUrls(
       protocol,
-      HOST,
+      fullHost,
       port,
       paths.publicUrlOrPath.slice(0, -1)
     );


### PR DESCRIPTION
This makes `react-scripts start` just work if the user specified a custom
HOST environment variable that ends with .localhost.
The host is internally converted to "localhost" to avoid a failed DNS
resolution while starting the dev server but is still used in full to
print the URL to the terminal and open the browser.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
