### PR TITLE
Ignore eslint cache

### DIFF
--- a/packages/cra-template-typescript/template/gitignore
+++ b/packages/cra-template-typescript/template/gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.eslintcache

--- a/packages/cra-template/template/gitignore
+++ b/packages/cra-template/template/gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.eslintcache


### PR DESCRIPTION
Add `.eslintcache` to `.gitignore` to fix #10306

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
