### PR TITLE
Add .eslintcache in gitignore files for cra templates

### DIFF
--- a/packages/cra-template-typescript/template/gitignore
+++ b/packages/cra-template-typescript/template/gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+.eslintcache
 
 # production
 /build

--- a/packages/cra-template/template/gitignore
+++ b/packages/cra-template/template/gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+.eslintcache
 
 # production
 /build


### PR DESCRIPTION
ESlint generates a cache file that defaults to [.eslintcache](https://eslint.org/docs/user-guide/command-line-interface#-cache-location) location.

Therefore the first thing people will encounter after running `npm start` is an untracked `.eslintcache` file generated. I believe this is not a desirable experience that CRA would want to provide.

Therefore I've added it into the .gitignore file.