### PR TITLE
Fix: Update browserslist for resolving npm(ReDoS) vulnerability

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.10.4",
     "address": "1.1.2",
-    "browserslist": "4.14.2",
+    "browserslist": "^4.16.6",
     "chalk": "2.4.2",
     "cross-spawn": "7.0.3",
     "detect-port-alt": "1.1.6",


### PR DESCRIPTION
Bumping browserslist to 4.16.6 for resolving npm vulnerability ["Regular Expression Denial of Service"](https://www.npmjs.com/advisories/1747)
