### PR TITLE
feat: Add testResultsProcessor to supported Jest keys

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -206,6 +206,7 @@ Supported overrides:
 - [`transform`](https://jestjs.io/docs/en/configuration.html#transform-object-string-pathtotransformer-pathtotransformer-object)
 - [`transformIgnorePatterns`](https://jestjs.io/docs/en/configuration.html#transformignorepatterns-array-string)
 - [`watchPathIgnorePatterns`](https://jestjs.io/docs/en/configuration.html#watchpathignorepatterns-array-string)
+- [`testResultsProcessor`](https://jestjs.io/docs/en/configuration#testresultsprocessor-string)
 
 Example package.json:
 

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -91,6 +91,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
     'transform',
     'transformIgnorePatterns',
     'watchPathIgnorePatterns',
+    'testResultsProcessor',
   ];
   if (overrides) {
     supportedKeys.forEach(key => {


### PR DESCRIPTION
Adds [`testResultsProcessor`](https://jestjs.io/docs/en/configuration#testresultsprocessor-string) to the supported keys for Jest. This will allow uses of create-react-app to specify which test result processor they want to use, to promote compatibility with common CI tools like Bamboo and TeamCity.

Fixes #882, #2474, #2824, #6224
Related to #7832