### PR TITLE
Update fast sass loader

### DIFF
--- a/packages/react-scripts/README-imodeljs.md
+++ b/packages/react-scripts/README-imodeljs.md
@@ -1,0 +1,33 @@
+# Information About iModel.js Specific Fork
+
+This README is intended to cover the differences between the iModel.js specific fork and how it relates to the upstream of [Create-React-App](https://github.com/facebook/create-react-app).
+
+Current upstream with `react-scripts@3.4.1`.
+
+## Differences
+
+- Support for iModel.js Extensions
+
+  - In order to support iModel.js Extensions, the "IModeljsLibraryExportsPlugin" webpack plugin from the "@bentley/webpack-tools-core" package is added to the webpack configuration.
+  - Added "@bentley/webpack-tools-core" to [package.json](./packages/react-scripts/package.json)
+  - Added the "IModeljsLibraryExportsPlugin" into the "plugins" section of the rawConfig.
+
+- Additional configuration options
+
+  > Note: These configuration variables are an extension of the [Advanced Configurations](create-react-app.dev/docs/advanced-configuration) supported by create-react-app.
+
+  | Variable                | Development | Production | Usage                                                                                                                                                                    |
+  | ----------------------- | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+  | USE_FAST_SASS           | ✅ Used     | ✅ Used    | When set to `true`, use the fast-sass-loader instead of sass-loader. This helps with long build times on smaller machines attempting to build an app with a large amount of scss/sass files. |
+  | DEBUG_BUILD_PERFORMANCE | ✅ Used     | 🚫 Ignored | When set to `true`, reports webpack build performance and bottlenecks. Uses the [speed measure webpack plugin](https://www.npmjs.com/package/speed-measure-webpack-plugin).                  |
+  | USE_FULL_SOURCEMAP | ✅ Used     | 🚫 Ignored | When set to `true`, the sourcemaps generated use 'source-map' instead of 'cheap-module-source-map'. This is known to cause out-of-memory errors but gives full fidelity source maps in debug builds.|
+- Typing changes
+
+  - By default, typescript tests are not type checked causing issue when trying to compile them later.
+  - Update the Jest configuration to support type checking
+    - In 'packages/react-scripts/scripts/utils/createJestConfig.js',
+      - add a global to the config for 'ts-jest'
+      - add a new transform for ts and tsx files for ts-jest
+
+- Support `imjs_` prefixed environment variables
+  - iModel.js places special significance on environment variables starting with `imjs_`. The `REACT_APP_` functionality has been extended to include the `imjs_` as well.

--- a/packages/react-scripts/README-imodeljs.md
+++ b/packages/react-scripts/README-imodeljs.md
@@ -16,11 +16,12 @@ Current upstream with `react-scripts@3.4.1`.
 
   > Note: These configuration variables are an extension of the [Advanced Configurations](create-react-app.dev/docs/advanced-configuration) supported by create-react-app.
 
-  | Variable                | Development | Production | Usage                                                                                                                                                                    |
-  | ----------------------- | ----------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-  | USE_FAST_SASS           | ✅ Used     | ✅ Used    | When set to `true`, use the fast-sass-loader instead of sass-loader. This helps with long build times on smaller machines attempting to build an app with a large amount of scss/sass files. |
-  | DEBUG_BUILD_PERFORMANCE | ✅ Used     | 🚫 Ignored | When set to `true`, reports webpack build performance and bottlenecks. Uses the [speed measure webpack plugin](https://www.npmjs.com/package/speed-measure-webpack-plugin).                  |
-  | USE_FULL_SOURCEMAP | ✅ Used     | 🚫 Ignored | When set to `true`, the sourcemaps generated use 'source-map' instead of 'cheap-module-source-map'. This is known to cause out-of-memory errors but gives full fidelity source maps in debug builds.|
+  | Variable                | Development | Production | Usage                                                                                                                                                                                                |
+  | ----------------------- | ----------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | USE_FAST_SASS           | ✅ Used     | ✅ Used    | When set to `true`, use the fast-sass-loader instead of sass-loader. This helps with long build times on smaller machines attempting to build an app with a large amount of scss/sass files.         |
+  | DEBUG_BUILD_PERFORMANCE | ✅ Used     | 🚫 Ignored | When set to `true`, reports webpack build performance and bottlenecks. Uses the [speed measure webpack plugin](https://www.npmjs.com/package/speed-measure-webpack-plugin).                          |
+  | USE_FULL_SOURCEMAP      | ✅ Used     | 🚫 Ignored | When set to `true`, the sourcemaps generated use 'source-map' instead of 'cheap-module-source-map'. This is known to cause out-of-memory errors but gives full fidelity source maps in debug builds. |
+
 - Typing changes
 
   - By default, typescript tests are not type checked causing issue when trying to compile them later.
@@ -31,3 +32,26 @@ Current upstream with `react-scripts@3.4.1`.
 
 - Support `imjs_` prefixed environment variables
   - iModel.js places special significance on environment variables starting with `imjs_`. The `REACT_APP_` functionality has been extended to include the `imjs_` as well.
+
+## Updating with upstream facebook/create-react-app
+
+1. Push upstream `master` to imodeljs `master`, there should _never_ be any conflicts. (Request an admin to do this when opening the PR in the next step)
+   ```sh
+   git remote add upstream https://github.com/facebook/create-react-app.git
+   git fetch upstream
+   git checkout master
+   git merge upstream/master
+   git push
+   ```
+1. Update `imodeljs` branch with new imodeljs `master`
+   a.
+   ```sh
+   git checkout imodeljs
+   git checkout -b merge-with-master
+   git merge origin/master
+   ```
+   b. Resolve merge conflicts
+   c. Set the version of react-scripts to `-dev.0` of whatever is incoming from `master`
+   c. Commit, push and open PR
+
+> Note: The main reason to create a PR branch is to have a linear first-parent history for all explicit changes to our branch instead of directly pushing overtop of them all. That way it's an explicit merge commit instead of a fast-forward merge.

--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -1,6 +1,8 @@
-# react-scripts
+# @bentley/react-scripts
 
-This package includes scripts and configuration used by [Create React App](https://github.com/facebook/create-react-app).<br>
+This is the iModel.js fork of react-scripts. Visit our [README](https://github.com/imodeljs/create-react-app/blob/imodeljs/packages/react-scripts/README-imodeljs.md) for information about the fork and the reason behind it.
+
+This package includes scripts and configuration used by [Create React App](https://github.com/imodeljs/create-react-app).<br>
 Please refer to its documentation:
 
 - [Getting Started](https://facebook.github.io/create-react-app/docs/getting-started) – How to create a new app.

--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -66,11 +66,13 @@ process.env.NODE_PATH = (process.env.NODE_PATH || '')
 
 // Grab NODE_ENV and REACT_APP_* environment variables and prepare them to be
 // injected into the application via DefinePlugin in webpack configuration.
+// NOTE: iModel.js change:  In addition to the other env. variables, grab imjs_* variables as well.
 const REACT_APP = /^REACT_APP_/i;
+const IMODELJS_APP = /^imjs_/i;
 
 function getClientEnvironment(publicUrl) {
   const raw = Object.keys(process.env)
-    .filter(key => REACT_APP.test(key))
+    .filter(key => REACT_APP.test(key) || IMODELJS_APP.test(key))
     .reduce(
       (env, key) => {
         env[key] = process.env[key];

--- a/packages/react-scripts/config/jest/babelTransform.js
+++ b/packages/react-scripts/config/jest/babelTransform.js
@@ -15,5 +15,9 @@ module.exports = babelJest.createTransformer({
   configFile: false,
   // With the added support for svg-sprites using the resource query '?sprite', this
   // plugin is needed to remove the query for imports during tests.
-  plugins: ['babel-plugin-import-remove-resource-query'],
+  // Adding the second plugin so tests don't break if some package decides to use raw-loader
+  plugins: [
+    'babel-plugin-import-remove-resource-query',
+    ['strip-requirejs-plugin-prefix', { plugin: 'raw-loader' }],
+  ],
 });

--- a/packages/react-scripts/config/jest/babelTransform.js
+++ b/packages/react-scripts/config/jest/babelTransform.js
@@ -13,4 +13,7 @@ module.exports = babelJest.createTransformer({
   presets: [require.resolve('babel-preset-react-app')],
   babelrc: false,
   configFile: false,
+  // With the added support for svg-sprites using the resource query '?sprite', this
+  // plugin is needed to remove the query for imports during tests.
+  plugins: ['babel-plugin-import-remove-resource-query'],
 });

--- a/packages/react-scripts/config/modules.js
+++ b/packages/react-scripts/config/modules.js
@@ -20,6 +20,10 @@ const resolve = require('resolve');
  * @param {Object} options
  */
 function getAdditionalModulePaths(options = {}) {
+  if (process.env.RELATIVE_MODULE_PATH) {
+    return [path.resolve(process.cwd() + process.env.RELATIVE_MODULE_PATH)];
+  }
+
   const baseUrl = options.baseUrl;
 
   // We need to explicitly check for null and undefined (and not a falsy value) because

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -692,7 +692,7 @@ module.exports = function(webpackEnv) {
       new CopyBentleyStaticResourcesPlugin(['public'], true),
 
       // NOTE: FilterWarningsPlugin is used to ignore warning coming from sourcemaps
-      new FilterWarningsPlugin({ exclude: /Cannot find source file/ }),
+      new FilterWarningsPlugin({ exclude: /Failed to parse source map/ }),
 
       // NOTE: HtmlWebpackPlugin, and InterpolateHtmlPlugin are injected here
       // after SpeedMeasureWebpackPlugin makes a wrapper, so SMWP won't track them

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -61,7 +61,10 @@ module.exports = function(proxy, allowedHost) {
     // for files like `favicon.ico`, `manifest.json`, and libraries that are
     // for some reason broken when imported through webpack. If you just want to
     // use an image, put it in `src` and `import` it from JavaScript instead.
-    contentBase: paths.appPublic,
+
+    // NOTE: iModel.js specific change to include both the 'public' directory and the
+    // 'build/public' directory.
+    contentBase: [paths.appPublic, paths.appBuild],
     contentBasePublicPath: paths.publicUrlOrPath,
     // By default files from `contentBase` will not trigger a page reload.
     watchContentBase: true,

--- a/packages/react-scripts/lib/react-app.d.ts
+++ b/packages/react-scripts/lib/react-app.d.ts
@@ -46,6 +46,14 @@ declare module '*.svg' {
     SVGSVGElement
   > & { title?: string }>;
 
+  export const sprite: string;
+
+  const src: string;
+  export default src;
+}
+
+// iModel.js Change: Add support for SVG Sprites.
+declare module '*.svg?sprite' {
   const src: string;
   export default src;
 }

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "react-scripts",
+  "name": "@bentley/react-scripts",
   "version": "3.4.1",
-  "description": "Configuration and scripts for Create React App.",
+  "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/create-react-app.git",
+    "url": "https://github.com/imodeljs/create-react-app.git",
     "directory": "packages/react-scripts"
   },
   "license": "MIT",
@@ -12,7 +12,7 @@
     "node": ">=8.10"
   },
   "bugs": {
-    "url": "https://github.com/facebook/create-react-app/issues"
+    "url": "https://github.com/imodeljs/create-react-app/issues"
   },
   "files": [
     "bin",
@@ -29,12 +29,14 @@
   "types": "./lib/react-app.d.ts",
   "dependencies": {
     "@babel/core": "7.9.0",
+    "@bentley/webpack-tools-core": "^2.0.0",
     "@svgr/webpack": "4.3.3",
     "@typescript-eslint/eslint-plugin": "^2.10.0",
     "@typescript-eslint/parser": "^2.10.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "^24.9.0",
     "babel-loader": "8.1.0",
+    "babel-plugin-import-remove-resource-query": "^1.0.0",
     "babel-plugin-named-asset-import": "^0.3.6",
     "babel-preset-react-app": "^9.1.2",
     "camelcase": "^5.3.1",
@@ -50,6 +52,7 @@
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "^1.6.1",
+    "fast-sass-loader": "^1.5.0",
     "file-loader": "4.3.0",
     "fs-extra": "^8.1.0",
     "html-webpack-plugin": "4.0.0-beta.11",
@@ -72,12 +75,17 @@
     "resolve-url-loader": "3.1.1",
     "sass-loader": "8.0.2",
     "semver": "6.3.0",
+    "source-map-loader": "^0.2.3",
+    "speed-measure-webpack-plugin": "^1.3.1",
     "style-loader": "0.23.1",
+    "svg-sprite-loader": "4.2.1",
     "terser-webpack-plugin": "2.3.5",
+    "ts-jest": "^24.2.0",
     "ts-pnp": "1.1.6",
     "url-loader": "2.3.0",
     "webpack": "4.42.0",
     "webpack-dev-server": "3.10.3",
+    "webpack-filter-warnings-plugin": "^1.2.1",
     "webpack-manifest-plugin": "2.2.0",
     "workbox-webpack-plugin": "4.3.1"
   },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",
@@ -79,12 +79,12 @@
     "speed-measure-webpack-plugin": "^1.3.1",
     "style-loader": "0.23.1",
     "svg-sprite-loader": "4.2.1",
-    "terser-webpack-plugin": "2.3.5",
+    "terser-webpack-plugin": "3.0.7",
     "ts-jest": "^24.2.0",
     "ts-pnp": "1.1.6",
     "url-loader": "2.3.0",
     "webpack": "4.42.0",
-    "webpack-dev-server": "3.10.3",
+    "webpack-dev-server": "3.11.0",
     "webpack-filter-warnings-plugin": "^1.2.1",
     "webpack-manifest-plugin": "2.2.0",
     "workbox-webpack-plugin": "4.3.1"

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "3.4.5",
+  "version": "3.4.6",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",
@@ -73,7 +73,7 @@
     "react-app-polyfill": "^1.0.6",
     "react-dev-utils": "^10.2.1",
     "resolve": "1.15.0",
-    "resolve-url-loader": "3.1.1",
+    "resolve-url-loader": "3.1.2",
     "sass-loader": "8.0.2",
     "semver": "6.3.0",
     "source-map-loader": "^1.0.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "3.4.3",
+  "version": "3.4.3-dev.0",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",
@@ -38,6 +38,7 @@
     "babel-loader": "8.1.0",
     "babel-plugin-import-remove-resource-query": "^1.0.0",
     "babel-plugin-named-asset-import": "^0.3.6",
+    "babel-plugin-strip-requirejs-plugin-prefix": "1.0.0",
     "babel-preset-react-app": "^9.1.2",
     "camelcase": "^5.3.1",
     "case-sensitive-paths-webpack-plugin": "2.3.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -53,7 +53,7 @@
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.19.0",
     "eslint-plugin-react-hooks": "^1.6.1",
-    "fast-sass-loader": "^1.5.0",
+    "fast-sass-loader": "^2.0.0",
     "file-loader": "4.3.0",
     "fs-extra": "^8.1.0",
     "html-webpack-plugin": "4.0.0-beta.11",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -75,7 +75,7 @@
     "resolve-url-loader": "3.1.1",
     "sass-loader": "8.0.2",
     "semver": "6.3.0",
-    "source-map-loader": "^0.2.3",
+    "source-map-loader": "^1.0.0",
     "speed-measure-webpack-plugin": "^1.3.1",
     "style-loader": "0.23.1",
     "svg-sprite-loader": "4.2.1",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "3.4.3-dev.0",
+  "version": "3.4.4",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bentley/react-scripts",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "iModel.js configuration and scripts for Create React App.",
   "repository": {
     "type": "git",
@@ -31,8 +31,8 @@
     "@babel/core": "7.9.0",
     "@bentley/webpack-tools-core": "^2.0.0",
     "@svgr/webpack": "4.3.3",
-    "@typescript-eslint/eslint-plugin": "^2.10.0",
-    "@typescript-eslint/parser": "^2.10.0",
+    "@typescript-eslint/eslint-plugin": "^4.1.1",
+    "@typescript-eslint/parser": "^4.1.1",
     "babel-eslint": "10.1.0",
     "babel-jest": "^24.9.0",
     "babel-loader": "8.1.0",

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -57,7 +57,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
       ),
     },
     transformIgnorePatterns: [
-      '[/\\\\]node_modules[/\\\\](?!@bentley/ui).+\\.(js|jsx|ts|tsx)$',
+      '[/\\\\]node_modules[/\\\\](?!@bentley).+\\.(js|jsx|ts|tsx)$',
       '^.+\\.module\\.(css|sass|scss)$',
     ],
     modulePaths: modules.additionalModulePaths || [],

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -39,8 +39,16 @@ module.exports = (resolve, rootDir, isEjecting) => {
       '<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}',
     ],
     testEnvironment: 'jest-environment-jsdom-fourteen',
+    globals: {
+      'ts-jest': {
+        tsConfig: {
+          jsx: 'react',
+        },
+      },
+    },
     transform: {
-      '^.+\\.(js|jsx|ts|tsx)$': isEjecting
+      '^.+\\.(ts|tsx)$': 'ts-jest',
+      '^.+\\.(js|jsx)$': isEjecting
         ? '<rootDir>/node_modules/babel-jest'
         : resolve('config/jest/babelTransform.js'),
       '^.+\\.css$': resolve('config/jest/cssTransform.js'),
@@ -49,7 +57,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
       ),
     },
     transformIgnorePatterns: [
-      '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$',
+      '[/\\\\]node_modules[/\\\\](?!@bentley/ui).+\\.(js|jsx|ts|tsx)$',
       '^.+\\.module\\.(css|sass|scss)$',
     ],
     modulePaths: modules.additionalModulePaths || [],

--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -256,7 +256,7 @@ function verifyTypeScriptSetup() {
   if (!fs.existsSync(paths.appTypeDeclarations)) {
     fs.writeFileSync(
       paths.appTypeDeclarations,
-      `/// <reference types="react-scripts" />${os.EOL}`
+      `/// <reference types="@bentley/react-scripts" />${os.EOL}`
     );
   }
 }


### PR DESCRIPTION
Update to version 2.0.0 of `fast-sass-loader`.

Version 2 introduces support for `dart-sass`, which means it may finally be an option for us again.  I did some initial testing and it looks like switching back to fast-sass-loader (w/ dart-sass) should speedup ui-test-app builds by more than 2x.