### PR TITLE
update Visual Studio Code debug config

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -78,9 +78,9 @@ Then add the block below to your `launch.json` file and put it inside the `.vsco
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Chrome",
-      "type": "chrome",
+      "name": "Attach to Chrome",
       "request": "launch",
+      "type": "pwa-chrome",
       "url": "http://localhost:3000",
       "webRoot": "${workspaceFolder}/src",
       "sourceMapPathOverrides": {


### PR DESCRIPTION
the [vscode-chrome-debug](https://github.com/microsoft/vscode-chrome-debug) has been deprecated as Visual Studio Code now has a bundled JavaScript Debugger that covers the same functionality.

> This extension has been deprecated as Visual Studio Code now has a bundled JavaScript Debugger that covers the same functionality. It is a debugger that debugs Node.js, Chrome, Edge, WebView2, VS Code extensions, and more. You can safely un-install this extension and you will still be able to have the functionality you need.

so the configuaration of  `launch.json` must be change for work properly.
