### PR TITLE
Fixing `node-sass` installation

### DIFF
--- a/docusaurus/docs/adding-bootstrap.md
+++ b/docusaurus/docs/adding-bootstrap.md
@@ -36,13 +36,13 @@ As of `react-scripts@2.0.0` you can import `.scss` files. This makes it possible
 To enable `scss` in Create React App you will need to install `node-sass`.
 
 ```sh
-npm install --save node-sass
+npm install --save node-sass@4
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add node-sass
+yarn add node-sass@4
 ```
 
 To customize Bootstrap, create a file called `src/custom.scss` (or similar) and import the Bootstrap source stylesheet. Add any overrides _before_ the imported file(s). You can reference [Bootstrap's documentation](https://getbootstrap.com/docs/4.1/getting-started/theming/#css-variables) for the names of the available variables.


### PR DESCRIPTION
This fixes:

```
Failed to compile.

./src/App.scss (./node_modules/css-loader/dist/cjs.js??ref--5-oneOf-6-1!./node_modules/postcss-loader/src??postcss!./node_modules/resolve-url-loader??ref--5-oneOf-6-3!./node_modules/s
ass-loader/dist/cjs.js??ref--5-oneOf-6-4!./src/App.scss)
Error: Node Sass version 5.0.0 is incompatible with ^4.0.0.
```

As it was reported here: `https://stackoverflow.com/questions/64625050/error-node-sass-version-5-0-0-is-incompatible-with-4-0-0`, with more than 588 votes.

This is probably just a workaround but fixes the issue for people that try to do it now.