### PR TITLE
Add .finally to IE11 Promise

### DIFF
--- a/packages/react-app-polyfill/ie11.js
+++ b/packages/react-app-polyfill/ie11.js
@@ -12,6 +12,7 @@ if (typeof Promise === 'undefined') {
   // and the user has no idea what causes React's erratic future behavior.
   require('promise/lib/rejection-tracking').enable();
   self.Promise = require('promise/lib/es6-extensions.js');
+  self.Promise = require('promise/lib/finally.js');
 }
 
 // Make sure we're in a Browser-like environment before importing polyfills


### PR DESCRIPTION
IE11 polyfill fails to provide .finally, this should do the trick.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
