### PR TITLE
Removed the imaginary margin which is always there.

### DIFF
--- a/packages/cra-template/template/src/index.css
+++ b/packages/cra-template/template/src/index.css
@@ -1,3 +1,7 @@
+* {
+  margin: 0;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',


### PR DESCRIPTION
# These are the before and after images. The imaginary margin just irritates the React developers.
### Before -
![img1](https://user-images.githubusercontent.com/64588766/104809873-817e6080-5816-11eb-8db8-78c08440008c.png)
### After -
![img2](https://user-images.githubusercontent.com/64588766/104809878-84795100-5816-11eb-89af-39971b8f7f92.png)

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
