### PR TITLE
Remove ESLint verification when opting-out

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyPackageTree.js
+++ b/packages/react-scripts/scripts/utils/verifyPackageTree.js
@@ -19,7 +19,7 @@ const isESLintPluginEnabled = process.env.DISABLE_ESLINT_PLUGIN !== 'true';
 // in the tree will likely break your setup.
 // This is a relatively low-effort way to find common issues.
 function verifyPackageTree() {
-  let depsToCheck = [
+  const depsToCheck = [
     // These are packages most likely to break in practice.
     // See https://github.com/facebook/create-react-app/issues/1795 for reasons why.
     // I have not included Babel here because plugins typically don't import Babel (so it's not affected).
@@ -28,11 +28,9 @@ function verifyPackageTree() {
     'jest',
     'webpack',
     'webpack-dev-server',
-  ];
-
-  if (isESLintPluginEnabled) {
-    depsToCheck = [...depsToCheck, 'babel-eslint', 'eslint'];
-  }
+    isESLintPluginEnabled && 'babel-eslint',
+    isESLintPluginEnabled && 'eslint',
+  ].filter(Boolean);
 
   // Inlined from semver-regex, MIT license.
   // Don't want to make this a dependency after ejecting.

--- a/packages/react-scripts/scripts/utils/verifyPackageTree.js
+++ b/packages/react-scripts/scripts/utils/verifyPackageTree.js
@@ -13,22 +13,27 @@ const fs = require('fs');
 const semver = require('semver');
 const path = require('path');
 
+const isESLintPluginEnabled = process.env.DISABLE_ESLINT_PLUGIN !== 'true';
+
 // We assume that having wrong versions of these
 // in the tree will likely break your setup.
 // This is a relatively low-effort way to find common issues.
 function verifyPackageTree() {
-  const depsToCheck = [
+  let depsToCheck = [
     // These are packages most likely to break in practice.
     // See https://github.com/facebook/create-react-app/issues/1795 for reasons why.
     // I have not included Babel here because plugins typically don't import Babel (so it's not affected).
-    'babel-eslint',
     'babel-jest',
     'babel-loader',
-    'eslint',
     'jest',
     'webpack',
     'webpack-dev-server',
   ];
+
+  if (isESLintPluginEnabled) {
+    depsToCheck = [...depsToCheck, 'babel-eslint', 'eslint'];
+  }
+
   // Inlined from semver-regex, MIT license.
   // Don't want to make this a dependency after ejecting.
   const getSemverRegex = () =>


### PR DESCRIPTION
This PR follows #10170 and ensures that we no longer "verify" `eslint` and `babel-eslint` versions if the user has opted out of the plugin completely.

Related comment: https://github.com/facebook/create-react-app/pull/10170#issuecomment-767080023