### PR TITLE
Configure checkForLatestVersion to call version API of npmjs.org using https proxy (if available)

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -1126,7 +1126,6 @@ function executeNodeScript({ cwd, args }, data, source) {
 function checkForLatestVersion() {
   return new Promise((resolve, reject) => {
     let proxy = getProxy();
-    console.log(proxy);
     let agent = proxy ? new httpsProxyAgent(proxy) : https.globalAgent;
     https
       .get(

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -30,6 +30,7 @@
 'use strict';
 
 const https = require('https');
+const httpsProxyAgent = require('https-proxy-agent');
 const chalk = require('chalk');
 const commander = require('commander');
 const dns = require('dns');
@@ -1124,9 +1125,15 @@ function executeNodeScript({ cwd, args }, data, source) {
 
 function checkForLatestVersion() {
   return new Promise((resolve, reject) => {
+    let proxy = getProxy();
+    console.log(proxy);
+    let agent = proxy ? new httpsProxyAgent(proxy) : https.globalAgent;
     https
       .get(
         'https://registry.npmjs.org/-/package/create-react-app/dist-tags',
+        {
+          agent: agent
+        },
         res => {
           if (res.statusCode === 200) {
             let body = '';

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -39,7 +39,8 @@
     "semver": "7.3.2",
     "tar-pack": "3.4.1",
     "tmp": "0.2.1",
-    "validate-npm-package-name": "3.0.0"
+    "validate-npm-package-name": "3.0.0",
+    "https-proxy-agent": "5.0.0"
   },
   "devDependencies": {
     "cross-env": "^7.0.2",


### PR DESCRIPTION
The create-react-app release hangs when run behind a https proxy, as the` checkForLatestVersion()` function tries to connect to https://registry.npmjs.org/-/package/create-react-app/dist-tags without using proxies.

The proposed patch uses the already available function `getProxy()` which reads the https proxy configuration from the environment variable `https_proxy` and, if not set, from npm configuration.

The patch introduces a dependency from the module [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent).
