### PR TITLE
wrap scripts into dom loaded event listener if defer is specified

### DIFF
--- a/packages/react-dev-utils/InlineChunkHtmlPlugin.js
+++ b/packages/react-dev-utils/InlineChunkHtmlPlugin.js
@@ -27,7 +27,11 @@ class InlineChunkHtmlPlugin {
     if (asset == null) {
       return tag;
     }
-    return { tagName: 'script', innerHTML: asset.source(), closeTag: true };
+    let source = asset.source();
+    if (tag.attributes.defer) {
+      source = `window.addEventListener('DOMContentLoaded', function () { ${source} })`;
+    }
+    return { tagName: 'script', innerHTML: source, closeTag: true };
   }
 
   apply(compiler) {


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Fixes #10752

This PR add a branch to detect what if `defer` attribute has been specified on script tag or not.
And if so, All script will be wrapped into a `DOMContentLoaded` event listener.

Here's an example for the changes:

We have a script:
```js
alert(document.body.innerText);
```

And a html tmeplate:
```html
<html>
    <body>
        <div>foo</div>
    </body>
</html>
```

And a webpack config:
```js
module.exports = {
    entry: './index.js',
    output: {
        path: path.resolve(__dirname, 'dist'),
        filename: 'index.js'
    },
    plugins: [
        new HtmlWebpackPlugin({
          inject: true,
          template: 'index.html'
        }),
        new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/.*/])
    ]
}
```


**Before changes:**

```html
<html>
<head>
    <script>alert(document.body.innerText);</script>
</head>
<body>
    <div>foo</div>
</body>
</html>
```
And It will caused an exception:
```
Uncaught TypeError: Cannot read property 'innerText' of null
```

** before changes with blocking **

```html
<html>
<body>
    <div>foo</div>
    <script>alert(document.body.innerText);</script>
</body>
</html>
```
That works fine.


**After changes (whatever blocking or not):**

```html
<html>
<body>
    <div>foo</div>
    <script>alert(document.body.innerText);</script>
</body>
</html>
```

And everything works fine.