### PR TITLE
remove chalk from formatWebpackMessages

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -7,7 +7,6 @@
 
 'use strict';
 
-const chalk = require('chalk');
 const friendlySyntaxErrorLabel = 'Syntax error:';
 
 function isLikelyASyntaxError(message) {
@@ -79,8 +78,6 @@ function formatMessage(message) {
     lines[1] +=
       'Run `npm install node-sass` or `yarn add node-sass` inside your workspace.';
   }
-
-  lines[0] = chalk.inverse(lines[0]);
 
   message = lines.join('\n');
   // Internal stacks are generally useless so we strip them... with the


### PR DESCRIPTION
Part of https://github.com/facebook/create-react-app/issues/9994 Webpack 5 series

`formatWebpackMessages.js` gets pulled into the browser and potentially runs there. 
This causes `Chalk` to try and run which eventually fails. 

The failure is because Webpack 5 no longer polyfills node built-ins. And Chalk uses `process`.
The best option is to not run chalk in formatWebpackMessages.js. The text will still show in the terminal just not have a grey background, I think this is a feature worth losing compared to the errors it causes in the browser, or the large amount of refactoring everyone using this would need to do.
