### PR TITLE
update broken pace.js link in document

### DIFF
--- a/docusaurus/docs/using-the-public-folder.md
+++ b/docusaurus/docs/using-the-public-folder.md
@@ -60,7 +60,7 @@ The `public` folder is useful as a workaround for a number of less common cases:
 
 - You need a file with a specific name in the build output, such as [`manifest.webmanifest`](https://developer.mozilla.org/en-US/docs/Web/Manifest).
 - You have thousands of images and need to dynamically reference their paths.
-- You want to include a small script like [`pace.js`](https://github.hubspot.com/pace/docs/welcome/) outside of the bundled code.
+- You want to include a small script like [`pace.js`](https://codebyzach.github.io/pace/) outside of the bundled code.
 - Some library may be incompatible with webpack and you have no other option but to include it as a `<script>` tag.
 
 Note that if you add a `<script>` that declares global variables, you should read the topic [Using Global Variables](using-global-variables.md) in the next section which explains how to reference them.


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

I found broken link in the document, so I fixed it.

<br>

at  `docsaurus/docs/using-the-public-folder.md`.

> You want to include a small script like `pace.js` outside of the bundled code.

changed `page.js` link from
https://github.hubspot.com/pace/docs/welcome/
to 
https://codebyzach.github.io/pace/

<br>

Thanks in advance.