### PR TITLE
react-dev-utils bump to immer 8.0.1

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -65,7 +65,7 @@
     "global-modules": "2.0.0",
     "globby": "11.0.1",
     "gzip-size": "5.1.1",
-    "immer": "7.0.9",
+    "immer": "8.0.1",
     "is-root": "2.1.0",
     "loader-utils": "2.0.0",
     "open": "^7.0.2",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Upgrade immer version to 8.0.1 to fix potential security issue reported for devs dependencies using old versions
