### PR TITLE
Update html-entities and use module flow types.

### DIFF
--- a/packages/react-error-overlay/.flowconfig
+++ b/packages/react-error-overlay/.flowconfig
@@ -2,7 +2,6 @@
 <PROJECT_ROOT>/src/**/*.js
 
 [ignore]
-.*/node_modules/.*
 .*/.git/.*
 .*/__test__/.*
 .*/fixtures/.*

--- a/packages/react-error-overlay/flow/env.js
+++ b/packages/react-error-overlay/flow/env.js
@@ -6,10 +6,6 @@ declare module '@babel/code-frame' {
   declare module.exports: any;
 }
 
-declare module 'html-entities' {
-  declare module.exports: any;
-}
-
 declare module 'settle-promise' {
   declare module.exports: any;
 }

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-testing-library": "^3.9.2",
     "flow-bin": "^0.116.0",
-    "html-entities": "1.3.1",
+    "html-entities": "^2.3.0",
     "jest": "26.6.0",
     "jest-fetch-mock": "2.1.2",
     "object-assign": "4.1.1",

--- a/packages/react-error-overlay/src/utils/generateAnsiHTML.js
+++ b/packages/react-error-overlay/src/utils/generateAnsiHTML.js
@@ -8,10 +8,8 @@
 /* @flow */
 
 import Anser from 'anser';
-import { AllHtmlEntities as Entities } from 'html-entities';
+import { encode } from 'html-entities';
 import type { Theme } from '../styles';
-
-const entities = new Entities();
 
 // Map ANSI colors from what babel-code-frame uses to base16-github
 // See: https://github.com/babel/babel/blob/e86f62b304d280d0bab52c38d61842b853848ba6/packages/babel-code-frame/src/index.js#L9-L22
@@ -45,7 +43,7 @@ const anserMap = {
 };
 
 function generateAnsiHTML(txt: string, theme: Theme): string {
-  const arr = new Anser().ansiToJson(entities.encode(txt), {
+  const arr = new Anser().ansiToJson(encode(txt), {
     use_classes: true,
   });
 


### PR DESCRIPTION
Hello, here is the list of changes:

1. `html-entities` library was updated to the latest stable version.
2. Flow types from `html-entities` were used instead of the local override.