### PR TITLE
make @babel, browserslist versions ^

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -52,9 +52,9 @@
     "webpackHotDevClient.js"
   ],
   "dependencies": {
-    "@babel/code-frame": "7.10.4",
+    "@babel/code-frame": "^7.10.4",
     "address": "1.1.2",
-    "browserslist": "4.14.2",
+    "browserslist": "^4.14.2",
     "chalk": "2.4.2",
     "cross-spawn": "7.0.3",
     "detect-port-alt": "1.1.6",


### PR DESCRIPTION
Babel, and browserlist are well maintained open source project, thus propose to make versions less explicit or use ^ so that developers have less duplication.