### PR TITLE
docs: move '/api' from use() to createProxyMiddleware()

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -99,8 +99,7 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function(app) {
   app.use(
-    '/api',
-    createProxyMiddleware({
+    createProxyMiddleware('/api', {
       target: 'http://localhost:5000',
       changeOrigin: true,
     })


### PR DESCRIPTION
Path `'/api'` should be the first argument of `createProxyMiddleware()` function, not `use()`.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
