### PR TITLE
Solve the issue of casting using 'as' keyword in .tsx files

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -32,7 +32,15 @@ npm install --save typescript @types/node @types/react @types/react-dom @types/j
 
 yarn add typescript @types/node @types/react @types/react-dom @types/jest
 ```
-
+Next, add the following to `package.json` :
+```json
+"eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  }
+```
 Next, rename any file to be a TypeScript file (e.g. `src/index.js` to `src/index.tsx`) and **restart your development server**!
 
 Type errors will show up in the same console as the build one. You'll have to fix these type errors before you continue development or build your project. For advanced configuration, [see here](advanced-configuration.md).


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
When the user migrate the existing React JS project to support Typescript a parsing error will raise during the build when using 'as' keyword in any .tsx file, the solution is to add a missing "eslintConfig" entry configuration to 'package.json'