### PR TITLE
Update setting-up-your-editor.md

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -116,13 +116,13 @@ Prettier is an opinionated code formatter with support for JavaScript, CSS and J
 To format our code whenever we make a commit in git, we need to install the following dependencies:
 
 ```sh
-npm install --save husky lint-staged prettier
+npm install --save husky@4.3.8 lint-staged prettier
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add husky lint-staged prettier
+yarn add husky@4.3.8 lint-staged prettier
 ```
 
 - `husky` makes it possible to use githooks as if they are npm scripts.


### PR DESCRIPTION
specify husky to use version 4 because version 6 is configured differently. More here: https://typicode.github.io/husky/#/?id=migrate-from-v4-to-v6

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
