### PR TITLE
'node-sass' is deprecated, 'sass' is used now

### DIFF
--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -10,12 +10,12 @@ Generally, we recommend that you don’t reuse the same CSS classes across diffe
 
 Following this rule often makes CSS preprocessors less useful, as features like mixins and nesting are replaced by component composition. You can, however, integrate a CSS preprocessor if you find it valuable.
 
-To use Sass, first install `node-sass`:
+To use Sass, first install `sass`:
 
 ```sh
-$ npm install node-sass --save
+$ npm install sass
 $ # or
-$ yarn add node-sass
+$ yarn add sass
 ```
 
 Now you can rename `src/App.css` to `src/App.scss` and update `src/App.js` to import `src/App.scss`.


### PR DESCRIPTION
node-sass is deprecated as per [node-sass npm page](https://www.npmjs.com/package/node-sass)

![image](https://user-images.githubusercontent.com/1297426/100884224-3a8f1280-34d7-11eb-81cc-63aa45b94bad.png)

[Sass](https://sass-lang.com/install) official website suggests use of sass package

![image](https://user-images.githubusercontent.com/1297426/100884473-83df6200-34d7-11eb-9fd3-643e22b6e8e2.png)

Changed node-sass to sass in documentation.
