### PR TITLE
Chore: (Docs) Updates for the Storybook docs

### DIFF
--- a/docusaurus/docs/developing-components-in-isolation.md
+++ b/docusaurus/docs/developing-components-in-isolation.md
@@ -14,7 +14,7 @@ Usually, it’s hard to see these states without running a sample app or some ex
 
 Create React App doesn’t include any tools for this by default, but you can add [Storybook for React](https://storybook.js.org) ([source](https://github.com/storybooks/storybook)) or [React Styleguidist](https://react-styleguidist.js.org/) ([source](https://github.com/styleguidist/react-styleguidist)) to your project. **These are third-party tools that let you develop components and see all their states in isolation from your app**.
 
-![Storybook for React Demo](https://i.imgur.com/7CIAWpB.gif)
+![Storybook for React Demo](https://raw.githubusercontent.com/storybookjs/storybook/next/docs/get-started/storybook-third-party-docs.gif)
 
 You can also deploy your Storybook or style guide as a static app. This way, everyone in your team can view and review different states of UI components without starting a backend server or creating an account in your app.
 
@@ -25,15 +25,15 @@ Storybook is a development environment for React UI components. It allows you to
 Run the following command inside your app’s directory:
 
 ```sh
-npx -p @storybook/cli sb init
+npx sb init
 ```
 
 After that, follow the instructions on the screen.
 
 Learn more about React Storybook:
 
-- [Learn Storybook (tutorial)](https://learnstorybook.com)
-- [Documentation](https://storybook.js.org/basics/introduction/)
+- [Learn Storybook (tutorial)](https://storybook.js.org/tutorials/)
+- [Documentation](https://storybook.js.org/docs/react/get-started/introduction)
 - [GitHub Repo](https://github.com/storybooks/storybook)
 - [Snapshot Testing UI](https://github.com/storybooks/storybook/tree/master/addons/storyshots) with Storybook + addon/storyshot
 


### PR DESCRIPTION
With this small pull request, the Storybook documentation is updated to include a more recent video/gif, and also some of the links were updated as well to redirect to their proper places. 

What was done:
- Updated the location of the gif to Storybook's own repo. 
- Fixed the links currently used to their respective place

The change to the way the gif was being added is intentional, and hope it's fine with all of you. The intention behind this is to avoid having to rely on an external provider and subsequent pull requests. If by any chance the Storybook UI changes, said gif will be updated and with that automatically propagate here.


Feel free to provide feedback