### PR TITLE
Discourage usage of react-sanpshot and react-snap

### DIFF
--- a/docusaurus/docs/pre-rendering-into-static-html-files.md
+++ b/docusaurus/docs/pre-rendering-into-static-html-files.md
@@ -4,7 +4,9 @@ title: Pre-Rendering into Static HTML Files
 sidebar_label: Pre-Rendering Static HTML
 ---
 
-If you’re hosting your `build` with a static hosting provider you can use [react-snapshot](https://www.npmjs.com/package/react-snapshot) or [react-snap](https://github.com/stereobooster/react-snap) to generate HTML pages for each route, or relative link, in your application. These pages will then seamlessly become active, or “hydrated”, when the JavaScript bundle has loaded.
+> Note: Both packages mentioned here haven't been maintained for one year at least. If you've found an alternative, please edit this page.
+
+If you’re hosting your `build` with a static hosting provider you can use [react-snapshot](https://www.npmjs.com/package/react-snapshot) or [react-snap](https://github.com/stereobooster/react-snap) to generate HTML pages for each route, or relative link, in your application. These pages will then seamlessly become active, or “hydrated”, when the JavaScript bundle has loaded. 
 
 There are also opportunities to use this outside of static hosting, to take the pressure off the server when generating and caching routes.
 


### PR DESCRIPTION
Added a note that warns about current state for both packages and suggest providing an alternative at [Pre-Rendering into Static HTML Files](https://create-react-app.dev/docs/pre-rendering-into-static-html-files)

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
closes #10430 
