### PR TITLE
When generating asset-manifest.json compute all entrypoints

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -703,8 +703,14 @@ module.exports = function (webpackEnv) {
             manifest[file.name] = file.path;
             return manifest;
           }, seed);
-          const entrypointFiles = entrypoints.main.filter(
-            fileName => !fileName.endsWith('.map')
+          const entrypointFiles = Object.keys(entrypoints).reduce(
+            (entrypointFiles, entryName) => {
+              entrypointFiles[entryName] = entrypoints[entryName].filter(
+                fileName => !fileName.endsWith('.map')
+              );
+              return entrypointFiles;
+            },
+            {}
           );
 
           return {


### PR DESCRIPTION
Even though CRA by default only generates `main` entrypoint there is no strong reason to only compute this information for that very entrypoint. This will make it easier for people who eject and need this feature for multiple entrypoints.