### PR TITLE
docs: note in Changelog that v3→v4 requires adding eslintConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,13 @@ Like any major release, `react-scripts@4.0.0` contains a number of breaking chan
 
 We've upgraded to ESLint 7 and added many new rules including some for Jest and React Testing Library as well as the `import/no-anonymous-default-export` rule. We've also upgraded `eslint-plugin-hooks` to version 4.0.0 and removed the `EXTEND_ESLINT` flag as it is no longer required to customize the ESLint config.
 
+In particular, you'll need to add the following to `package.json` for ESLint to continue to work:
+```js
+"eslintConfig": {
+  "extends": ["react-app", "react-app/jest"]
+},
+```
+
 ### Jest
 
 We've upgraded to Jest 26 and now set `resetMocks` to `true` by default in the Jest config.


### PR DESCRIPTION
I came across this when trying to upgrade my company's create-react-app from v3→v4. The migration path doesn't note that you will lose ESLint capabilities unless you specify `eslintConfig` explicitly in your `package.json` going forward.

Historical progression of ESLint changes in Webpack, to clarify how we got here:
- removal of original extend and addition to `template.json`: https://github.com/facebook/create-react-app/pull/9587/files
- referencing of /base instead of /index: https://github.com/facebook/create-react-app/pull/9640/files#diff-8e25c4f6f592c1fcfc38f0d43d62cbd68399f44f494c1b60f0cf9ccd7344d697R366

This was also noticed by other developers in these bugs:
https://github.com/facebook/create-react-app/issues/9791
https://github.com/facebook/create-react-app/issues/10212

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
