### PR TITLE
chore: updating typescript docs

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -35,7 +35,8 @@ yarn add typescript @types/node @types/react @types/react-dom @types/jest
 
 Next, rename any file to be a TypeScript file (e.g. `src/index.js` to `src/index.tsx`) and **restart your development server**!
 
-Type errors will show up in the same console as the build one. You'll have to fix these type errors before you continue development or build your project. For advanced configuration, [see here](advanced-configuration.md).
+Type errors will show up in the same console as the build one. You'll have to fix these type errors before you continue development or build your project. Many of them are fixed by adding `import React from 'react';` to your tsx files.
+For advanced configuration, [see here](advanced-configuration.md).
 
 ## Getting Started with TypeScript and React
 


### PR DESCRIPTION
When switching an existing starter to use typescript, the files did have many errors. When comparing that to a new starter the main difference that was not mentioned was the import of react. With that, all default tags are known. It's more convenient to mention it here, too.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
