### PR TITLE
PoC: supoort absolute path for launchEditor

### DIFF
--- a/packages/react-dev-utils/launchEditor.js
+++ b/packages/react-dev-utils/launchEditor.js
@@ -285,6 +285,8 @@ function printInstructions(fileName, errorMessage) {
 
 let _childProcess = null;
 function launchEditor(fileName, lineNumber, colNumber) {
+  // supoort absolute file path
+  fileName = path.relative(process.cwd(), fileName);
   if (!fs.existsSync(fileName)) {
     return;
   }


### PR DESCRIPTION
## Summary
To supoort react devtools launch editor feature https://github.com/facebook/react/pull/20821

![launchEditor](https://user-images.githubusercontent.com/14012511/107875836-0f746680-6efd-11eb-899b-c22a7b1f7d60.gif)

## Current issues
When we develop a react project in `DEV`, we can get the component source file path by `source`, (but it's abosulte path usually, react-dev-utils not support currently.)
```js
 * @param {*} source An annotation object (added by a transpiler or otherwise)
 * indicating filename, line number, and/or other information.
 * @internal
 */
const ReactElement = function(type, key, ref, self, source, owner, props) {
```
#### for example
`/Users/username/code/src/app.tsx` 🙅‍♂️
`/src/app.tsx`  👌

## support custom launchEditorEndpoint
![2021-02-16 12 34 52](https://user-images.githubusercontent.com/14012511/108018695-6ab86d00-7053-11eb-9719-a0d1fa792a87.png)


Do we need change these hard code for `launchEditorEndpoint` ???
```diff
- // TODO: we might want to make this injectable to support DEV-time non-root URLs.
- module.exports = '/__open-stack-frame-in-editor';
+ const LaunchEditorEndpoint = process.env.LAUNCH_EDITOR_ENDPOINT ?? '/__open-stack-frame-in-editor';
+ module.exports = LaunchEditorEndpoint;
```
So we can inject custom `LaunchEditorEndpoint` by node process env.
```json
"start": "LAUNCH_EDITOR_ENDPOINT=/__open-in-editor react-scripts start"
```
## Test Plan
Please tell me how to test this change ? necessary unit test will be added later when I figure out how to test it.

## append
Welcome any suggestion. 😄  This is a `draft` pull request, not the final pull request.
