### PR TITLE
Change source map loader use to array

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -379,7 +379,7 @@ module.exports = function (webpackEnv) {
           enforce: 'pre',
           exclude: /@babel(?:\/|\\{1,2})runtime/,
           test: /\.(js|mjs|jsx|ts|tsx|css)$/,
-          use: 'source-map-loader',
+          use: ['source-map-loader'],
         },
         {
           // "oneOf" will traverse all following loaders until one will


### PR DESCRIPTION
This follows up #8227 (re: [#issuecomment](https://github.com/facebook/create-react-app/pull/8227#issuecomment-859218638)) and fixes the config for `source-map-loader` to use an array for the `use` property.  This fixes compatibility with `customize-cra` and follows the recommended usage by `source-map-loader`'s docs.

Without this PR, `customize-cra` throws the error `e.use.some() is not a function`, because it assumes that the `use` property is an array if it is truthy.  This may be a normal expectation by webpack configurations, I'm not sure, but I think better compatibility is important.

I don't believe this change has any impact on anything else and just ensures best compatibility.

cc: @justingrant @mrmckeb 