### PR TITLE
Support TextMate as an editor

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -62,6 +62,7 @@ const COMMON_EDITORS_OSX = {
     '/Applications/GoLand.app/Contents/MacOS/goland',
   '/Applications/Rider.app/Contents/MacOS/rider':
     '/Applications/Rider.app/Contents/MacOS/rider',
+  '/Applications/TextMate.app/Contents/MacOS/TextMate': 'mate'
 };
 
 const COMMON_EDITORS_LINUX = {


### PR DESCRIPTION
Hello,

This add Textmate (https://macromates.com/) to the editors list. Its line argument format was already present but not the command line to actually call it : https://github.com/facebook/create-react-app/blob/0f6fc2bc71d78f0dcae67f3f08ce98a42fc0a57c/packages/react-dev-utils/launchEditor.js#L153-L156

Tested on MacOS 10.13.6.