### PR TITLE
Bumped postcss-normalize to v10

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -68,7 +68,7 @@
     "postcss": "8.2.4",
     "postcss-flexbugs-fixes": "5.0.2",
     "postcss-loader": "4.2.0",
-    "postcss-normalize": "9.0.0",
+    "postcss-normalize": "^10.0.0",
     "postcss-preset-env": "6.7.0",
     "postcss-safe-parser": "5.0.2",
     "prompts": "2.4.0",


### PR DESCRIPTION
postcss-normalize@10.0.0 was [released](https://github.com/csstools/postcss-normalize/releases/tag/10.0.0) with support for PostCSS 8

We should bump it after merging #10456


