### PR TITLE
Add lint rule against TypeScript const enums

### DIFF
--- a/packages/eslint-config-react-app/README.md
+++ b/packages/eslint-config-react-app/README.md
@@ -19,7 +19,7 @@ If you want to use this ESLint configuration in a project not built with Create 
 First, install this package, ESLint and the necessary plugins.
 
 ```sh
-npm install --save-dev eslint-config-react-app @typescript-eslint/eslint-plugin@^4.0.0 @typescript-eslint/parser@^4.0.0 babel-eslint@^10.0.0 eslint@^7.5.0 eslint-plugin-flowtype@^5.2.0 eslint-plugin-import@^2.22.0 eslint-plugin-jsx-a11y@^6.3.1 eslint-plugin-react@^7.20.3 eslint-plugin-react-hooks@^4.0.8
+npm install --save-dev eslint-config-react-app @typescript-eslint/eslint-plugin@^4.0.0 @typescript-eslint/parser@^4.0.0 babel-eslint@^10.0.0 eslint@^7.5.0 eslint-plugin-flowtype@^5.2.0 eslint-plugin-import@^2.22.0 eslint-plugin-jsx-a11y@^6.3.1 eslint-plugin-react@^7.20.3 eslint-plugin-react-hooks@^4.0.8 eslint-plugin-typescript-enum@^2.0.10
 ```
 
 Then create a file named `.eslintrc.json` with following contents in the root folder of your project:

--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -42,7 +42,7 @@ module.exports = {
         // typescript-eslint specific options
         warnOnUnsupportedTypeScriptVersion: true,
       },
-      plugins: ['@typescript-eslint'],
+      plugins: ['@typescript-eslint', 'typescript-enum'],
       // If adding a typescript-eslint version of an existing ESLint rule,
       // make sure to disable the ESLint rule here.
       rules: {
@@ -88,6 +88,9 @@ module.exports = {
         ],
         'no-useless-constructor': 'off',
         '@typescript-eslint/no-useless-constructor': 'warn',
+
+        // @babel/plugin-transform-typescript does not support `const enum`s.
+        'typescript-enum/no-const-enum': 'error',
       },
     },
   ],

--- a/packages/eslint-config-react-app/package.json
+++ b/packages/eslint-config-react-app/package.json
@@ -27,7 +27,8 @@
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^4.0.8",
-    "eslint-plugin-testing-library": "^3.9.0"
+    "eslint-plugin-testing-library": "^3.9.0",
+    "eslint-plugin-typescript-enum": "^2.0.10"
   },
   "peerDependenciesMeta": {
     "eslint-plugin-jest": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-testing-library": "^3.9.2",
+    "eslint-plugin-typescript-enum": "^2.0.10",
     "eslint-webpack-plugin": "^2.1.0",
     "file-loader": "6.1.1",
     "fs-extra": "^9.0.1",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Closes https://github.com/facebook/create-react-app/issues/10137.

[@babel/plugin-transform-typescript does not support `const enum`s](https://babeljs.io/docs/en/babel-plugin-transform-typescript#caveats), this PR aims to reflect that by adding [`typescript-enum/no-const-enum`](https://github.com/shian15810/eslint-plugin-typescript-enum/blob/main/docs/rules/no-const-enum.md) to **eslint-config-react-app**, so as users are aware of this in their IDEs without having to run build.
