### PR TITLE
Allow configuring jest's `cacheDirectory`

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -73,6 +73,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
   }
   const overrides = Object.assign({}, require(paths.appPackageJson).jest);
   const supportedKeys = [
+    'cacheDirectory',
     'clearMocks',
     'collectCoverageFrom',
     'coveragePathIgnorePatterns',


### PR DESCRIPTION
Related issue: #2687

Jest's [`cacheDirectory`](https://jestjs.io/docs/configuration#cachedirectory-string) option is useful to allow caching `react-scripts test` on github workflows runs, using the action `actions/cache@v2`.

The default [`cacheDirectory`](https://jestjs.io/docs/configuration#cachedirectory-string) value is not really cacheable on github workflows.