### PR TITLE
Fix Issue 9904: Fast Refresh env var always set to true

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -95,7 +95,7 @@ function getClientEnvironment(publicUrl) {
         WDS_SOCKET_PORT: process.env.WDS_SOCKET_PORT,
         // Whether or not react-refresh is enabled.
         // It is defined here so it is available in the webpackHotDevClient.
-        FAST_REFRESH: process.env.FAST_REFRESH !== 'false',
+        FAST_REFRESH: (!!process.env.FAST_REFRESH) !== false,
       }
     );
   // Stringify all values so we can feed into webpack DefinePlugin

--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -95,7 +95,7 @@ function getClientEnvironment(publicUrl) {
         WDS_SOCKET_PORT: process.env.WDS_SOCKET_PORT,
         // Whether or not react-refresh is enabled.
         // It is defined here so it is available in the webpackHotDevClient.
-        FAST_REFRESH: (!!process.env.FAST_REFRESH) !== false,
+        FAST_REFRESH: (!!process.env.FAST_REFRESH) || false,
       }
     );
   // Stringify all values so we can feed into webpack DefinePlugin


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Hot reloading was not working with React "^17.0.1", in my case I had v17.0.2.
See Issue #9904.

## Copied from my comment on that issue:

For my system at least, this was down to a minor error of boolean logic in the CRA config.

This is what **config/env.js** looks like by default for v4 of CRA in Typescript:
```
// Whether or not react-refresh is enabled.
// react-refresh is not 100% stable at this time,
// which is why it's disabled by default.
// It is defined here so it is available in the webpackHotDevClient.
FAST_REFRESH: process.env.FAST_REFRESH !== 'false',
```
This can never result in `FAST_REFRESH` being set to `false`, for two reasons.

#### Boolean logic
<img width="226" alt="Screen Shot 2021-05-16 at 3 19 17 pm" src="https://user-images.githubusercontent.com/2941824/118386352-335d5a80-b65a-11eb-8494-ae5ae0e9e2a2.png">

If `FAST_REFRESH` is undefined, as it will be for most people here, then **config/env.js** will set it to true, even though the intention here is to set it to false by default. It's just a mistake of boolean logic.

#### Strings are truthy
If that error were not present, we would still not have `FAST_REFRESH` disabled by default. The default value is not being set to the boolean value of `false`, it is being set to the string `'false'`. So if evaluated as a boolean, it will be interpreted as truthy, and give a true value.
<img width="238" alt="Screen Shot 2021-05-16 at 3 22 39 pm" src="https://user-images.githubusercontent.com/2941824/118386410-a8c92b00-b65a-11eb-9783-873d1d5c232b.png">

This is why setting `FAST_REFRESH=false` in the dotfiles worked for so many people, wheras the disabled-by-default config didn't. They were setting entirely different values. I don't know why it didn't work for everyone, possibly a difference of dependency versions or OS.

#### Fix
The solution is to convert the environment variable to a boolean before trying to evaluate it as one, and _then_ using a boolean for false instead of a string, and using an OR operator:
```
FAST_REFRESH: (!!process.env.FAST_REFRESH) || false
```
