### PR TITLE
chore: set react-logo not to be selected

### DIFF
--- a/packages/cra-template/template/src/App.css
+++ b/packages/cra-template/template/src/App.css
@@ -10,6 +10,7 @@
 @media (prefers-reduced-motion: no-preference) {
   .App-logo {
     animation: App-logo-spin infinite 20s linear;
+    user-select: none;
   }
 }
 


### PR DESCRIPTION
Avoid the react-logo being selected like below.

![logo-was-selected](https://github.com/luwuer/create-react-app/blob/images-repo/images/logo-no-selected.gif?raw=true)