### PR TITLE
adding a proper look to the folder hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ my-app
     ├── index.css
     ├── index.js
     ├── logo.svg
-    └── serviceWorker.js
+    ├── serviceWorker.js
     └── setupTests.js
 ```
 


### PR DESCRIPTION
It is a simple README.md change that I have committed. The folder hierarchy's second last file had an ending line typed on the left. So, I corrected it and I put a normal line as it was the second last and not the last. 

