### PR TITLE
Removed serviceWorker.js from folder structure in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ my-app
     ├── index.css
     ├── index.js
     ├── logo.svg
-    └── serviceWorker.js
+    └── reportWebVitals.js
     └── setupTests.js
 ```
 


### PR DESCRIPTION
Removing serviceWorker.js which is not provided by default. 
Also added reportWebVitals.js which is now included.

```diff
- serviceWorker.js
+ reportWebVitals.js
```

I personally run into confusion while finding the service worker. Because generally all the docs about create-react-app says that serviceWorker.js is provided by default. But it is not the case now and showing that it should be available from first README.md makes confusion that 'why I don't have it?'.

I found someone mentioned this is issues but nothing happened so I am creating this PR.
Thank you.
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
