### PR TITLE
Add mini-svg-data-uri for url-loader

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -36,6 +36,7 @@ const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin'
 // @remove-on-eject-begin
 const getCacheIdentifier = require('react-dev-utils/getCacheIdentifier');
 // @remove-on-eject-end
+const svgToMiniDataURI = require('mini-svg-data-uri');
 const createEnvironmentHash = require('./webpack/persistentCache/createEnvironmentHash');
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
@@ -359,6 +360,18 @@ module.exports = function (webpackEnv) {
                   maxSize: imageInlineSizeLimit,
                 },
               },
+            },
+            {
+              test: /\.svg$/,
+              use: [
+                {
+                  loader: require.resolve('url-loader'),
+                  options: {
+                    limit: imageInlineSizeLimit,
+                    generator: (content) => svgToMiniDataURI(content.toString()),
+                  },
+                },
+              ],
             },
             {
               test: /\.svg$/,


### PR DESCRIPTION
This PR adds svg loading/inlining for non-component svg imports, those of the form `import ReloadSvg from "assets/icons/reload.svg"`. I made this change in my own project and it seems to work.

<img width="846" alt="screenshot" src="https://user-images.githubusercontent.com/10591373/132142111-e2e6f5b8-b073-453e-b84f-1dc5563a8085.png">

