### PR TITLE
Run npm with --no-audit

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -392,6 +392,7 @@ function install(root, useYarn, usePnp, dependencies, verbose, isOnline) {
       command = 'npm';
       args = [
         'install',
+        '--no-audit', // https://github.com/facebook/create-react-app/issues/11174
         '--save',
         '--save-exact',
         '--loglevel',

--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -297,7 +297,12 @@ module.exports = function (
   } else {
     command = 'npm';
     remove = 'uninstall';
-    args = ['install', '--save', verbose && '--verbose'].filter(e => e);
+    args = [
+      'install',
+      '--no-audit', // https://github.com/facebook/create-react-app/issues/11174
+      '--save',
+      verbose && '--verbose',
+    ].filter(e => e);
   }
 
   // Install additional template dependencies, if present.


### PR DESCRIPTION
This should improve the situation with https://github.com/facebook/create-react-app/issues/11174 somewhat.

These "audits" are pretty much always misleading for build tooling and get people into a hopeless rabbit hole of trying to work around issues that aren't real problems. Let's suppress the audit on the first run. The user can always do it themselves if they want to, but it's pretty much always misleading and harmful.