### PR TITLE
Add .eslintcache to gitignore template

### DIFF
--- a/packages/cra-template-typescript/template/gitignore
+++ b/packages/cra-template-typescript/template/gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.eslintcache
 
 npm-debug.log*
 yarn-debug.log*

--- a/packages/cra-template/template/gitignore
+++ b/packages/cra-template/template/gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.eslintcache
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
Hello! I ran `npx create-react-app client --template typescript` and then `yarn start` and found that `.eslintcache` appeared and should have been git ignored. This adds .eslintcache to the gitignore part of the relevant templates.