### PR TITLE
Update TypeScript example to include --use-npm for npx

### DIFF
--- a/packages/cra-template-typescript/README.md
+++ b/packages/cra-template-typescript/README.md
@@ -7,7 +7,7 @@ To use this template, add `--template typescript` when creating a new app.
 For example:
 
 ```sh
-npx create-react-app my-app --template typescript
+npx create-react-app my-app --use-npm --template typescript
 
 # or
 


### PR DESCRIPTION
If no `--use-npm` is provided, even though the user would want to execute it through npm, `create-react-app` would still trigger the usage of yarn (because of the lack on the parameter).

This provides a better example on usage for npm (and so, npx), versus yarn.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
