### PR TITLE
feat(babel-preset-react-app): add support for logical assignment

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -189,6 +189,7 @@ module.exports = function (api, opts, env) {
       // See https://github.com/facebook/create-react-app/issues/8445#issuecomment-588512250
       require('@babel/plugin-proposal-optional-chaining').default,
       require('@babel/plugin-proposal-nullish-coalescing-operator').default,
+      require('@babel/plugin-proposal-logical-assignment-operators').default,
     ].filter(Boolean),
     overrides: [
       isFlowEnabled && {

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -24,6 +24,7 @@
     "@babel/core": "7.12.3",
     "@babel/plugin-proposal-class-properties": "7.12.1",
     "@babel/plugin-proposal-decorators": "7.12.1",
+    "@babel/plugin-proposal-logical-assignment-operators": "7.13.8",
     "@babel/plugin-proposal-nullish-coalescing-operator": "7.12.1",
     "@babel/plugin-proposal-numeric-separator": "7.12.1",
     "@babel/plugin-proposal-optional-chaining": "7.12.1",

--- a/packages/react-scripts/fixtures/kitchensink/template/integration/syntax.test.js
+++ b/packages/react-scripts/fixtures/kitchensink/template/integration/syntax.test.js
@@ -88,6 +88,14 @@ describe('Integration', () => {
       );
     });
 
+    it('logical assignment', async () => {
+      doc = await initDOM('logical-assignment');
+
+      expect(
+        doc.getElementById('feature-logical-assignment').childElementCount
+      ).toBe(4);
+    });
+
     it('object destructuring', async () => {
       doc = await initDOM('object-destructuring');
 

--- a/packages/react-scripts/fixtures/kitchensink/template/src/App.js
+++ b/packages/react-scripts/fixtures/kitchensink/template/src/App.js
@@ -166,6 +166,11 @@ class App extends Component {
           this.setFeature(f.default)
         );
         break;
+      case 'logical-assignment':
+        import('./features/syntax/LogicalAssignment').then(f =>
+          this.setFeature(f.default)
+        );
+        break;
       case 'no-ext-inclusion':
         import('./features/webpack/NoExtInclusion').then(f =>
           this.setFeature(f.default)

--- a/packages/react-scripts/fixtures/kitchensink/template/src/features/syntax/LogicalAssignment.js
+++ b/packages/react-scripts/fixtures/kitchensink/template/src/features/syntax/LogicalAssignment.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+function load() {
+  return [
+    { id: 1, name: '1' },
+    { id: 2, name: '2' },
+    { id: 3, name: '3' },
+    { id: 4, name: '4' },
+  ];
+}
+
+export default class LogicalAssignment extends Component {
+  static propTypes = {
+    onReady: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { users: [] };
+  }
+
+  async componentDidMount() {
+    const users = load();
+    this.setState({ users });
+  }
+
+  componentDidUpdate() {
+    this.props.onReady();
+  }
+
+  render() {
+    return (
+      <div id="feature-logical-assignment">
+        {this.state.users.map(user => {
+          user.name ??= 'unknown name';
+          return <div key={user.id}>{user.name}</div>;
+        })}
+      </div>
+    );
+  }
+}

--- a/packages/react-scripts/fixtures/kitchensink/template/src/features/syntax/LogicalAssignment.test.js
+++ b/packages/react-scripts/fixtures/kitchensink/template/src/features/syntax/LogicalAssignment.test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import LogicalAssignment from './LogicalAssignment';
+
+describe('logical assignment', () => {
+  it('renders without crashing', () => {
+    const div = document.createElement('div');
+    return new Promise(resolve => {
+      ReactDOM.render(<LogicalAssignment onReady={resolve} />, div);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

This change adds support for logical assignment operators into `babel-preset-react-app`.
I have also updated E2E tests inside `react-scripts` so I can test it by running `./tasks/local-test.sh --test-suite kitchensink`.
This is the only way I could test it. When I tried running all E2E tests it failed when publishing to local repository inside this test suite.