### PR TITLE
Add loading indicator when modifying files

### DIFF
--- a/packages/cra-template/template/src/App.css
+++ b/packages/cra-template/template/src/App.css
@@ -7,12 +7,23 @@
   pointer-events: none;
 }
 
+#__cra-loading-icon {
+  height: 8vmin;
+  pointer-events: none;
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  display: none;
+}
+
 @media (prefers-reduced-motion: no-preference) {
   .App-logo {
     animation: App-logo-spin infinite 20s linear;
   }
+  #__cra-loading-icon {
+      animation: __cra-loading-icon-spin infinite 2s linear;
+  }
 }
-
 .App-header {
   background-color: #282c34;
   min-height: 100vh;
@@ -29,6 +40,19 @@
 }
 
 @keyframes App-logo-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+#__cra-loading-icon.visible {
+  display: block;
+}
+
+@keyframes __cra-loading-icon-spin {
   from {
     transform: rotate(0deg);
   }

--- a/packages/cra-template/template/src/App.js
+++ b/packages/cra-template/template/src/App.js
@@ -17,6 +17,7 @@ function App() {
         >
           Learn React
         </a>
+        <img id='__cra-loading-icon' src={logo} alt="logo" />
       </header>
     </div>
   );

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -191,6 +191,24 @@ function handleAvailableHash(hash) {
   mostRecentCompilationHash = hash;
 }
 
+function loadingDOMElement() {
+  return document.getElementById('__cra-loading-icon');
+}
+
+function hideLoadingIcon() {
+  var elem = loadingDOMElement();
+  if(elem) {
+    elem.classList.remove("visible");
+  }
+}
+
+function displayLoadingIcon() {
+  var elem = loadingDOMElement();
+  if(elem) {
+    elem.classList.add("visible");
+  }
+}
+
 // Handle messages from the server.
 connection.onmessage = function (e) {
   var message = JSON.parse(e.data);
@@ -201,6 +219,7 @@ connection.onmessage = function (e) {
     case 'still-ok':
     case 'ok':
       handleSuccess();
+      hideLoadingIcon();
       break;
     case 'content-changed':
       // Triggered when a file from `contentBase` changed.
@@ -210,7 +229,11 @@ connection.onmessage = function (e) {
       handleWarnings(message.data);
       break;
     case 'errors':
+      hideLoadingIcon()
       handleErrors(message.data);
+      break;
+    case 'invalid':
+      displayLoadingIcon();
       break;
     default:
     // Do nothing.


### PR DESCRIPTION
This adds a loading indicator to the user's browser when the app is compiling:

![loading-icon](https://user-images.githubusercontent.com/1259399/101868314-d82fb500-3b5b-11eb-988d-95436d1fc680.gif)

This is useful for users because they can see in real time in their browsers if their app is compiling or not. There's a similar feature on Next.js that works pretty well too.

This pull request presents a first version of this funtionality. It defines the loading icon in the user's `src/App.js` template file. This icon is toggled depending if the app is compiling or not.

I'd like to hear feedback about the icon too. I would probably not look good on every background, so I'd be glad to get some help me with it :-) 
I'd also be glad to hear ideas about how to do this without modifying `src/App.js` nor `src/App.css`.