### PR TITLE
docs: Fix confusing section reference

### DIFF
--- a/docusaurus/docs/adding-images-fonts-and-files.md
+++ b/docusaurus/docs/adding-images-fonts-and-files.md
@@ -41,7 +41,7 @@ Please be advised that this is also a custom feature of webpack.
 
 **It is not required for React** but many people enjoy it (and React Native uses a similar mechanism for images).
 
-An alternative way of handling static assets is described in the next section.
+An alternative way of handling static assets is described in a later section on [using the public folder](using-the-public-folder.md).
 
 ## Adding SVGs
 


### PR DESCRIPTION
The "next section" mentioned in the note on an alternative way of handling static assets is no longer the section on using the public folder (a section on loading .graphql files is now the next section). This clarifies the previous wording and includes an explicit link to the relevant section.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
