### PR TITLE
Add default .editorconfig to template

### DIFF
--- a/packages/cra-template/template/.editorconfig
+++ b/packages/cra-template/template/.editorconfig
@@ -1,0 +1,15 @@
+# https://github.com/facebook/react/blob/main/.editorconfig
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/test/integration/create-react-app/index.test.js
+++ b/test/integration/create-react-app/index.test.js
@@ -11,7 +11,13 @@ jest.setTimeout(1000 * 60 * 5);
 const projectName = 'test-app';
 const genPath = join(__dirname, projectName);
 
-const generatedFiles = ['.gitignore', 'package.json', 'src', 'yarn.lock'];
+const generatedFiles = [
+  '.gitignore',
+  'package.json',
+  'src',
+  'yarn.lock',
+  '.editorconfig',
+];
 
 beforeEach(() => remove(genPath));
 afterAll(() => remove(genPath));


### PR DESCRIPTION
Same file as https://github.com/facebook/react
So just expliciting the _de facto_ default coding standard used

I noticed I kept adding that file myself manually to all my new CRA projects, so I was wondering if maybe it should be part of the default template? `.editorconfig` files are quite standard nowadays, and it feels appropriate to generate them similarly to the `.gitignore` file.

Pull request is sadly blind as I've been unable to run the test on my local machine (known issue: https://github.com/facebook/create-react-app/pull/9811).
