### PR TITLE
split code blocks in Adding TypeScript page of Create React App documentation for easier copying and pasting

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -9,13 +9,13 @@ title: Adding TypeScript
 
 ## Installation
 
-To start a new Create React App project with [TypeScript](https://www.typescriptlang.org/), you can run:
+To start a new Create React App project with [TypeScript](https://www.typescriptlang.org/), you can run
 
 ```sh
 npx create-react-app my-app --template typescript
-
-# or
-
+```
+or
+```sh
 yarn create react-app my-app --template typescript
 ```
 
@@ -23,13 +23,13 @@ yarn create react-app my-app --template typescript
 >
 > Global installs of `create-react-app` are no longer supported.
 
-To add [TypeScript](https://www.typescriptlang.org/) to an existing Create React App project, first install it:
+To add [TypeScript](https://www.typescriptlang.org/) to an existing Create React App project, first install it with
 
 ```sh
 npm install --save typescript @types/node @types/react @types/react-dom @types/jest
-
-# or
-
+```
+or
+```sh
 yarn add typescript @types/node @types/react @types/react-dom @types/jest
 ```
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
This change just updates the ["Adding TypeScript" page of the Create React App documentation](https://create-react-app.dev/docs/adding-typescript/) so that the commands to add TypeScript to either a new or existing Create React App project are in their own, separate code blocks.

This makes them easier to copy and paste, as opposed to copying an entire block of two commands with a commented `# or` in them. Hope this helps!

Update: I created an ticket that tracks the issue this pull request seeks to fix. This pull request closes #10562 if we decide to merge it.