### PR TITLE
fix: load config "react-app" error

### DIFF
--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -9,7 +9,8 @@
       "@types/react-dom": "^17.0.0",
       "@types/jest": "^26.0.15",
       "typescript": "^4.1.2",
-      "web-vitals": "^1.0.1"
+      "web-vitals": "^1.0.1",
+      "eslint-config-react-app": "^6.0.0"
     },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -4,7 +4,8 @@
       "@testing-library/jest-dom": "^5.11.4",
       "@testing-library/react": "^11.1.0",
       "@testing-library/user-event": "^12.1.10",
-      "web-vitals": "^1.0.1"
+      "web-vitals": "^1.0.1",
+      "eslint-config-react-app": "^6.0.0"
     },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]


### PR DESCRIPTION
Hello! Good morning.

I am studying Yarnberry these days. So I decided to use yarnberry for create-react-app.
After setting it up, I started with `yarn start`. However, it did not start with the following error:

```shell
Failed to compile

Failed to load config "react-app" to extend from.
Referenced from: /Users/an-eungyeol/Documents/yarn/normalreact/package.json
```
After seeing this error, I searched Google for it. And I found the (#10463) issue. 
This issue provided solutions to install eslint-config-react-app. So I added the module to the cra template. The number of users of Yarnberry seems to be increasing these days.
I really hope this PR is received.

