### PR TITLE
Ignore .eslintcache 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn-error.log*
 /.changelog
 .npm/
 yarn.lock
+.eslintcache


### PR DESCRIPTION
 Add .eslintcache to `.gitignore` file to disables its tracking. This file is unnecessary in the git tree. 
 
 Reference: https://github.com/facebook/create-react-app/issues/10161