### PR TITLE
Serve the root index.html for all client-side routes when hosted in Netlify or GitLab Pages

### DIFF
--- a/packages/cra-template-typescript/template/public/_redirects
+++ b/packages/cra-template-typescript/template/public/_redirects
@@ -1,0 +1,4 @@
+# Serve the root index.html for all client-side routes when hosted in Netlify or GitLab Pages.
+# More information here: https://create-react-app.dev/docs/deployment/#serving-apps-with-client-side-routing
+
+/* /index.html 200

--- a/packages/cra-template/template/public/_redirects
+++ b/packages/cra-template/template/public/_redirects
@@ -1,0 +1,4 @@
+# Serve the root index.html for all client-side routes when hosted in Netlify or GitLab Pages.
+# More information here: https://create-react-app.dev/docs/deployment/#serving-apps-with-client-side-routing
+
+/* /index.html 200


### PR DESCRIPTION
### Summary

Adds a `_redirects` file that allows client-side [`pushState`](https://developer.mozilla.org/en-US/docs/Web/API/History_API#Adding_and_modifying_history_entries) routing to work out of the box when deployed on [Netlify](https://www.netlify.com/) or [GitLab Pages](https://about.gitlab.com/stages-devops-lifecycle/pages/).

More details about the `_redirects` file can be found [here](https://docs.netlify.com/routing/overview/). [Here's a section](https://docs.netlify.com/routing/redirects/rewrites-proxies/#history-pushstate-and-single-page-apps) about this specific setup.

### How to test

TODO
