### PR TITLE
docs: Fix broken Pace.js link

### DIFF
--- a/docusaurus/docs/using-the-public-folder.md
+++ b/docusaurus/docs/using-the-public-folder.md
@@ -60,7 +60,7 @@ The `public` folder is useful as a workaround for a number of less common cases:
 
 - You need a file with a specific name in the build output, such as [`manifest.webmanifest`](https://developer.mozilla.org/en-US/docs/Web/Manifest).
 - You have thousands of images and need to dynamically reference their paths.
-- You want to include a small script like [`pace.js`](https://github.hubspot.com/pace/docs/welcome/) outside of the bundled code.
+- You want to include a small script like [`pace.js`](https://codebyzach.github.io/pace/) outside of the bundled code.
 - Some library may be incompatible with webpack and you have no other option but to include it as a `<script>` tag.
 
 Note that if you add a `<script>` that declares global variables, you should read the topic [Using Global Variables](using-global-variables.md) in the next section which explains how to reference them.


### PR DESCRIPTION
The current link to Pace.js is pointing to a 404 page (https://github.hubspot.com/pace/docs/welcome/)

I have updated the link to point to the correct Pace.js URL (https://codebyzach.github.io/pace/)

I have built and tested the documentation locally
