### PR TITLE
Fix dependencies in cra typescript template

### DIFF
--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -1,6 +1,9 @@
 {
   "package": {
     "dependencies": {
+      "web-vitals": "^1.0.1"
+    },
+    "devDependencies":{
       "@testing-library/jest-dom": "^5.11.4",
       "@testing-library/react": "^11.1.0",
       "@testing-library/user-event": "^12.1.10",
@@ -8,8 +11,7 @@
       "@types/react": "^17.0.0",
       "@types/react-dom": "^17.0.0",
       "@types/jest": "^26.0.15",
-      "typescript": "^4.1.2",
-      "web-vitals": "^1.0.1"
+      "typescript": "^4.1.2"
     },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]


### PR DESCRIPTION
Hi there, 

under `packages > cra-template-typescript > template.json`, I moved some packages from production to `devDependencies`, since they are only needed for local development and testing environment.

From:
![image](https://user-images.githubusercontent.com/44829778/111243316-faead180-8654-11eb-93d1-a28bec9ae61d.png)

To:
![image](https://user-images.githubusercontent.com/44829778/111242348-1654dd00-8653-11eb-80b0-8f4c662481dd.png)

Thanks