### PR TITLE
Allow custom branch names

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -71,6 +71,7 @@ function init() {
     )
     .option('--use-npm')
     .option('--use-pnp')
+    .option('--branch-name <type>')
     .allowUnknownOption()
     .on('--help', () => {
       console.log(
@@ -229,13 +230,14 @@ function init() {
           program.scriptsVersion,
           program.template,
           program.useNpm,
-          program.usePnp
+          program.usePnp,
+          program.branchName
         );
       }
     });
 }
 
-function createApp(name, verbose, version, template, useNpm, usePnp) {
+function createApp(name, verbose, version, template, useNpm, usePnp, branchName) {
   const unsupportedNodeVersion = !semver.satisfies(process.version, '>=10');
   if (unsupportedNodeVersion) {
     console.log(
@@ -342,7 +344,8 @@ function createApp(name, verbose, version, template, useNpm, usePnp) {
     originalDirectory,
     template,
     useYarn,
-    usePnp
+    usePnp,
+    branchName
   );
 }
 
@@ -425,7 +428,8 @@ function run(
   originalDirectory,
   template,
   useYarn,
-  usePnp
+  usePnp,
+  branchName
 ) {
   Promise.all([
     getInstallPackage(version, originalDirectory),
@@ -510,7 +514,7 @@ function run(
             cwd: process.cwd(),
             args: nodeArgs,
           },
-          [root, appName, verbose, originalDirectory, templateName],
+          [root, appName, verbose, originalDirectory, templateName, branchName],
           `
         var init = require('${packageName}/scripts/init.js');
         init.apply(null, JSON.parse(process.argv[1]));

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -41,13 +41,27 @@ function isInMercurialRepository() {
   }
 }
 
-function tryGitInit() {
+function tryGitInit(branchName) {
   try {
     execSync('git --version', { stdio: 'ignore' });
     if (isInGitRepository() || isInMercurialRepository()) {
       return false;
     }
+  } catch (e) {
+    console.warn('Git repo not initialized', e);
+    return false;
+  }
 
+  if(branchName) {
+    try {
+      execSync(`git init --initial-branch=${branchName}`, { stdio: 'ignore' });
+      return true;
+    } catch (e) {
+    console.warn(`Error while trying to initialize git repo with a custom branch name (${branchName})`, e);
+    }
+  }
+
+  try {
     execSync('git init', { stdio: 'ignore' });
     return true;
   } catch (e) {
@@ -86,7 +100,8 @@ module.exports = function (
   appName,
   verbose,
   originalDirectory,
-  templateName
+  templateName,
+  branchName
 ) {
   const appPackage = require(path.join(appPath, 'package.json'));
   const useYarn = fs.existsSync(path.join(appPath, 'yarn.lock'));
@@ -280,7 +295,7 @@ module.exports = function (
   // Initialize git repo
   let initializedGit = false;
 
-  if (tryGitInit()) {
+  if (tryGitInit(branchName)) {
     initializedGit = true;
     console.log();
     console.log('Initialized a git repository.');


### PR DESCRIPTION
## What Adds This PR?
This change allows to create new projects with a custom branch name:

```npx create-react-app my-app --branch-name main```

## Why?
There is a lot of interest in the community to [end with racist or patriarcal background](https://twitter.com/andrestaltz/status/1030200563802230786). Even [GitHub changed its default branch to main for new repositories](https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/). We should allow people to provide a custom branch name to initialize their CRA projects.

## Solution Details
The proposed solution tries to run `git init --initial-branch=custom-branch` first if a custom branch name is provided. If there's an error running this command, it runs `git init` as a fallback. Why this? Because [git throws an error if you run `git init` with `--initial-branch` on versions prior to 2.28.0](https://stackoverflow.com/a/42871621/2043736). Try to get the output from `git --version` failed because `execSync('git --version', { stdio: 'ignore' });`  returns null.

## Extras
I tried to configure [init.defaultBranch](https://github.blog/2020-07-27-highlights-from-git-2-28/) in my computer but my git version is 2.26.2 and that feature was added on 2.28.0. I don't want to upgrade my git version yet since we may need to test this change on old git versions.

## Questions
I'd like to know how to test this changes as similar as possible as running `npx create-react-app ...`.

I was able to partially test my changes by running `yarn create-react-app my-app --branch-name main` after cloning this repository. However, since a git repository is already initialized, I wasn't able to check that this changes worked. I'm only sure that the custom branch name is passed down to the expected functions (mostly by running console.logs), so test that this changes work as expected is necessary.

An automated test would be really nice, but if not possible, a manual way to test is great too.