### PR TITLE
feat: allow to configure jsx importSource option

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -97,6 +97,7 @@ module.exports = function (api, opts, env) {
           // behavior for any plugins that require one.
           ...(opts.runtime !== 'automatic' ? { useBuiltIns: true } : {}),
           runtime: opts.runtime || 'classic',
+          ...(process.env.JSX_IMPORT_SOURCE ? { importSource: process.env.JSX_IMPORT_SOURCE } : {}),
         },
       ],
       isTypeScriptEnabled && [require('@babel/preset-typescript').default],


### PR DESCRIPTION
This allows libraries such as https://github.com/welldone-software/why-did-you-render to work, also, it should allow to use React replacement libraries such as Preact.