### PR TITLE
fix: fast refresh stops on needed bail outs

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -245,9 +245,13 @@ function tryApplyUpdates(onHotUpdateSuccess) {
   function handleApplyUpdates(err, updatedModules) {
     // NOTE: This var is injected by Webpack's DefinePlugin, and is a boolean instead of string.
     const hasReactRefresh = process.env.FAST_REFRESH;
-    const wantsForcedReload = err || !updatedModules || hadRuntimeError;
+    const wantsErrorReload = err || hadRuntimeError;
+    const needsForcedReload = !updatedModules;
     // React refresh can handle hot-reloading over errors.
-    if (!hasReactRefresh && wantsForcedReload) {
+    // However, when updatedModules is falsy,
+    // it indicates the current update cannot be applied safely,
+    // and thus we should bail out to a forced reload for consistency.
+    if ((!hasReactRefresh && wantsErrorReload) || needsForcedReload) {
       window.location.reload();
       return;
     }

--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -230,6 +230,18 @@ function canApplyUpdates() {
   return module.hot.status() === 'idle';
 }
 
+function canAcceptErrors() {
+  // NOTE: This var is injected by Webpack's DefinePlugin, and is a boolean instead of string.
+  const hasReactRefresh = process.env.FAST_REFRESH;
+
+  const status = module.hot.status();
+  // React refresh can handle hot-reloading over errors.
+  // However, when hot-reload status is abort or fail,
+  // it indicates the current update cannot be applied safely,
+  // and thus we should bail out to a forced reload for consistency.
+  return hasReactRefresh && ["abort", "fail"].indexOf(status) === -1
+}
+
 // Attempt to update code on the fly, fall back to a hard reload.
 function tryApplyUpdates(onHotUpdateSuccess) {
   if (!module.hot) {
@@ -243,15 +255,13 @@ function tryApplyUpdates(onHotUpdateSuccess) {
   }
 
   function handleApplyUpdates(err, updatedModules) {
-    // NOTE: This var is injected by Webpack's DefinePlugin, and is a boolean instead of string.
-    const hasReactRefresh = process.env.FAST_REFRESH;
-    const wantsErrorReload = err || hadRuntimeError;
-    const needsForcedReload = !updatedModules;
-    // React refresh can handle hot-reloading over errors.
-    // However, when updatedModules is falsy,
-    // it indicates the current update cannot be applied safely,
-    // and thus we should bail out to a forced reload for consistency.
-    if ((!hasReactRefresh && wantsErrorReload) || needsForcedReload) {
+    const haveErrors = err || hadRuntimeError;
+    // When there is no error but updatedModules is unavailable,
+    // it indicates a critical failure in hot-reloading,
+    // e.g. server is not ready to serve new bundle,
+    // and hence we need to do a forced reload.
+    const needsForcedReload = !err && !updatedModules;
+    if ((haveErrors && !canAcceptErrors()) || needsForcedReload) {
       window.location.reload();
       return;
     }


### PR DESCRIPTION
Fast Refresh requires the HMR runtime to support bail out behaviour (we do not do so within the core runtime as it has to be platform agnostic) - and currently webpackHotDevClient does not do so properly as it circumvents the logic for forced reloads completely when using Fast Refresh.

The changes done here ensures that:
- If Fast Refresh is not enabled, we would always bail out to a forced reload;
- If Fast Refresh is enabled and there are updated modules, it indicates the update has at least partially executed, and we can rely on Fast Refresh being resilient to errors and skip the forced reload;
- If Fast Refresh is enabled and there are none updated modules, check for the status of the hot update. If it is `abort` or `failed`, it indicates the update cannot be executed without being inconsistent (i.e. Fast Refresh bailed out), we would bail out to a forced reload.

To verify the impact of this change:

- Start a new project with CRA v4, update `App.js` with multiple exports (e.g. pmmmwh/react-refresh-webpack-plugin#426)
- Run the project, try updating `App.js` with anything. Without this PR changes would not propagate on screen.
- With this PR, the page should force refresh and propagate the changes.

To verify addendum to this change (error recovery):

- Using the same project, remove extra exports in `App.js`
- Run the project, wait for the first compilation to complete
- Try adding a `throw new Error('no')` within the `App` component, compilation should show the error overlay
- Try removing the error within the component, `App` should HMR properly without forced refresh
- Try creating syntax errors within the module (e.g. remove quotation marks in imports), compilation should show the error overlay
- Try fixing the error, `App` should HMR properly without forced refresh

This should:
Fixes #9904
Fixes #9913
Fixes #9984
Fixes Partially #10078
Fixes #10287
Fixes #10539
Fixes #10606
Fixes #11087 