### PR TITLE
added ability to customize localIdentName without ejecting

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -55,6 +55,9 @@ const reactRefreshOverlayEntry = require.resolve(
 // makes for a smoother build process.
 const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
 
+const localIdentName = process.env.LOCAL_IDENT_NAME;
+const getLocalIdent = localIdentName ? function () { } : getCSSModuleLocalIdent;
+
 const imageInlineSizeLimit = parseInt(
   process.env.IMAGE_INLINE_SIZE_LIMIT || '10000'
 );
@@ -530,7 +533,8 @@ module.exports = function (webpackEnv) {
                   ? shouldUseSourceMap
                   : isEnvDevelopment,
                 modules: {
-                  getLocalIdent: getCSSModuleLocalIdent,
+                  localIdentName,
+                  getLocalIdent,
                 },
               }),
             },
@@ -566,7 +570,8 @@ module.exports = function (webpackEnv) {
                     ? shouldUseSourceMap
                     : isEnvDevelopment,
                   modules: {
-                    getLocalIdent: getCSSModuleLocalIdent,
+                    localIdentName,
+                    getLocalIdent,
                   },
                 },
                 'sass-loader'


### PR DESCRIPTION
I added the ability to customize the css/sass `localIdentName` without the need to eject.

I always eject my projects simply because I only want to customize localIdentName, which seems unnecessary to me. So I fixed it with this pull request :)

Now, you can simply add the variable `LOCAL_IDENT_NAME` to a `.env` file to customize the localIdentName.

Here is an example of my `.env` file:

```
LOCAL_IDENT_NAME=[hash:base64:5]
```

So now my css classes look like this:

```css
._3iokT {
    font-weight: 500;
    font-size: 15px;
}
```

instead of like this:
```css
.Card_Title__2DIe2 {
    font-weight: 500;
    font-size: 15px;
}
```

This also allows to reduce the css and js file bundle since we can make the css classes shorter.

All of this is possible now without needing to eject!

I will greatly appreciate if you consider this pull request!
Let me know if you have any questions!