### PR TITLE
print a stack if setupProxy.js doesn't parse

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -175,7 +175,9 @@ checkBrowsers(paths.appPath, isInteractive)
     }
   })
   .catch(err => {
-    if (err && err.message) {
+    if (err && err.stack) {
+      console.log(err.stack);
+    } else if (err && err.message) {
       console.log(err.message);
     }
     process.exit(1);


### PR DESCRIPTION
Before, `npm start` would say this:

```
Unexpected token '?'
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! ui@0.1.0 start: `react-scripts start`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the ui@0.1.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/slamb/.npm/_logs/2021-03-04T20_50_38_776Z-debug.log
```

(The logfile isn't helpful; it doesn't even say the `Unexpected token
'?'` part.)

After, the `Unexpected token '?'` line is replaced with the following:

```
/home/slamb/git/moonfire-nvr/ui/src/setupProxy.js:13
      target: process.env.PROXY_TARGET ?? "http://localhost:8080/",
                                        ^

SyntaxError: Unexpected token '?'
    at wrapSafe (internal/modules/cjs/loader.js:1054:16)
    at Module._compile (internal/modules/cjs/loader.js:1102:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Module.load (internal/modules/cjs/loader.js:986:32)
    at Function.Module._load (internal/modules/cjs/loader.js:879:14)
    at Module.require (internal/modules/cjs/loader.js:1026:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.before (/home/slamb/git/moonfire-nvr/ui/node_modules/react-scripts/config/webpackDevServer.config.js:123:9)
    at Server.setupBeforeFeature (/home/slamb/git/moonfire-nvr/ui/node_modules/webpack-dev-server/lib/Server.js:455:18)
    at Object.before (/home/slamb/git/moonfire-nvr/ui/node_modules/webpack-dev-server/lib/Server.js:515:16)
```

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
