### PR TITLE
changed node-sass to sass in docs

### DIFF
--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -10,12 +10,12 @@ Generally, we recommend that you don’t reuse the same CSS classes across diffe
 
 Following this rule often makes CSS preprocessors less useful, as features like mixins and nesting are replaced by component composition. You can, however, integrate a CSS preprocessor if you find it valuable.
 
-To use Sass, first install `node-sass`:
+To use Sass, first install `sass`:
 
 ```sh
-$ npm install node-sass --save
+$ npm install sass --save
 $ # or
-$ yarn add node-sass
+$ yarn add sass
 ```
 
 Now you can rename `src/App.css` to `src/App.scss` and update `src/App.js` to import `src/App.scss`.


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

The docs currently say to to install `node-sass` [here](https://create-react-app.dev/docs/adding-a-sass-stylesheet), and `node-sass` has now been deprecated. The sass website recommends using `sass` instead. This pull request changes the docs from saying to install `node-sass` to saying to install `sass`.
