### PR TITLE
fix(react-scripts): disable custom TS PnP resolve for Yarn >= 2

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -747,10 +747,14 @@ module.exports = function (webpackEnv) {
           }),
           async: isEnvDevelopment,
           checkSyntacticErrors: true,
-          resolveModuleNameModule: process.versions.pnp
-            ? `${__dirname}/pnpTs.js`
-            : undefined,
-          resolveTypeReferenceDirectiveModule: process.versions.pnp
+          // Needed to support Yarn PnP for Yarn 1, Yarn >= 2 adds PnP support
+          // to TypeScript automatically
+          resolveModuleNameModule: process.versions.pnp === '1'
+          ? `${__dirname}/pnpTs.js`
+          : undefined,
+          // Needed to support Yarn PnP for Yarn 1, Yarn >= 2 adds PnP support
+          // to TypeScript automatically
+          resolveTypeReferenceDirectiveModule: process.versions.pnp === '1'
             ? `${__dirname}/pnpTs.js`
             : undefined,
           tsconfig: paths.appTsConfig,


### PR DESCRIPTION
**What's the problem this PR addresses?**

Importing `.json` files causes TypeScript builds to fail with
```
TypeScript error in /path/to/project/src/App.tsx(4,18):
Cannot find module './foo.json' or its corresponding type declarations.  TS2307
```

Fixes https://github.com/facebook/create-react-app/issues/9172
Fixes https://github.com/facebook/create-react-app/issues/10455

**How did you fix it?**

Disabled the custom resolve provided to `ForkTsCheckerWebpackPlugin` when using Yarn >= 2. This fixes the issue since Yarn 2+ adds support for PnP directly to TypeScript which has access to the correct `compilerOptions`, the one passed to `ts-pnp` is an empty object.