### PR TITLE
Bump immer version for fixing security issue

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -65,7 +65,7 @@
     "global-modules": "2.0.0",
     "globby": "11.0.1",
     "gzip-size": "5.1.1",
-    "immer": "8.0.1",
+    "immer": "8.0.4",
     "is-root": "2.1.0",
     "loader-utils": "2.0.0",
     "open": "^7.0.2",


### PR DESCRIPTION
Bump immer minor version to fix `Prototype Pollution` Security issue.

![image](https://user-images.githubusercontent.com/28918386/113871927-03a47280-97d1-11eb-9f61-13cb8d22861b.png)

