### PR TITLE
chore: bump web-vital dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "svg-term-cli": "^2.1.1",
     "tempy": "^0.2.1",
     "wait-for-localhost": "^3.3.0",
-    "web-vitals": "^0.2.4"
+    "web-vitals": "^1.0.1"
   },
   "husky": {
     "hooks": {

--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -9,7 +9,7 @@
       "@types/react-dom": "^16.9.8",
       "@types/jest": "^26.0.15",
       "typescript": "^4.0.3",
-      "web-vitals": "^0.2.4"
+      "web-vitals": "^1.0.1"
     },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -4,7 +4,7 @@
       "@testing-library/jest-dom": "^5.11.4",
       "@testing-library/react": "^11.1.0",
       "@testing-library/user-event": "^12.1.10",
-      "web-vitals": "^0.2.4"
+      "web-vitals": "^1.0.1"
     },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]


### PR DESCRIPTION
web-vitals package has upgraded its version to 1.0.1 This PR is just a routine task to upgrade the dependency. The core functionality of web-vitals is working after the upgrade. I created a sample project and hit `reportWebVitals(console.log);` Following is the result that proves the successful of web-vitals functionality.

![image](https://user-images.githubusercontent.com/8158506/100132147-01d5b480-2eab-11eb-94a9-9017f25a75b3.png)
