### PR TITLE
docs: remove react-snapshot from pre-render docs

### DIFF
--- a/docusaurus/docs/pre-rendering-into-static-html-files.md
+++ b/docusaurus/docs/pre-rendering-into-static-html-files.md
@@ -4,7 +4,7 @@ title: Pre-Rendering into Static HTML Files
 sidebar_label: Pre-Rendering Static HTML
 ---
 
-If you’re hosting your `build` with a static hosting provider you can use [react-snapshot](https://www.npmjs.com/package/react-snapshot) or [react-snap](https://github.com/stereobooster/react-snap) to generate HTML pages for each route, or relative link, in your application. These pages will then seamlessly become active, or “hydrated”, when the JavaScript bundle has loaded.
+If you’re hosting your `build` with a static hosting provider you can use [react-snap](https://github.com/stereobooster/react-snap) to generate HTML pages for each route, or relative link, in your application. These pages will then seamlessly become active, or “hydrated”, when the JavaScript bundle has loaded.
 
 There are also opportunities to use this outside of static hosting, to take the pressure off the server when generating and caching routes.
 


### PR DESCRIPTION
react-snapshot already deprecated from the author itself (https://github.com/geelen/react-snapshot)

so i think, it's better to remove that recommendation from this page

![image](https://user-images.githubusercontent.com/27436728/132162955-b44c8907-4db8-4221-b9e0-583dcaa185cc.png)

