### PR TITLE
feat: allow custom jsxImportSource

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -93,10 +93,13 @@ module.exports = function (api, opts, env) {
           // Adds component stack to warning messages
           // Adds __self attribute to JSX which React will use for some warnings
           development: isEnvDevelopment || isEnvTest,
+          runtime: opts.runtime || 'classic',
           // Will use the native built-in instead of trying to polyfill
           // behavior for any plugins that require one.
           ...(opts.runtime !== 'automatic' ? { useBuiltIns: true } : {}),
-          runtime: opts.runtime || 'classic',
+          ...(opts.runtime === 'automatic' && opts.importSource != null
+            ? { importSource: opts.importSource }
+            : {}),
         },
       ],
       isTypeScriptEnabled && [require('@babel/preset-typescript').default],

--- a/packages/react-scripts/config/jest/babelTransform.js
+++ b/packages/react-scripts/config/jest/babelTransform.js
@@ -22,6 +22,7 @@ const hasJsxRuntime = (() => {
     return false;
   }
 })();
+const jsxImportSource = process.env.JSX_IMPORT_SOURCE;
 
 module.exports = babelJest.createTransformer({
   presets: [
@@ -29,6 +30,7 @@ module.exports = babelJest.createTransformer({
       require.resolve('babel-preset-react-app'),
       {
         runtime: hasJsxRuntime ? 'automatic' : 'classic',
+        ...(jsxImportSource ? { importSource: jsxImportSource } : {}),
       },
     ],
   ],

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -86,6 +86,7 @@ const hasJsxRuntime = (() => {
     return false;
   }
 })();
+const jsxImportSource = process.env.JSX_IMPORT_SOURCE;
 
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
@@ -414,6 +415,9 @@ module.exports = function (webpackEnv) {
                     require.resolve('babel-preset-react-app'),
                     {
                       runtime: hasJsxRuntime ? 'automatic' : 'classic',
+                      ...(jsxImportSource
+                        ? { importSource: jsxImportSource }
+                        : {}),
                     },
                   ],
                 ],

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -250,6 +250,14 @@ function verifyTypeScriptSetup() {
     }
   }
 
+  if (parsedCompilerOptions.jsxImportSource != null) {
+    if (hasJsxRuntime && semver.gte(ts.version, '4.1.0-beta')) {
+      if (process.env.JSX_IMPORT_SOURCE == null) {
+        process.env.JSX_IMPORT_SOURCE = parsedCompilerOptions.jsxImportSource;
+      }
+    }
+  }
+
   // tsconfig will have the merged "include" and "exclude" by this point
   if (parsedTsConfig.include == null) {
     appTsConfig = immer(appTsConfig, config => {

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -218,7 +218,7 @@ function verifyTypeScriptSetup() {
   if (appTsConfig.compilerOptions == null) {
     appTsConfig.compilerOptions = {};
     firstTimeSetup = true;
-  } 
+  }
 
   for (const option of Object.keys(compilerOptions)) {
     const { parsedValue, value, suggested, reason } = compilerOptions[option];
@@ -255,6 +255,19 @@ function verifyTypeScriptSetup() {
       if (process.env.JSX_IMPORT_SOURCE == null) {
         process.env.JSX_IMPORT_SOURCE = parsedCompilerOptions.jsxImportSource;
       }
+    } else {
+      appTsConfig = immer(appTsConfig, config => {
+        delete config.compilerOptions.jsxImportSource;
+      });
+      messages.push(
+        `${chalk.cyan(
+          'compilerOptions.jsxImportSource'
+        )} removed (requires ${chalk.bold(
+          'babel react runtime'
+        )} to be ${chalk.cyan.bold('automatic')} and ${chalk.bold(
+          'typescript'
+        )} version ${chalk.cyan.bold('>=4.1.0-beta')})`
+      );
     }
   }
 


### PR DESCRIPTION
### PR content
This PR allows configuring a custom value for the `importSource` option of `@babel/preset-react`.

TypeScript users can set the corresponding compiler option `jsxImportSource` in `tsconfig.json` (introduced in TypeScript 4.1) to configure the JSX import source.
The compiler option will be removed if from `tsconfig.json` if Babel won't use it.

JavaScript users, or TypeScript users that want to override `tsconfig.json`, can set the environment variable `JSX_IMPORT_SOURCE`.

### Motivation

This PR implements the feature request motivated in https://github.com/facebook/create-react-app/issues/9847 (Emotion without pragma + consistency between tsconfig and Babel) and supersedes the implementations of two existing pull requests https://github.com/facebook/create-react-app/pull/10138 ([why-did-you-render](https://github.com/welldone-software/why-did-you-render), Preact) and https://github.com/facebook/create-react-app/pull/10580.

While this project tries to avoid flags, there are some considerations that might make the case for an exception: the limited logic, the parallel in the implementation with the react runtime heuristic, the assistance to TypeScript users and the benefits of the feature for React users (e.g. ease of use of libraries like Emotion, compatibility with developer tooling like why-did-you-render).

### Test plan

I tested with a React + TypeScript + Emotion setup (`compilerOptions.jsxImportSource` set to `"@emotion/react"`).

- With the published version, the css prop is not transformed to classes.
- With this branch, the css prop is correctly transformed to classes
- When called with `JSX_IMPORT_SOURCE=react` the result is the same again as with the published version (because the environment variable takes precedence)
- When the requirements for this feature are not met, a message is added to the list of tsconfig changes and `jsxImportSource` is removed

<img width="920" alt="Screenshot 2021-02-20 at 17 06 55" src="https://user-images.githubusercontent.com/3393736/108601971-d7a76c00-739f-11eb-8e91-1e41e438c865.png">
