### PR TITLE
Merge AVIF loader config

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -374,22 +374,11 @@ module.exports = function (webpackEnv) {
           // match the requirements. When no loader matches it will fall
           // back to the "file" loader at the end of the loader list.
           oneOf: [
-            // TODO: Merge this config once `image/avif` is in the mime-db
-            // https://github.com/jshttp/mime-db
-            {
-              test: [/\.avif$/],
-              loader: require.resolve('url-loader'),
-              options: {
-                limit: imageInlineSizeLimit,
-                mimetype: 'image/avif',
-                name: 'static/media/[name].[hash:8].[ext]',
-              },
-            },
             // "url" loader works like "file" loader except that it embeds assets
             // smaller than specified limit in bytes as data URLs to avoid requests.
             // A missing `test` is equivalent to a match.
             {
-              test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
+              test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/, /\.avif$/],
               loader: require.resolve('url-loader'),
               options: {
                 limit: imageInlineSizeLimit,


### PR DESCRIPTION
Relative #9611.

[mime-type](https://github.com/jshttp/mime-types) upgraded dependency [mime-db@1.45.0](https://github.com/jshttp/mime-db/releases/tag/v1.45.0).
Added `image/avif` with extension `.avif`.

![image](https://user-images.githubusercontent.com/47573306/103560313-88da6b80-4ef2-11eb-909c-0b15e09213e3.png)

So I merged loader config.

![image](https://user-images.githubusercontent.com/47573306/103559928-ed48fb00-4ef1-11eb-8e0d-e0d07c38b28d.png)

It worked well in my testing.
