### PR TITLE
fix: remove unused React imports from typescript template

### DIFF
--- a/packages/cra-template-typescript/template/src/App.test.tsx
+++ b/packages/cra-template-typescript/template/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 

--- a/packages/cra-template-typescript/template/src/App.tsx
+++ b/packages/cra-template-typescript/template/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 


### PR DESCRIPTION
React imports can be removed from React 17.x.y