### PR TITLE
[suggestion] Change "Remove" to "Delete" so as not to be confused with running "yarn remove" to remove the dependency

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyPackageTree.js
+++ b/packages/react-scripts/scripts/utils/verifyPackageTree.js
@@ -117,7 +117,7 @@ function verifyPackageTree() {
             `  ${chalk.cyan('2.')} Delete ${chalk.bold(
               'node_modules'
             )} in your project folder.\n` +
-            `  ${chalk.cyan('3.')} Remove "${chalk.bold(
+            `  ${chalk.cyan('3.')} Delete "${chalk.bold(
               dep
             )}" from ${chalk.bold('dependencies')} and/or ${chalk.bold(
               'devDependencies'


### PR DESCRIPTION
When going through the steps in the **verifyPackageTree.js** file, one might try to run `yarn remove` to remove the dependency, but really the user should manually delete the text entry from the list of [dev] dependencies. If you try `yarn` remove after deleting **yarn.lock** file, you will get a "No lockfile in this directory" error (this is what I did -- oops 😅  ).

I think changing "Remove" to "Delete" makes this more clear.