### PR TITLE
Add `homepage` example without the full domain

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -106,6 +106,8 @@ To override this, specify the `homepage` in your `package.json`, for example:
 
 ```js
   "homepage": "http://mywebsite.com/relativepath",
+  // or to support multiple different domains/environments:
+  "homepage": "/relativepath",
 ```
 
 This will let Create React App correctly infer the root path to use in the generated HTML file.


### PR DESCRIPTION
Consider 3 different possibilities for where an app will be deployed:

1. Deploying to just a single domain and path (e.g. always `example.com/my-app`)
2. Deploying to any arbitrary domain and path (e.g. `example.com/my-app` but also `random.com/blah`)
3. Deploying to multiple domains but always the same route (e.g. `example.com/my-app` and `test.example.com/my-app`)

Scenario 1 is well-documented at ["Deployment - Building for relative paths"](https://create-react-app.dev/docs/deployment/#building-for-relative-paths):

```
  "homepage": "http://mywebsite.com/relativepath",
```

Scenario 2 is well-documented at [Deployment - Serving the Same Build from Different Paths](https://create-react-app.dev/docs/deployment/#serving-the-same-build-from-different-paths), including the caveat that it breaks client-side routing:

```
  "homepage": ".",
```

Scenario 3 does not have a documented solution, despite it being the most common one in my experience. As far as I can tell, the following configuration works perfectly well:

```
  "homepage": "/relativepath",
```

But after much searching I haven't seen anywhere on the internet that mentions the ability to specify `homepage` with just a path and no domain.

This PR adds that example to the docs. 