### PR TITLE
Add section on testing component CSS with Jest

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -124,6 +124,12 @@ it('renders welcome message', () => {
 
 Learn more about the utilities provided by `react-testing-library` to facilitate testing asynchronous interactions as well as selecting form elements from the [`react-testing-library` documentation](https://testing-library.com/react) and [examples](https://codesandbox.io/s/github/kentcdodds/react-testing-library-examples).
 
+### Testing Component CSS and Styles
+
+jsdom can be used to test inline styles and for the existence of class selectors, but it isn't ideal for testing computed styles without some additional setup. Stylesheets are imported as empty objects by default, so no styles are loaded into jsdom, therefore assertion methods like `toBeVisible` and `toHaveStyle` likely will not work in most cases if your component is using external stylesheets. If you wish to have CSS styles added for testing, this must be implemented on your own.
+
+If possible, consider a different tool for testing styles or an approach that uses classes only, as jsdom [doesn't handle have layouts implemented](https://github.com/jsdom/jsdom#unimplemented-parts-of-the-web-platform). You may want to use something that utilizes a browser.
+
 ## Using Third Party Assertion Libraries
 
 We recommend that you use `expect()` for assertions and `jest.fn()` for spies. If you are having issues with them please [file those against Jest](https://github.com/facebook/jest/issues/new), and we’ll fix them. We intend to keep making them better for React, supporting, for example, [pretty-printing React elements as JSX](https://github.com/facebook/jest/pull/1566).


### PR DESCRIPTION
jsdom isn't ideal (or suitable?) for testing component style, but it isn't super obvious as it really isn't explicitly stated anywhere in create-react-app, jest, or react-testing-library docs. 

CRA is designed to get people started with React and is somewhat of a closed system with it not exposing its webpack config, so I think it is useful to explicitly state that it isn't supported out of the box, as well as a nice nudge to encourage someone to try a different approach.

I know there are ways to do it, but it seemed out of scope, which is why I stuck to this simple caveat.

It's a harmless addition that could save someone time. Maybe this was just a "me" problem, but I tripped up on it enough to want to add this to the docs, and I've used CRA for years (just never tried to test a style!). Thoughts?