### PR TITLE
Add babel-plugin-transform-flow-enums to Babel config for Flow Enums support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7549,6 +7549,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/babel-plugin-transform-flow-enums": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-enums/-/babel-plugin-transform-flow-enums-0.0.2.tgz",
+      "integrity": "sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==",
+      "dependencies": {
+        "@babel/plugin-syntax-flow": "^7.12.1"
+      }
+    },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
@@ -32980,6 +32988,7 @@
         "@babel/preset-typescript": "^7.14.5",
         "@babel/runtime": "^7.14.5",
         "babel-plugin-macros": "^3.1.0",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
     },
@@ -39681,6 +39690,14 @@
         }
       }
     },
+    "babel-plugin-transform-flow-enums": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-enums/-/babel-plugin-transform-flow-enums-0.0.2.tgz",
+      "integrity": "sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==",
+      "requires": {
+        "@babel/plugin-syntax-flow": "^7.12.1"
+      }
+    },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
@@ -39732,6 +39749,7 @@
         "@babel/preset-typescript": "^7.14.5",
         "@babel/runtime": "^7.14.5",
         "babel-plugin-macros": "^3.1.0",
+        "babel-plugin-transform-flow-enums": "^0.0.2",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
       }
     },

--- a/packages/babel-preset-react-app/create.js
+++ b/packages/babel-preset-react-app/create.js
@@ -112,6 +112,7 @@ module.exports = function (api, opts, env) {
         require('@babel/plugin-transform-flow-strip-types').default,
         false,
       ],
+      isFlowEnabled && require('babel-plugin-transform-flow-enums'),
       // Experimental macros support. Will be documented after it's had some time
       // in the wild.
       require('babel-plugin-macros'),

--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -36,6 +36,7 @@
     "@babel/preset-typescript": "^7.14.5",
     "@babel/runtime": "^7.14.5",
     "babel-plugin-macros": "^3.1.0",
+    "babel-plugin-transform-flow-enums": "^0.0.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
   }
 }


### PR DESCRIPTION
This PR is an attempt to enable support for Flow Enums, as described in https://github.com/facebook/create-react-app/issues/11433. CRA already uses required version of Babel, so only the necessary transform plugin is needed. The rest of the steps to enable Flow Enums are supposed to be covered by the user: enabling the option in `.flowconfig` and installing `flow-enums-runtime`.

I tested my changes by running `npm run e2e`.

Please let me know if any docs needs to be updated.
