### PR TITLE
Updated cmd command for running coverage test

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -176,7 +176,7 @@ Similarly, `fit()` lets you focus on a specific test without running any other t
 
 Jest has an integrated coverage reporter that works well with ES6 and requires no configuration.
 
-Run `npm test -- --coverage` (note extra `--` in the middle) to include a coverage report like this:
+Run `npm test -- --coverage --watchAll=false` (note extra `--` in the middle) to include a coverage report like this:
 
 ![coverage report](https://i.imgur.com/5bFhnTS.png)
 


### PR DESCRIPTION
Coverage tests don't work when in the default watch mode, so watchAll=false must be set to get the correct coverage results.
This isn't clearly documented, and this change includes that command.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
