### PR TITLE
fix(ModuleScopePlugin): support pnp in workspaces

### DIFF
--- a/packages/react-dev-utils/ModuleScopePlugin.js
+++ b/packages/react-dev-utils/ModuleScopePlugin.js
@@ -35,6 +35,12 @@ class ModuleScopePlugin {
         ) {
           return callback();
         }
+        if (process.versions.pnp) {
+          const {findPackageLocator} = require('pnpapi');
+          if (findPackageLocator(request.__innerRequest_request) !== null) {
+            return callback();
+          }
+        }
         // Resolve the issuer from our appSrc and make sure it's one of our files
         // Maybe an indexOf === 0 would be better?
         if (


### PR DESCRIPTION
Fixes #10508, #9226, #8757

I cannot take credit for this fix - @Xerkus wrote it here:
https://github.com/facebook/create-react-app/issues/10508#issuecomment-829266760

I am only PR'ing this as yarn2 lists create-react-app as compatible with PnP, but create-react-app does not work with workspaces .. kind of funny considering create-react-app is a yarn workspace itself :)

Verified by adding resolution on react-dev-utils: "https://github.com/facebook/create-react-app/issues/10508#issuecomment-829266760"

![image](https://user-images.githubusercontent.com/13755626/126577576-28c0c8d3-8ca1-42cf-9558-fbf2910f4a18.png)
