### PR TITLE
Remove outdated comments on react-refresh

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -94,8 +94,6 @@ function getClientEnvironment(publicUrl) {
         WDS_SOCKET_PATH: process.env.WDS_SOCKET_PATH,
         WDS_SOCKET_PORT: process.env.WDS_SOCKET_PORT,
         // Whether or not react-refresh is enabled.
-        // react-refresh is not 100% stable at this time,
-        // which is why it's disabled by default.
         // It is defined here so it is available in the webpackHotDevClient.
         FAST_REFRESH: process.env.FAST_REFRESH !== 'false',
       }

--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -97,7 +97,7 @@ function getClientEnvironment(publicUrl) {
         // react-refresh is not 100% stable at this time,
         // which is why it's disabled by default.
         // It is defined here so it is available in the webpackHotDevClient.
-        FAST_REFRESH: process.env.FAST_REFRESH === 'true',
+        FAST_REFRESH: process.env.FAST_REFRESH !== 'false',
       }
     );
   // Stringify all values so we can feed into webpack DefinePlugin

--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -97,7 +97,7 @@ function getClientEnvironment(publicUrl) {
         // react-refresh is not 100% stable at this time,
         // which is why it's disabled by default.
         // It is defined here so it is available in the webpackHotDevClient.
-        FAST_REFRESH: process.env.FAST_REFRESH !== 'false',
+        FAST_REFRESH: process.env.FAST_REFRESH === 'true',
       }
     );
   // Stringify all values so we can feed into webpack DefinePlugin


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Related Issue: https://github.com/facebook/create-react-app/issues/9984#
Without `FAST_REFRESH=false`, auto reload on `src/index.js` does not work. 

According to comment, `react-refresh` should be disabled by default.
This commit changes default value of `process.env.FAST_REFRESH`.

For testing
`$ yarn create-react-app path/to/app`.
Edit `path/to/app/src/index.js`.

