### PR TITLE
Fix slow recompile times for existing users

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-testing-library": "^3.9.2",
-    "eslint-webpack-plugin": "^2.1.0",
+    "eslint-webpack-plugin": "^2.4.1",
     "file-loader": "6.1.1",
     "fs-extra": "^9.0.1",
     "html-webpack-plugin": "4.5.0",


### PR DESCRIPTION
https://github.com/facebook/create-react-app/issues/9886 was a crippling performance regression that rendered `react-scripts` close to unusable, at least for all my projects where I was using it.
Fortunately, this performance regression was fixed by the following release of `eslint-webpack-plugin`: https://github.com/webpack-contrib/eslint-webpack-plugin/releases/tag/v2.4.1 (otherwise I would have been forced to downgrade to react-scripts 3.X).

However, the performance regression was only fixed for new users of `react-scripts`, but not for existing users.
The problem is that the internal dependency to  `eslint-webpack-plugin` still accepts broken versions it its admissible range of versions.
Therefore, existing users are forced to read through https://github.com/facebook/create-react-app/issues/9886 until they find out that they either have to manually bump `eslint-webpack-plugin` or delete their entire `package-lock.json` and re-install everything from scratch.

So this PR is an attempt to fix the performance regression for all users that are updating `react-scripts`, instead of waiting until they read through GitHub bug reports or delete their package-lock files.

