### PR TITLE
Added a timeout to checkForLastestVersion

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -1141,7 +1141,11 @@ function checkForLatestVersion() {
       )
       .on('error', () => {
         reject();
-      });
+      })
+      .on('timeout', () => {
+        reject();
+      })
+      .setTimeout(5000);
   });
 }
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
The default registry of NPM can not be got quickly in some areas, and the developers have to set local registries to optimize, so using GET to send a request to npm to check the last version become very slow, even block the whole progress.

In this case, `npm view create-react-app version` is fine while `https.get('https://registry.npmjs.org/-/package/create-react-app/dist-tags', ....)` blocks the progress, as the promise would never be solved or rejected if it didn't get a response.

I added a 5s timeout to make it continue to work if can't `checkForLastestVersion` get the response after the timeout.
The 5s waiting time is acceptable for me, it also can be other values. The main purpose is that the `checkForLastestVersion` not block the progress if it cannot get a response from npm default registry.

I'd be glad and appreciate it if you could consider this pull request!

