### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -431,7 +431,7 @@ We've removed this rule as it is not compatible with Prettier. If you rely on th
   - [#7921](https://github.com/facebook/create-react-app/pull/7921) Add restoreMocks to supported jest config keys ([@ianschmitz](https://github.com/ianschmitz))
   - [#6352](https://github.com/facebook/create-react-app/pull/6352) Add additional information for postcss errors (#6282) ([@buildbreakdo](https://github.com/buildbreakdo))
   - [#6753](https://github.com/facebook/create-react-app/pull/6753) Add Service-Worker header to checkValidServiceWorker ([@darthmaim](https://github.com/darthmaim))
-  - [#7832](https://github.com/facebook/create-react-app/pull/7832) feat: add additional Jest keys to whitelist ([@mrmckeb](https://github.com/mrmckeb))
+  - [#7832](https://github.com/facebook/create-react-app/pull/7832) Add additional Jest keys to whitelist ([@mrmckeb](https://github.com/mrmckeb))
   - [#7022](https://github.com/facebook/create-react-app/pull/7022) Fix node_modules sourcemap config (which will fix VSCode debugging of CRA apps) ([@justingrant](https://github.com/justingrant))
 - `cra-template`
   - [#7931](https://github.com/facebook/create-react-app/pull/7931) No spinning React logo if `prefers-reduced-motion` ([@donavon](https://github.com/donavon))
@@ -462,7 +462,7 @@ We've removed this rule as it is not compatible with Prettier. If you rely on th
 - `react-dev-utils`, `react-scripts`
   - [#7972](https://github.com/facebook/create-react-app/pull/7972) Add placeholders where old template READMEs used to be ([@iansu](https://github.com/iansu))
 - `babel-preset-react-app`
-  - [#7932](https://github.com/facebook/create-react-app/pull/7932) fix seperators typo ([@donavon](https://github.com/donavon))
+  - [#7932](https://github.com/facebook/create-react-app/pull/7932) fix separators typo ([@donavon](https://github.com/donavon))
 - `react-dev-utils`
   - [#7897](https://github.com/facebook/create-react-app/pull/7897) chore: Fix broken link for CRA deployment ([@haruelrovix](https://github.com/haruelrovix))
 - `react-scripts`

--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -406,9 +406,8 @@ If you exclude or ignore necessary files from the package you will see a error s
 
 ```
 remote: Could not find a required file.
-remote:   Name: `index.html`
-remote:   Searched in: /tmp/build_a2875fc163b209225122d68916f1d4df/public
-remote:
+remote: Name: `index.html`
+remote: Searched in: /tmp/build_a2875fc163b209225122d68916f1d4df/public
 remote: npm ERR! Linux 3.13.0-105-generic
 remote: npm ERR! argv "/tmp/build_a2875fc163b209225122d68916f1d4df/.heroku/node/bin/node" "/tmp/build_a2875fc163b209225122d68916f1d4df/.heroku/node/bin/npm" "run" "build"
 ```

--- a/packages/react-error-overlay/fixtures/bundle.mjs
+++ b/packages/react-error-overlay/fixtures/bundle.mjs
@@ -4038,7 +4038,7 @@ var DOMProperty = {
    *
    * @type {Object}
    */
-  getPossibleStandardName:  true ? { autofocus: 'autoFocus' } : null,
+  getPossibleStandardName: true ? { autofocus: 'autoFocus' } : null,
 
   /**
    * All of the isCustomAttribute() functions that have been injected.
@@ -6634,7 +6634,7 @@ var EventPluginRegistry = {
    * only in __DEV__.
    * @type {Object}
    */
-  possibleRegistrationNames:  true ? {} : null,
+  possibleRegistrationNames: true ? {} : null,
   // Trust the developer to only use possibleRegistrationNames in __DEV__
 
   /**
@@ -7133,14 +7133,14 @@ var MouseEventInterface = {
   getModifierState: getEventModifierState,
   button: function (event) {
     // Webkit, Firefox, IE9+
-    // which:  1 2 3
+    // which: 1 2 3
     // button: 0 1 2 (standard)
     var button = event.button;
     if ('which' in event) {
       return button;
     }
     // IE<9
-    // which:  undefined
+    // which: undefined
     // button: 0 0 0
     // button: 1 4 2 (onmouseup)
     return button === 2 ? 2 : button === 4 ? 1 : 0;
@@ -8822,7 +8822,7 @@ function executeDirectDispatch(event) {
 
 /**
  * @param {SyntheticEvent} event
- * @return {boolean} True iff number of dispatches accumulated is greater than 0.
+ * @return {boolean} True if number of dispatches accumulated is greater than 0.
  */
 function hasDispatches(event) {
   return !!event._dispatchListeners;

--- a/packages/react-error-overlay/fixtures/bundle_u.mjs
+++ b/packages/react-error-overlay/fixtures/bundle_u.mjs
@@ -4038,7 +4038,7 @@ var DOMProperty = {
    *
    * @type {Object}
    */
-  getPossibleStandardName:  true ? { autofocus: 'autoFocus' } : null,
+  getPossibleStandardName: true ? { autofocus: 'autoFocus' } : null,
 
   /**
    * All of the isCustomAttribute() functions that have been injected.
@@ -6758,7 +6758,7 @@ var EventPluginRegistry = {
    * only in __DEV__.
    * @type {Object}
    */
-  possibleRegistrationNames:  true ? {} : null,
+  possibleRegistrationNames: true ? {} : null,
   // Trust the developer to only use possibleRegistrationNames in __DEV__
 
   /**
@@ -7257,14 +7257,14 @@ var MouseEventInterface = {
   getModifierState: getEventModifierState,
   button: function (event) {
     // Webkit, Firefox, IE9+
-    // which:  1 2 3
+    // which: 1 2 3
     // button: 0 1 2 (standard)
     var button = event.button;
     if ('which' in event) {
       return button;
     }
     // IE<9
-    // which:  undefined
+    // which: undefined
     // button: 0 0 0
     // button: 1 4 2 (onmouseup)
     return button === 2 ? 2 : button === 4 ? 1 : 0;
@@ -8958,7 +8958,7 @@ function executeDirectDispatch(event) {
 
 /**
  * @param {SyntheticEvent} event
- * @return {boolean} True iff number of dispatches accumulated is greater than 0.
+ * @return {boolean} True if number of dispatches accumulated is greater than 0.
  */
 function hasDispatches(event) {
   return !!event._dispatchListeners;

--- a/packages/react-error-overlay/src/containers/RuntimeErrorContainer.js
+++ b/packages/react-error-overlay/src/containers/RuntimeErrorContainer.js
@@ -79,7 +79,7 @@ class RuntimeErrorContainer extends PureComponent<Props, State> {
         />
         <Footer
           line1="This screen is visible only in development. It will not appear if the app crashes in production."
-          line2="Open your browser’s developer console to further inspect this error.  Click the 'X' or hit ESC to dismiss this message."
+          line2="Open your browser’s developer console to further inspect this error. Click the 'X' or hit ESC to dismiss this message."
         />
       </ErrorOverlay>
     );

--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -35,7 +35,7 @@ const dotenvFiles = [
 
 // Load environment variables from .env* files. Suppress warnings using silent
 // if this file is missing. dotenv will never modify any environment variables
-// that have already been set.  Variable expansion is supported in .env files.
+// that have already been set. Variable expansion is supported in .env files.
 // https://github.com/motdotla/dotenv
 // https://github.com/motdotla/dotenv-expand
 dotenvFiles.forEach(dotenvFile => {

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -471,7 +471,7 @@ module.exports = function (webpackEnv) {
                 ),
                 // @remove-on-eject-end
                 // Babel sourcemaps are needed for debugging into node_modules
-                // code.  Without the options below, debuggers like VSCode
+                // code. Without the options below, debuggers like VSCode
                 // show incorrect code and set breakpoints on the wrong lines.
                 sourceMaps: shouldUseSourceMap,
                 inputSourceMap: shouldUseSourceMap,

--- a/test/fixtures/webpack-message-formatting/__snapshots__/index.test.js.snap
+++ b/test/fixtures/webpack-message-formatting/__snapshots__/index.test.js.snap
@@ -62,7 +62,7 @@ Object {
 Failed to compile.
 
 ./src/App.js
-  Line 4:13:  'b' is not defined  no-undef
+  Line 4:13: 'b' is not defined  no-undef
 
 Search for the keywords to learn more about each error.
 
@@ -79,7 +79,7 @@ Object {
 Compiled with warnings.
 
 ./src/App.js
-  Line 3:10:  'foo' is defined but never used  no-unused-vars
+  Line 3:10: 'foo' is defined but never used  no-unused-vars
 
 Search for the keywords to learn more about each warning.
 To ignore, add // eslint-disable-next-line to the line before.


### PR DESCRIPTION
Hello, 
I've found some minor typos in the documentation, solved with this PR.

+ Fixed minor typos:  **iff -> if**:  "bundle_u.mjs" (line 8961) and "bundle.mjs" (line 8825);
+ Remove empty "**remote:**"  for "deployment.md" (line 411);
+ Fix double spaces: "deployment.md", "bundle.mjs", "bundle_u.mjs", "RuntimeErrorContainer.js", "env.js", "webpack.config.js", "index.test.js.snap";