### PR TITLE
Bump css-loader to 5.2.4 in packages/react-scripts/

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -41,7 +41,7 @@
     "bfj": "^7.0.2",
     "camelcase": "^6.1.0",
     "case-sensitive-paths-webpack-plugin": "2.3.0",
-    "css-loader": "4.3.0",
+    "css-loader": "5.2.4",
     "dotenv": "8.2.0",
     "dotenv-expand": "5.1.0",
     "eslint": "^7.11.0",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Updates dependency to make use `/* webpack-ignore */`

Co-authored-by: WalkerM <78025519+wlkrm@users.noreply.github.com>
