### PR TITLE
fix: workbox-webpack-plugin comes with a wrong workbox-build version

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -73,7 +73,8 @@
     "webpack": "5.41.1",
     "webpack-dev-server": "4.0.0-rc.0",
     "webpack-manifest-plugin": "3.1.1",
-    "workbox-webpack-plugin": "6.1.2"
+    "workbox-webpack-plugin": "6.1.5",
+    "workbox-build": "6.1.5"
   },
   "devDependencies": {
     "react": "^17.0.1",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -73,7 +73,7 @@
     "webpack": "5.41.1",
     "webpack-dev-server": "4.0.0-rc.0",
     "webpack-manifest-plugin": "3.1.1",
-    "workbox-webpack-plugin": "6.1.5"
+    "workbox-webpack-plugin": "6.1.2"
   },
   "devDependencies": {
     "react": "^17.0.1",


### PR DESCRIPTION
Hey everybody

workbox-webpack-plugin messed up the dependencies and installs uncompatible with workbox-webpack-plugin workbox-build

E.g.
[workbox-webpack-plugin](https://github.com/GoogleChrome/workbox) 6.1.5 requires workbox-build 6.1.5
But installs latest one which is 6.2.4 at the moment

It leads to the failing `npm run start`

Workarround
To lock workbox-build  version as well for workbox-webpack-plugin

Other solution can be to use any kind of lock file (yarn, npm) for the react-scripts at least