### PR TITLE
fix: remove @babel/eslint-parser verification when opting-out

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyPackageTree.js
+++ b/packages/react-scripts/scripts/utils/verifyPackageTree.js
@@ -23,13 +23,12 @@ function verifyPackageTree() {
     // These are packages most likely to break in practice.
     // See https://github.com/facebook/create-react-app/issues/1795 for reasons why.
     // I have not included Babel here because plugins typically don't import Babel (so it's not affected).
-    '@babel/eslint-parser',
     'babel-jest',
     'babel-loader',
     'jest',
     'webpack',
     'webpack-dev-server',
-    isESLintPluginEnabled && 'babel-eslint',
+    isESLintPluginEnabled && '@babel/eslint-parser',
     isESLintPluginEnabled && 'eslint',
   ].filter(Boolean);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

This PR is a follow-up to #10761, essentially porting #10499 on top of it.

The CI is failing because `babel-eslint` is no longer in `package.json` of `react-scripts`: https://github.com/facebook/create-react-app/runs/3069230016