### PR TITLE
Docs: some installation commands should be dev dependencies instead of normal dependencies

### DIFF
--- a/docusaurus/docs/adding-flow.md
+++ b/docusaurus/docs/adding-flow.md
@@ -9,7 +9,7 @@ Recent versions of [Flow](https://flow.org/) work with Create React App projects
 
 To add Flow to a Create React App project, follow these steps:
 
-1. Run `npm install --save flow-bin` (or `yarn add flow-bin`).
+1. Run `npm install --save-dev flow-bin` (or `yarn add flow-bin --dev`).
 2. Add `"flow": "flow"` to the `scripts` section of your `package.json`.
 3. Run `npm run flow init` (or `yarn flow init`) to create a [`.flowconfig` file](https://flow.org/en/docs/config/) in the root directory.
 4. Add `// @flow` to any files you want to type check (for example, to `src/App.js`).

--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -26,11 +26,11 @@ yarn create react-app my-app --template typescript
 To add [TypeScript](https://www.typescriptlang.org/) to an existing Create React App project, first install it:
 
 ```sh
-npm install --save typescript @types/node @types/react @types/react-dom @types/jest
+npm install --save-dev typescript @types/node @types/react @types/react-dom @types/jest
 
 # or
 
-yarn add typescript @types/node @types/react @types/react-dom @types/jest
+yarn add typescript @types/node @types/react @types/react-dom @types/jest --dev
 ```
 
 Next, rename any file to be a TypeScript file (e.g. `src/index.js` to `src/index.tsx`) and **restart your development server**!

--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -116,13 +116,13 @@ Prettier is an opinionated code formatter with support for JavaScript, CSS and J
 To format our code whenever we make a commit in git, we need to install the following dependencies:
 
 ```sh
-npm install --save husky lint-staged prettier
+npm install --save-dev husky lint-staged prettier
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add husky lint-staged prettier
+yarn add husky lint-staged prettier --dev
 ```
 
 - `husky` makes it possible to use githooks as if they are npm scripts.


### PR DESCRIPTION
When going through the docs, i saw many installation commands that are supposed to be dev dependencies.

For example: https://create-react-app.dev/docs/adding-typescript

```
npm install --save typescript @types/node @types/react @types/react-dom @types/jest

# or

yarn add typescript @types/node @types/react @types/react-dom @types/jest
```

I believe some dependencies such as typescript should be dev dependencies so that it's not included in the production bundle.