### PR TITLE
Fixed issue where resolve-url-loader would not work on Windows due to CRLF.

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -9,6 +9,7 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const webpack = require('webpack');
 const resolve = require('resolve');
@@ -92,6 +93,7 @@ const hasJsxRuntime = (() => {
 module.exports = function (webpackEnv) {
   const isEnvDevelopment = webpackEnv === 'development';
   const isEnvProduction = webpackEnv === 'production';
+  const isWindows = os.platform() === 'win32';
 
   // Variable used for enabling profiling in Production
   // passed into alias object. Uses a flag if passed into the build command
@@ -157,6 +159,7 @@ module.exports = function (webpackEnv) {
           options: {
             sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
             root: paths.appSrc,
+            removeCR: isWindows,
           },
         },
         {


### PR DESCRIPTION
Fixed issue where resolve-url-loader would not work on Windows due to removeCR not being specified on Windows machines. This fixes #8596

I've been unable to get create-react-app working inside this repo to test (even in WSL), but I have replaced the webpack in an existing project's `node_modules/react-scripts` which resolved the issues in that project.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
