### PR TITLE
fix typescript template

### DIFF
--- a/packages/cra-template-typescript/template/src/App.tsx
+++ b/packages/cra-template-typescript/template/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 


### PR DESCRIPTION
Since React v17, importing React is no longer necessary, so I fixed it.