### PR TITLE
Fix error importing `createProxyMiddleware` function

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -85,7 +85,7 @@ $ yarn add http-proxy-middleware
 Next, create `src/setupProxy.js` and place the following contents in it:
 
 ```js
-const { createProxyMiddleware } = require('http-proxy-middleware');
+const createProxyMiddleware = require('http-proxy-middleware');
 
 module.exports = function(app) {
   // ...
@@ -95,7 +95,7 @@ module.exports = function(app) {
 You can now register proxies as you wish! Here's an example using the above `http-proxy-middleware`:
 
 ```js
-const { createProxyMiddleware } = require('http-proxy-middleware');
+const createProxyMiddleware = require('http-proxy-middleware');
 
 module.exports = function(app) {
   app.use(


### PR DESCRIPTION
When the `createProxyMiddleware` function is imported with curly braces ({}) like this:
` const { createProxyMiddleware } = require('http-proxy-middleware');`

it causes following error:
`createProxyMiddleware is not a function`

The `createProxyMiddleware` function works when imported without curly braces ({}):
`const createProxyMiddleware = require('http-proxy-middleware');`

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
