### PR TITLE
Upgrade docs http links to https

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ labels: 'issue: bug report, needs triage'
     * yarn.lock
 
   Then you need to decide which package manager you prefer to use.
-  We support both npm (https://npmjs.com) and yarn (http://yarnpkg.com/).
+  We support both npm (https://npmjs.com) and yarn (https://yarnpkg.com/).
   However, **they can't be used together in one project** so you need to pick one.
 
   If you decided to use npm, run this in your project directory:

--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -156,7 +156,7 @@ npm install -g create-react-app@1.3.0
 
   If you are using Yarn, and you have created at least one app previously, Create React App now works offline.
 
-  <img src="http://i.imgur.com/1FLa9Tg.gif" width="500" alt="Yarn offline installation demo">
+  <img src="https://i.imgur.com/1FLa9Tg.gif" width="500" alt="Yarn offline installation demo">
 
 #### :bug: Bug Fix
 
@@ -515,7 +515,7 @@ Inside any created project that has not been ejected, run:
 npm install --save-dev --save-exact react-scripts@0.9.0
 ```
 
-Then, run your tests. If you are affected by breaking changes from Jest 18, consult [blog post](https://facebook.github.io/jest/blog/2016/12/15/2016-in-jest.html), [changelog](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-1800), and [documentation](http://facebook.github.io/jest/docs/getting-started.html). You might need to update any snapshots since their format might have changed.
+Then, run your tests. If you are affected by breaking changes from Jest 18, consult [blog post](https://facebook.github.io/jest/blog/2016/12/15/2016-in-jest.html), [changelog](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-1800), and [documentation](https://facebook.github.io/jest/docs/getting-started.html). You might need to update any snapshots since their format might have changed.
 
 If you relied on the browser not starting in non-interactive terminals, you now need to explicitly specify `BROWSER=none` as an environment variable to disable it.
 
@@ -993,7 +993,7 @@ Thanks to [@fson](https://github.com/fson) for cutting this release.
 
 ### Build Dependency (`react-scripts`)
 
-- Updates Jest to [version 16.0](http://facebook.github.io/jest/blog/2016/10/03/jest-16.html), with an upgraded CLI, improved snapshot testing, new matchers and more. ([@chase](https://github.com/chase) in [#858](https://github.com/facebook/create-react-app/pull/858))
+- Updates Jest to [version 16.0](https://facebook.github.io/jest/blog/2016/10/03/jest-16.html), with an upgraded CLI, improved snapshot testing, new matchers and more. ([@chase](https://github.com/chase) in [#858](https://github.com/facebook/create-react-app/pull/858))
 - Test setup file `src/setupTests.js` is now called after test framework initialization to support loading custom matchers. ([@just-boris](https://github.com/just-boris) in [#846](https://github.com/facebook/create-react-app/pull/846))
 - Build command shows better instructions for deploying the app to GitHub Pages ([@Janpot](https://github.com/Janpot) in [#841](https://github.com/facebook/create-react-app/pull/841))
 - Build command now generates an asset manifest with mappings from each filename to its final output filename. ([@lukyth](https://github.com/lukyth) in [#891](https://github.com/facebook/create-react-app/pull/891))
@@ -1394,7 +1394,7 @@ Newly created projects will use `0.2.1` automatically. You **don’t** need to u
 
 - You can now enable deployment to GitHub Pages by adding `homepage` field to `package.json` ([@dhruska](https://github.com/dhruska) in [#94](https://github.com/facebook/create-react-app/pull/94))
 - Development server now runs on `0.0.0.0` and works with VirtualBox ([@JWo1F](https://github.com/JWo1F) in [#128](https://github.com/facebook/create-react-app/pull/128))
-- Cloud9 and Nitrous online IDEs are now supported ([@gaearon](http://github.com/gaearon) in [2fe84e](https://github.com/facebook/create-react-app/commit/2fe84ecded55f1d5258d91f9c2c07698ae0d2fb4))
+- Cloud9 and Nitrous online IDEs are now supported ([@gaearon](https://github.com/gaearon) in [2fe84e](https://github.com/facebook/create-react-app/commit/2fe84ecded55f1d5258d91f9c2c07698ae0d2fb4))
 - When `3000` port is taken, we offer to use another port ([@chocnut](https://github.com/chocnut) in [#101](https://github.com/facebook/create-react-app/pull/101), [2edf21](https://github.com/facebook/create-react-app/commit/2edf2180f2aa6bf647807d0b1fcd95f4cfe4a558))
 - You can now `import` CSS files from npm modules ([@glennreyes](https://github.com/glennreyes) in [#105](https://github.com/facebook/create-react-app/pull/105), [@breaddevil](https://github.com/breaddevil) in [#178](https://github.com/facebook/create-react-app/pull/178))
 - `fetch` and `Promise` polyfills are now always included ([@gaearon](https://github.com/gaearon) in [#235](https://github.com/facebook/create-react-app/pull/235))

--- a/CHANGELOG-1.x.md
+++ b/CHANGELOG-1.x.md
@@ -1547,7 +1547,7 @@ You can automatically convert your project to fix them by running the [correspon
 
 #### How do I make my tests work with Jest 20?
 
-Please refer to the [Jest 19](https://facebook.github.io/jest/blog/2017/02/21/jest-19-immersive-watch-mode-test-platform-improvements.html#breaking-changes) and [Jest 20](http://facebook.github.io/jest/blog/2017/05/06/jest-20-delightful-testing-multi-project-runner.html#breaking-changes) breaking changes for migration instructions.
+Please refer to the [Jest 19](https://facebook.github.io/jest/blog/2017/02/21/jest-19-immersive-watch-mode-test-platform-improvements.html#breaking-changes) and [Jest 20](https://facebook.github.io/jest/blog/2017/05/06/jest-20-delightful-testing-multi-project-runner.html#breaking-changes) breaking changes for migration instructions.
 
 If you use snapshots, you will likely need to update them once because of the change in format.
 

--- a/docusaurus/docs/adding-css-reset.md
+++ b/docusaurus/docs/adding-css-reset.md
@@ -66,7 +66,7 @@ Browser support is dictated by what normalize.css [supports]. As of this writing
 - iOS Safari (last 2)
 - Internet Explorer 9+
 
-[browserslist]: http://browserl.ist/
+[browserslist]: https://browserl.ist/
 [css reset]: https://cssreset.com/what-is-a-css-reset/
 [normalize.css]: https://github.com/csstools/normalize.css
 [supports]: https://github.com/csstools/normalize.css#browser-support

--- a/docusaurus/docs/code-splitting.md
+++ b/docusaurus/docs/code-splitting.md
@@ -5,7 +5,7 @@ title: Code Splitting
 
 Instead of downloading the entire app before users can use it, code splitting allows you to split your code into small chunks which you can then load on demand.
 
-This project setup supports code splitting via [dynamic `import()`](http://2ality.com/2017/01/import-operator.html#loading-code-on-demand). Its [proposal](https://github.com/tc39/proposal-dynamic-import) is in stage 4. The `import()` function-like form takes the module name as an argument and returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) which always resolves to the namespace object of the module.
+This project setup supports code splitting via [dynamic `import()`](https://2ality.com/2017/01/import-operator.html#loading-code-on-demand). Its [proposal](https://github.com/tc39/proposal-dynamic-import) is in stage 4. The `import()` function-like form takes the module name as an argument and returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) which always resolves to the namespace object of the module.
 
 Here is an example:
 

--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -161,7 +161,7 @@ You can specify other environments in the same way.
 
 Variables in `.env.production` will be used as fallback because `NODE_ENV` will always be set to `production` for a build.
 
-## [AWS Amplify](http://console.amplify.aws)
+## [AWS Amplify](https://console.amplify.aws)
 
 The AWS Amplify Console provides continuous deployment and hosting for modern web apps (single page apps and static site generators) with serverless backends. The Amplify Console offers globally available CDNs, custom domain setup, feature branch deployments, and password protection.
 

--- a/docusaurus/docs/importing-a-component.md
+++ b/docusaurus/docs/importing-a-component.md
@@ -5,7 +5,7 @@ title: Importing a Component
 
 This project setup supports ES6 modules thanks to webpack.
 
-While you can still use `require()` and `module.exports`, we encourage you to use [`import` and `export`](http://exploringjs.com/es6/ch_modules.html) instead.
+While you can still use `require()` and `module.exports`, we encourage you to use [`import` and `export`](https://exploringjs.com/es6/ch_modules.html) instead.
 
 For example:
 
@@ -47,7 +47,7 @@ Named exports are useful for utility modules that export several functions. A mo
 Learn more about ES6 modules:
 
 - [When to use the curly braces?](https://stackoverflow.com/questions/36795819/react-native-es-6-when-should-i-use-curly-braces-for-import/36796281#36796281)
-- [Exploring ES6: Modules](http://exploringjs.com/es6/ch_modules.html)
+- [Exploring ES6: Modules](https://exploringjs.com/es6/ch_modules.html)
 - [Understanding ES6: Modules](https://leanpub.com/understandinges6/read#leanpub-auto-encapsulating-code-with-modules)
 
 ## Absolute Imports

--- a/packages/babel-preset-react-app/README.md
+++ b/packages/babel-preset-react-app/README.md
@@ -30,7 +30,7 @@ Then create a file named `.babelrc` with following contents in the root folder o
 }
 ```
 
-This preset uses the `useBuiltIns` option with [transform-object-rest-spread](http://babeljs.io/docs/plugins/transform-object-rest-spread/) and [transform-react-jsx](http://babeljs.io/docs/plugins/transform-react-jsx/), which assumes that `Object.assign` is available or polyfilled.
+This preset uses the `useBuiltIns` option with [transform-object-rest-spread](https://babeljs.io/docs/plugins/transform-object-rest-spread/) and [transform-react-jsx](https://babeljs.io/docs/plugins/transform-react-jsx/), which assumes that `Object.assign` is available or polyfilled.
 
 ## Usage with Flow
 

--- a/packages/eslint-config-react-app/README.md
+++ b/packages/eslint-config-react-app/README.md
@@ -30,7 +30,7 @@ Then create a file named `.eslintrc.json` with following contents in the root fo
 }
 ```
 
-That's it! You can override the settings from `eslint-config-react-app` by editing the `.eslintrc.json` file. Learn more about [configuring ESLint](http://eslint.org/docs/user-guide/configuring) on the ESLint website.
+That's it! You can override the settings from `eslint-config-react-app` by editing the `.eslintrc.json` file. Learn more about [configuring ESLint](https://eslint.org/docs/user-guide/configuring) on the ESLint website.
 
 ## Jest rules
 


### PR DESCRIPTION
Upgraded all `http` links to `https` that support the `https` protocol.

<details>
  <summary>All upgraded links</summary>

  Links
  ---
  https://exploringjs.com/es6/ch_modules.html
  https://yarnpkg.com/
  https://i.imgur.com/1FLa9Tg.gif
  https://facebook.github.io/jest/docs/getting-started.html
  https://facebook.github.io/jest/blog/2016/10/03/jest-16.html
  https://github.com/gaearon
  https://facebook.github.io/jest/blog/2017/05/06/jest-20-delightful-testing-multi-project-runner.html#breaking-changes
  https://browserl.ist/
  https://2ality.com/2017/01/import-operator.html#loading-code-on-demand
  https://console.amplify.aws
  https://babeljs.io/docs/plugins/transform-object-rest-spread
  https://eslint.org/docs/user-guide/configuring
  https://babeljs.io/docs/plugins/transform-react-jsx

</details>
