### PR TITLE
Add a nonce to the react-error-overlay script

### DIFF
--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -146,6 +146,7 @@ function update() {
         'script'
       );
       script.type = 'text/javascript';
+      script.nonce = 'react-error-overlay';
       script.innerHTML = iframeScript;
       iframeDocument.body.appendChild(script);
     }


### PR DESCRIPTION
Add a `nonce='react-error-overlay'` prop to the `script` tag that the `react-error-overlay` package injects into the page.

This allows this nonce to be added to a CSP in a development environment instead of adding `'unsafe-inline'` to a CSP and to still have this package work.
