### PR TITLE
chore: bump typescript version

### DIFF
--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -5,10 +5,10 @@
       "@testing-library/react": "^11.1.0",
       "@testing-library/user-event": "^12.1.10",
       "@types/node": "^12.0.0",
-      "@types/react": "^16.9.53",
-      "@types/react-dom": "^16.9.8",
+      "@types/react": "^17.0.0",
+      "@types/react-dom": "^17.0.0",
       "@types/jest": "^26.0.15",
-      "typescript": "^4.0.3",
+      "typescript": "^4.1.2",
       "web-vitals": "^0.2.4"
     },
     "eslintConfig": {


### PR DESCRIPTION
As react version is 17.0.1, @types/react and @types/react-dom should be updated too.
Also, typescript version should be 4.1.2.
(I'm not sure what causes this, but when I create typescript project with CRA 4.0.1, installed node_modules/typescript version is 4.1.2, but root package.json describes it as "^4.0.3".)