### PR TITLE
update eslint-webpack-plugin@2.4.1 and enable treads in linter

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -757,6 +757,7 @@ module.exports = function (webpackEnv) {
         eslintPath: require.resolve('eslint'),
         context: paths.appSrc,
         cache: true,
+        treads: true,
         cacheLocation: path.resolve(
           paths.appNodeModules,
           '.cache/.eslintcache'

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-testing-library": "^3.9.2",
-    "eslint-webpack-plugin": "^2.1.0",
+    "eslint-webpack-plugin": "^2.4.1",
     "file-loader": "6.1.1",
     "fs-extra": "^9.0.1",
     "html-webpack-plugin": "4.5.0",


### PR DESCRIPTION
I have perfomance problem in build. Results diff react-scripts@4.0.1 and react-scripts@3.4.3 in my project:

Default:

- react-scripts@3.4.3 eslint-loader@3.0.3, cache: true Done in 190.03s.
- react-scripts@4.0.1 eslint-webpack-plugin@2.4.1, cache: true Done in **369.82s.**

Disable cache:

- react-scripts@3.4.3 eslint-loader@3.0.3, cache: false Done in 101.78s.
- react-scripts@4.0.1 eslint-webpack-plugin@2.4.1, cache: false Done in 101.98s.

Enable Treads:

- react-scripts@4.0.1 eslint-webpack-plugin@2.4.1, cache: true, treads: true Done in 106.12s.
- react-scripts@4.0.1 eslint-webpack-plugin@2.4.1, cache: false, treads: true Done in 84.70s.


I see performance improvement after package update eslint-webpack-plugin to 2.4.1 and enable multi treads linter.

Enable treads