### PR TITLE
Update browserslist dependancy version

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.10.4",
     "address": "1.1.2",
-    "browserslist": "4.14.2",
+    "browserslist": "^4.16.5",
     "chalk": "2.4.2",
     "cross-spawn": "7.0.3",
     "detect-port-alt": "1.1.6",


### PR DESCRIPTION
"browserslist" was updated to 4.16.5  to fix the "Regular Expression Denial of Service" vulnerability
Find more info @ https://www.npmjs.com/advisories/1747
