### PR TITLE
fix(react-scripts): added sass/node-sass peer dependencies

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -95,9 +95,17 @@
     "fsevents": "^2.1.3"
   },
   "peerDependencies": {
+    "node-sass": "^4.0.0 || ^5.0.0",
+    "sass": "^1.3.0",
     "typescript": "^3.2.1 || ^4"
   },
   "peerDependenciesMeta": {
+    "node-sass": {
+      "optional": true
+    },
+    "sass": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }


### PR DESCRIPTION
Added `sass`/`node-sass` optional peer dependencies to `react-scripts`.

These are optional peer dependencies of [`sass-loader`](https://github.com/webpack-contrib/sass-loader/blob/4caf60fb4a5e8f2d13cdde531e5277b0d2b9ab0b/package.json#L43-L44), which is a dependency of `react-scripts`. Therefore `react-scripts` must provide the dependency.