### PR TITLE
updating src/setupTests.js example

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -154,7 +154,7 @@ const localStorageMock = {
   removeItem: jest.fn(),
   clear: jest.fn(),
 };
-global.localStorage = localStorageMock;
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
 ```
 
 > Note: Keep in mind that if you decide to "eject" before creating `src/setupTests.js`, the resulting `package.json` file won't contain any reference to it, so you should manually create the property `setupFilesAfterEnv` in the configuration for Jest, something like the following:


### PR DESCRIPTION
Updating the assignment localStorageMock to the 'global' object in example.

The mock object is not set correctly when the assignment operator ('=') is used.  When running the test below with the previous 'src/setupTest.js' example, I get the error "window.localStorage.getItem.mockReturnValue is not a function."  When 'Object.defineProperty' replaces the assignment in 'src/setupTest.js,' the test passes.

```
import '@testing-library/jest-dom';
import { render, screen } from '@testing-library/react';

it('should get the item', () => {
    const MockComponent = () => (
        <p>{global.localStorage.getItem('test')}</p>
    );
    const expected = 'juicy';
    global.localStorage.getItem.mockReturnValue(expected);
    render(<MockComponent />);
    const element = screen.getByText(expected);
    expect(element).toBeInTheDocument();
    expect(global.localStorage.getItem).toBeCalled();
});
```
