### PR TITLE
fix: create-react-app slow behind corporate proxies

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -49,6 +49,10 @@ const validateProjectName = require('validate-npm-package-name');
 
 const packageJson = require('./package.json');
 
+// Environments behind corporate proxies require NO_UPDATE_NOTIFIER variable
+// for npm to work in child_process
+const npmExecOptions = { env: { ...process.env, NO_UPDATE_NOTIFIER: 'true' } };
+
 let projectName;
 
 function init() {
@@ -195,7 +199,9 @@ function init() {
   checkForLatestVersion()
     .catch(() => {
       try {
-        return execSync('npm view create-react-app version').toString().trim();
+        return execSync('npm view create-react-app version', npmExecOptions)
+          .toString()
+          .trim();
       } catch (e) {
         return null;
       }
@@ -772,7 +778,7 @@ function checkNpmVersion() {
   let hasMinNpm = false;
   let npmVersion = null;
   try {
-    npmVersion = execSync('npm --version').toString().trim();
+    npmVersion = execSync('npm --version', npmExecOptions).toString().trim();
     hasMinNpm = semver.gte(npmVersion, '6.0.0');
   } catch (err) {
     // ignore
@@ -1009,7 +1015,9 @@ function getProxy() {
   } else {
     try {
       // Trying to read https-proxy from .npmrc
-      let httpsProxy = execSync('npm config get https-proxy').toString().trim();
+      let httpsProxy = execSync('npm config get https-proxy', npmExecOptions)
+        .toString()
+        .trim();
       return httpsProxy !== 'null' ? httpsProxy : undefined;
     } catch (e) {
       return;


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Fixes #10403. This PR speeds up `npx create-react-app` by six minutes when run behind a corporate proxy. 

## What:

NPM has a bug where it acts really slow when run via `child_process` in an environment behind corporate proxy. Similar issues:
- https://github.com/prettier/prettier-vscode/issues/1143
- https://github.com/microsoft/vscode-languageserver-node/issues/551

With current version of CRA it takes **6 minutes additional time** when `npx create-react-app` is run.

Use this to test whether your environment is affected: `node -e "console.log(require('child_process').execSync('npm --version', { env: { ...process.env, NO_UPDATE_NOTIFIER: undefined }}).toString())"`.
This command takes 3 minutes to run in such environments.

## How:

There is a work-around. If `NO_UPDATE_NOTIFIER` is available as environment variable npm internally skips some checks and moves on. Setting this variable `"true"` is something I always do to my work machines - but CRA cannot expect all developers to do this manually.

This PR adds `NO_UPDATE_NOTIFIER` to those `require('child_process').execSync('npm ...')` calls. 
[Link to child_process docs for busy people](https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options) 😄 

## Test Plan:

As this can only be reproduced when in environment behind corporate proxy this cannot be unit tested. I tested this manually in such environment. Debug logs are wrapped around these lines:

https://github.com/facebook/create-react-app/blob/0f6fc2bc71d78f0dcae67f3f08ce98a42fc0a57c/packages/create-react-app/createReactApp.js#L198

https://github.com/facebook/create-react-app/blob/0f6fc2bc71d78f0dcae67f3f08ce98a42fc0a57c/packages/create-react-app/createReactApp.js#L1012

Without the fix:
```
$ node index.js repro-app
Checking version [15:16:21]
Version 4.0.1 Time [15:19:29]

Creating a new React app in <removed>

Installing packages. This might take a couple of minutes.
Getting proxy [15:19:30]
Got proxy true Time [15:22:39]
```

With the fix:
```
$ node index.js fixed-app
Checking version [15:50:52]
Version 4.0.1 Time [15:50:54]

Creating a new React app in <removed>

Installing packages. This might take a couple of minutes.
Getting proxy [15:50:54]
Got proxy true Time [15:50:55]
```

All comments are welcome. 👍 