### PR TITLE
fix: dependency issue after workbox-webpack-plugin 6.2 release

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -73,7 +73,7 @@
     "webpack": "5.41.1",
     "webpack-dev-server": "4.0.0-rc.0",
     "webpack-manifest-plugin": "3.1.1",
-    "workbox-webpack-plugin": "6.2.0"
+    "workbox-webpack-plugin": "6.2.4"
   },
   "devDependencies": {
     "react": "^17.0.1",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -73,7 +73,7 @@
     "webpack": "5.41.1",
     "webpack-dev-server": "4.0.0-rc.0",
     "webpack-manifest-plugin": "3.1.1",
-    "workbox-webpack-plugin": "6.1.5"
+    "workbox-webpack-plugin": "6.2.0"
   },
   "devDependencies": {
     "react": "^17.0.1",


### PR DESCRIPTION
The latest release of `workbox-build` is not being pulled by `react-scripts` due to an explicit dependency on `workbox-webpack-plugin@6.1.5`.

Since there are no breaking changes mentioned in the Workbox [releases notes](https://github.com/GoogleChrome/workbox/releases/tag/v6.2.0), this PR updated the version to `6.2.0`