### PR TITLE
feat: add testPathIgnorePatterns override option to createJestConfig

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -203,6 +203,7 @@ Supported overrides:
 - [`restoreMocks`](https://jestjs.io/docs/en/configuration#restoremocks-boolean)
 - [`snapshotSerializers`](https://jestjs.io/docs/en/configuration.html#snapshotserializers-array-string)
 - [`testMatch`](https://jestjs.io/docs/en/configuration#testmatch-arraystring)
+- [`testPathIgnorePatterns`](https://jestjs.io/docs/configuration#testpathignorepatterns-arraystring)
 - [`transform`](https://jestjs.io/docs/en/configuration.html#transform-object-string-pathtotransformer-pathtotransformer-object)
 - [`transformIgnorePatterns`](https://jestjs.io/docs/en/configuration.html#transformignorepatterns-array-string)
 - [`watchPathIgnorePatterns`](https://jestjs.io/docs/en/configuration.html#watchpathignorepatterns-array-string)

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -88,6 +88,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'restoreMocks',
     'snapshotSerializers',
     'testMatch',
+    'testPathIgnorePatterns',
     'transform',
     'transformIgnorePatterns',
     'watchPathIgnorePatterns',


### PR DESCRIPTION
This PR is a follow-up from: https://github.com/facebook/create-react-app/pull/9473#discussion_r468993013

I've had a few situations where it would have been helpful to have the `testPathIgnorePatterns` as an override option - a few users on StackOverflow also ran into the same: https://stackoverflow.com/a/55634512/5237070).