### PR TITLE
Bump Immer to v9.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16080,9 +16080,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.4.tgz",
-      "integrity": "sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -33224,7 +33224,7 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": "8.0.4",
+        "immer": "9.0.6",
         "is-root": "2.1.0",
         "loader-utils": "2.0.0",
         "open": "^7.0.2",
@@ -46470,9 +46470,9 @@
       }
     },
     "immer": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.4.tgz",
-      "integrity": "sha512-jMfL18P+/6P6epANRvRk6q8t+3gGhqsJ9EuJ25AXE+9bNTYtssvzeYbEd0mXRYWCmmXSIbnlpz6vd6iJlmGGGQ=="
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -54298,7 +54298,7 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": "8.0.4",
+        "immer": "9.0.6",
         "is-root": "2.1.0",
         "jest": "26.6.0",
         "loader-utils": "2.0.0",

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -65,7 +65,7 @@
     "global-modules": "2.0.0",
     "globby": "11.0.1",
     "gzip-size": "5.1.1",
-    "immer": "8.0.4",
+    "immer": "9.0.6",
     "is-root": "2.1.0",
     "loader-utils": "2.0.0",
     "open": "^7.0.2",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Address Prototype Pollution in Immer by bumping it to `v9.0.6` in `react-dev-utils`.

Fix #11443.
