### PR TITLE
Update ModuleNotFoundPlugin to support Webpack 5

### DIFF
--- a/packages/react-dev-utils/ModuleNotFoundPlugin.js
+++ b/packages/react-dev-utils/ModuleNotFoundPlugin.js
@@ -100,8 +100,13 @@ class ModuleNotFoundPlugin {
     const { prettierError } = this;
     compiler.hooks.make.intercept({
       register(tap) {
+        // "SingleEntryPlugin" can be removed when Webpack 4 no longer have to be supported
         if (
-          !(tap.name === 'MultiEntryPlugin' || tap.name === 'SingleEntryPlugin')
+          !(
+            tap.name === 'MultiEntryPlugin' ||
+            tap.name === 'SingleEntryPlugin' ||
+            tap.name === 'EntryPlugin'
+          )
         ) {
           return tap;
         }


### PR DESCRIPTION
Support both "SingleEntryPlugin" and "EntryPlugin"

ref: https://webpack.js.org/blog/2020-10-10-webpack-5-release/#minor-changes

Part of making way for Webpack 5 #9994 

`yarn docker:e2e --test-suite simple` not tested - but done manual QA*