### PR TITLE
Small update to wording in using-the-public-folder.md

### DIFF
--- a/docusaurus/docs/using-the-public-folder.md
+++ b/docusaurus/docs/using-the-public-folder.md
@@ -50,7 +50,7 @@ render() {
 Keep in mind the downsides of this approach:
 
 - None of the files in `public` folder get post-processed or minified.
-- Missing files will not be called at compilation time, and will cause 404 errors for your users.
+- Missing files will not be caught at compilation time, and will cause 404 errors for your users.
 - Result filenames won’t include content hashes so you’ll need to add query arguments or rename them every time they change.
 
 ## When to Use the `public` Folder


### PR DESCRIPTION
I think I have corrected the wording. 

I changed from 'Missing files will not be called at compilation time' to 'Missing files will not be caught at compilation time'.

If 'called' was indeed the intended wording, then please decline the PR without comment. I don't want to waste anyone's time.