### PR TITLE
feat: added dark and light mode support for codeblocks

### DIFF
--- a/docusaurus/website/docusaurus.config.js
+++ b/docusaurus/website/docusaurus.config.js
@@ -57,6 +57,11 @@ const siteConfig = {
         },
       ],
     },
+    prism: {
+      theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/dracula'),
+      defaultLanguage: 'javascript',
+    },
     footer: {
       style: 'dark',
       links: [


### PR DESCRIPTION
Thank you for sending the PR!

I have updated the website's code blocks part according to docusaurus new feature (prism) for adding and light and dark mode compatibility

**screen record earlier :** 

https://user-images.githubusercontent.com/40708551/123582044-b8f82c80-d7fa-11eb-847f-d83aacf52599.mov



**screen record of change**

https://user-images.githubusercontent.com/40708551/123581859-5ef76700-d7fa-11eb-8525-5d93454133c4.mov



Happy contributing!
