### PR TITLE
Upgrade eslint-webpack-plugin to fix opt-out flag

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -759,7 +759,7 @@ module.exports = function (webpackEnv) {
           extensions: ['js', 'mjs', 'jsx', 'ts', 'tsx'],
           formatter: require.resolve('react-dev-utils/eslintFormatter'),
           eslintPath: require.resolve('eslint'),
-          emitWarning: isEnvDevelopment && emitErrorsAsWarnings,
+          failOnError: !(isEnvDevelopment && emitErrorsAsWarnings),
           context: paths.appSrc,
           cache: true,
           cacheLocation: path.resolve(

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-testing-library": "^3.9.2",
-    "eslint-webpack-plugin": "^2.1.0",
+    "eslint-webpack-plugin": "^2.5.2",
     "file-loader": "6.1.1",
     "fs-extra": "^9.0.1",
     "html-webpack-plugin": "4.5.0",


### PR DESCRIPTION
An update to `eslint-webpack-plugin` broke behaviour of the new flag (`ESLINT_NO_DEV_ERRORS`) that allowed users to opt-out of ESLint errors during development.

Since that time, another change was made that allows us to have similar behaviour to before.
- https://github.com/webpack-contrib/eslint-webpack-plugin/pull/72#issuecomment-773706538
- https://github.com/webpack-contrib/eslint-webpack-plugin/pull/85

With this new version of the plugin, we can now show errors in the terminal as errors - but as we've just rolled out the previous change, it made more sense to just fix the behaviour today. We can look at how to improve this further in future iterations.

Closes #9887.