### PR TITLE
feat: add disabling typescript incremental build configuration

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -62,6 +62,9 @@ const imageInlineSizeLimit = parseInt(
 // Check if TypeScript is setup
 const useTypeScript = fs.existsSync(paths.appTsConfig);
 
+// Check disable incremental build in fork-ts-checker-webpack-plugin
+const useTypeScriptIncrementalBuild = !process.env.DISABLE_TS_INCREMENTAL_BUILD || true;
+
 // Get the path to the uncompiled service worker (if it exists).
 const swSrc = paths.swSrc;
 
@@ -734,6 +737,7 @@ module.exports = function (webpackEnv) {
             ? `${__dirname}/pnpTs.js`
             : undefined,
           tsconfig: paths.appTsConfig,
+          useTypescriptIncrementalApi: useTypeScriptIncrementalBuild,
           reportFiles: [
             // This one is specifically to match during CI tests,
             // as micromatch doesn't match


### PR DESCRIPTION
As the project's scale is getting bigger, the incremental parsing time increases exponentially.
not only build script, but also every time I run script `yarn start`, the incremental parsing time cost.
It is very uncomfortable when I develop.

and so many people use `customized-cra` to disable TS incremental option in fork-ts-checker-webpack-plugin

so I suggest that add advanced configuration with env `DISABLE_TS_INCREMENTAL_BUILD` 

reference: https://create-react-app.dev/docs/advanced-configuration

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
