### PR TITLE
Upgrade sass-loader to ^11.1.1

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -77,7 +77,7 @@
     "react-refresh": "^0.8.3",
     "resolve": "1.18.1",
     "resolve-url-loader": "^3.1.2",
-    "sass-loader": "^10.0.5",
+    "sass-loader": "^11.1.1",
     "semver": "7.3.2",
     "source-map-loader": "^1.1.2",
     "style-loader": "1.3.0",


### PR DESCRIPTION
# Why

* Fix https://github.com/facebook/create-react-app/issues/10944

I couldn't find any test to check if something is wrong.
I don't see that much usage of `sass-loader`, which may implies that this change doesn't break anything.

The problem here is that `sass-loader` `v11` upgrades `node-sass` from `v5` to `v6`, which removes support for Node `v10`, which is a problem for `CRA` because the documentation says that it supports `=> 10.16`

Deeper explanation in https://github.com/facebook/create-react-app/issues/10944#issuecomment-869760083

Feel free to reject this PR if I'm missing something. Everything ran too smooth. It feels weird that works on the first try