### PR TITLE
feat(monorepo): adds ability to run cra-template-typescript locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ yarn-error.log*
 /.changelog
 .npm/
 yarn.lock
+.eslintcache
+packages/cra-template-typescript/template/src/react-app-env.d.ts
+packages/cra-template-typescript/template/tsconfig.json

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
     "alex": "^8.2.0",
     "eslint": "^7.11.0",
     "execa": "1.0.0",
@@ -41,6 +43,7 @@
     "strip-ansi": "^6.0.0",
     "svg-term-cli": "^2.1.1",
     "tempy": "^0.2.1",
+    "typescript": "^4.1.2",
     "wait-for-localhost": "^3.3.0",
     "web-vitals": "^1.0.1"
   },

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -115,7 +115,7 @@ if (
   !reactScriptsLinked &&
   __dirname.indexOf(path.join('packages', 'react-scripts', 'config')) !== -1
 ) {
-  const templatePath = '../cra-template/template';
+  const templatePath = `../cra-template${process.env.CRA_TEMPLATE_TS_LOCAL ? '-typescript' : ''}/template`;
   module.exports = {
     dotenv: resolveOwn(`${templatePath}/.env`),
     appPath: resolveApp('.'),

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -138,6 +138,25 @@ CI=true yarn test
 # Test local start command
 yarn start --smoke-test
 
+# Run the same tests against  with cra-template-typescript
+# Test local build command
+rm -rf build
+CRA_TEMPLATE_TS_LOCAL=true yarn build
+# Check for expected output
+exists build/*.html
+exists build/static/js/*.js
+exists build/static/css/*.css
+exists build/static/media/*.svg
+exists build/favicon.ico
+
+# Run tests with CI flag
+CI=true CRA_TEMPLATE_TS_LOCAL=true yarn test
+# Uncomment when snapshot testing is enabled by default:
+# exists template/src/__snapshots__/App.test.js.snap
+
+# Test local start command
+CRA_TEMPLATE_TS_LOCAL=true yarn start --smoke-test
+
 # Publish the monorepo
 publishToLocalRegistry
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

I had some extra 🦃 day time and wanted to submit this small customization we introduced into our fork for consideration upstream. 

This PR adds the ability to run the `cra-template-typescript` source locally, which is nice when verifying the template contents and TS ecosystem.

To run:

```
CRA_TEMPLATE_TS_LOCAL=true yarn start
CRA_TEMPLATE_TS_LOCAL=true yarn build
CRA_TEMPLATE_TS_LOCAL=true yarn test
```

![image](https://user-images.githubusercontent.com/298435/100380328-401ec100-2fdc-11eb-97af-0f4d6130e487.png)


This relies on a `process.env` check within `paths.js` that alters the hardcoded path to `cra-template`.

I know webpack 5 is doing away with Node polyfilling, but CRA currently still supports `process.env` so I am hoping this is alright. 

Running this for the first time is interesting too, in that TypeScript generates two files that have historically never been present, `tsconfig.json` and the `react-app-env.d.ts` file. I've currently gitignored these files, as there is value in the `tsconfig.json` being generated by TS from version to version (I know the definition is added during init). 🤔 though on some level it's interesting to think that CRA could have more opinion here about what a default tsconfig looks like (with added maintenance then...)

> I am being slightly lazy here and letting the GH CI handle the complete suite. Forgive me, but kiddos call 👶 