### PR TITLE
Simplify babel plugin option logic

### DIFF
--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -95,7 +95,7 @@ module.exports = function (api, opts, env) {
           development: isEnvDevelopment || isEnvTest,
           // Will use the native built-in instead of trying to polyfill
           // behavior for any plugins that require one.
-          ...(opts.runtime !== 'automatic' ? { useBuiltIns: true } : {}),
+          useBuiltIns: opts.runtime !== 'automatic',
           runtime: opts.runtime || 'classic',
         },
       ],


### PR DESCRIPTION
Just simplifying an overcomplicated condition in `babel-preset-react-app`.

Default value for `useBuiltIns` is `false`.
https://babeljs.io/docs/en/babel-preset-react#usebuiltins