### PR TITLE
allow tsconfig to contain emitDeclarationOnly=true

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -144,7 +144,6 @@ function verifyTypeScriptSetup() {
     },
     resolveJsonModule: { value: true, reason: 'to match webpack loader' },
     isolatedModules: { value: true, reason: 'implementation limitation' },
-    noEmit: { value: true },
     jsx: {
       parsedValue:
         hasJsxRuntime && semver.gte(ts.version, '4.1.0-beta')
@@ -220,6 +219,11 @@ function verifyTypeScriptSetup() {
     firstTimeSetup = true;
   }
 
+  if (parsedCompilerOptions['emitDeclarationOnly'] != null) {
+    compilerOptions['emitDeclarationOnly'] = { value: true };
+  } else {
+    compilerOptions['noEmit'] = { value: true };
+  }
   for (const option of Object.keys(compilerOptions)) {
     const { parsedValue, value, suggested, reason } = compilerOptions[option];
 


### PR DESCRIPTION
Fixes #10796 
Fixes #9373
Fixes #8551

[Typescript project references](https://www.typescriptlang.org/docs/handbook/project-references.html) are a useful feature in a monorepo that allow building sub-packages incrementally and don't require a rebuild of a dependency to get up-to date type information in the editor of that dependency.

However, for it to work, some fields need to be set in the tsconfig: `composite: true, incremental: true, emitDeclarationOnly: true` the last one is a problem because typescript errors when there is a field for `noEmit` and for `emitDeclarationOnly`. This PR inspect the users' config, and if they already have a `emitDeclarationOnly`, it needs to be set to the value true and if they don't the current behaviour is kept. 

I've tried copying this file to my local project's node_modules and now I can add `emitDeclarationOnly` without a problem (and thus without react-scripts overwriting my tsconfig)