### PR TITLE
Shouldn't the const braces be removed to make it work properly?

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -95,7 +95,7 @@ module.exports = function(app) {
 You can now register proxies as you wish! Here's an example using the above `http-proxy-middleware`:
 
 ```js
-const { createProxyMiddleware } = require('http-proxy-middleware');
+const createProxyMiddleware = require('http-proxy-middleware');
 
 module.exports = function(app) {
   app.use(


### PR DESCRIPTION


It works fine after removing the braces.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
After removing curly braces in works well
<img width="640" alt="Works well2" src="https://user-images.githubusercontent.com/39605922/109417128-9d744500-7a05-11eb-8390-5f668b85858a.PNG">
<img width="344" alt="Works well" src="https://user-images.githubusercontent.com/39605922/109416646-e676ca00-7a02-11eb-9428-c358e77caf2e.PNG">

If I run the command(yarn start) without removing the curly braces I get the following output
<img width="640" alt="Works bad" src="https://user-images.githubusercontent.com/39605922/109416712-42415300-7a03-11eb-933e-80eee040f512.PNG">
