### PR TITLE
Update start.js

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -126,7 +126,7 @@ checkBrowsers(paths.appPath, isInteractive)
       webpack,
     });
     // Load proxy config
-    const proxySetting = require(paths.appPackageJson).proxy;
+    const proxySetting = process.env.PROXY || require(paths.appPackageJson).proxy;
     const proxyConfig = prepareProxy(
       proxySetting,
       paths.appPublic,


### PR DESCRIPTION
Allow specifying proxySetting via environment variable as well as by property in package.json

The proxy setting is an all or nothing affair and I have to explain to other devs on my team how to remove the proxy from the package.json file when they try to run in dev mode without a proxy. This is a little tiny change that allows setting a current configuration setting as an environment variable as well as in package.json, so technically I'm not ADDING a configuration. 😄 

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
