### PR TITLE
WP5 -  Update WebpackManifestPlugin

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -20,7 +20,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const safePostCssParser = require('postcss-safe-parser');
-const ManifestPlugin = require('webpack-manifest-plugin');
+const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const WorkboxWebpackPlugin = require('workbox-webpack-plugin');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
@@ -682,7 +682,7 @@ module.exports = function (webpackEnv) {
       //   `index.html`
       // - "entrypoints" key: Array of files which are included in `index.html`,
       //   can be used to reconstruct the HTML if necessary
-      new ManifestPlugin({
+      new WebpackManifestPlugin({
         fileName: 'asset-manifest.json',
         publicPath: paths.publicUrlOrPath,
         generate: (seed, files, entrypoints) => {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -83,7 +83,7 @@
     "url-loader": "4.1.1",
     "webpack": "4.44.2",
     "webpack-dev-server": "3.11.0",
-    "webpack-manifest-plugin": "2.2.0",
+    "webpack-manifest-plugin": "3.0.0",
     "workbox-webpack-plugin": "5.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Update webpack-manifest-plugin@3.0.0

Changes:
* Updated export signature

ref: https://github.com/shellscape/webpack-manifest-plugin/releases/tag/v3.0.0

Part of making way for Webpack 5 #9994 

`yarn docker:e2e --test-suite simple` not tested - but done manual QA*