### PR TITLE
Install `http-proxy-middleware` as dev dependency

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -74,12 +74,12 @@ If the `proxy` option is **not** flexible enough for you, you can get direct acc
 
 You can use this feature in conjunction with the `proxy` property in `package.json`, but it is recommended you consolidate all of your logic into `src/setupProxy.js`.
 
-First, install `http-proxy-middleware` using npm or Yarn:
+First, install `http-proxy-middleware` as a development dependency using npm or Yarn:
 
 ```sh
-$ npm install http-proxy-middleware --save
+$ npm install http-proxy-middleware --save-dev
 $ # or
-$ yarn add http-proxy-middleware
+$ yarn add http-proxy-middleware --dev
 ```
 
 Next, create `src/setupProxy.js` and place the following contents in it:


### PR DESCRIPTION
Install the `http-proxy-middleware` development server as a development dependency instead than a general dependency. As specified in the official documentation:
https://github.com/chimurai/http-proxy-middleware#install

I installed it like this and it's working.
