### PR TITLE
Updated webpack and webpack-dev-server version

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -83,8 +83,8 @@
     "terser-webpack-plugin": "4.2.3",
     "ts-pnp": "1.2.0",
     "url-loader": "4.1.1",
-    "webpack": "4.44.2",
-    "webpack-dev-server": "3.11.1",
+    "webpack": "5.28.0",
+    "webpack-dev-server": "3.11.2",
     "webpack-manifest-plugin": "3.0.0",
     "workbox-webpack-plugin": "5.1.4"
   },


### PR DESCRIPTION
Trying to fix the issue #10740 which causes error while starting the local server because react-scripts package contains the old version of webpack.
And if you have webpack installed on your machine this would cause errors to start local server

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
