### PR TITLE
Coerce Node versions with metadata

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -236,7 +236,12 @@ function init() {
 }
 
 function createApp(name, verbose, version, template, useNpm, usePnp) {
-  const unsupportedNodeVersion = !semver.satisfies(process.version, '>=10');
+  const unsupportedNodeVersion = !semver.satisfies(
+    // Coerce strings with metadata (i.e. `15.0.0-nightly`).
+    semver.coerce(process.version),
+    '>=10'
+  );
+
   if (unsupportedNodeVersion) {
     console.log(
       chalk.yellow(


### PR DESCRIPTION
Coerces Node versions with metadata, to support `-nightly`, `-rc`, etc.

Closes #9614.