### PR TITLE
chore: bump react refresh plugin to 0.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5474,9 +5474,9 @@
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.2.tgz",
-      "integrity": "sha512-BWOG6opI9+L5HjQIj6znFLwVXkjDS98PKfRDlbPFvinTz4wQ7ZSXxV0lLOfRW12HXcqk4DEzrphjRMJFXuihNg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.3.tgz",
+      "integrity": "sha512-OoTnFb8XEYaOuMNhVDsLRnAO6MCYHNs1g6d8pBcHhDFsi1P3lPbq/IklwtbAx9cG0W4J9KswxZtwGnejrnxp+g==",
       "dependencies": {
         "ansi-html-community": "^0.0.8",
         "common-path-prefix": "^3.0.0",
@@ -32416,7 +32416,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.14.2",
-        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
         "@svgr/webpack": "^5.5.0",
         "babel-jest": "^27.1.0",
         "babel-loader": "^8.2.2",
@@ -36730,9 +36730,9 @@
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.2.tgz",
-      "integrity": "sha512-BWOG6opI9+L5HjQIj6znFLwVXkjDS98PKfRDlbPFvinTz4wQ7ZSXxV0lLOfRW12HXcqk4DEzrphjRMJFXuihNg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.3.tgz",
+      "integrity": "sha512-OoTnFb8XEYaOuMNhVDsLRnAO6MCYHNs1g6d8pBcHhDFsi1P3lPbq/IklwtbAx9cG0W4J9KswxZtwGnejrnxp+g==",
       "requires": {
         "ansi-html-community": "^0.0.8",
         "common-path-prefix": "^3.0.0",
@@ -52262,7 +52262,7 @@
       "version": "file:packages/react-scripts",
       "requires": {
         "@babel/core": "^7.14.2",
-        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
         "@svgr/webpack": "^5.5.0",
         "babel-jest": "^27.1.0",
         "babel-loader": "^8.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5474,9 +5474,9 @@
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.1.tgz",
-      "integrity": "sha512-ccap6o7+y5L8cnvkZ9h8UXCGyy2DqtwCD+/N3Yru6lxMvcdkPKtdx13qd7sAC9s5qZktOmWf9lfUjsGOvSdYhg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.2.tgz",
+      "integrity": "sha512-BWOG6opI9+L5HjQIj6znFLwVXkjDS98PKfRDlbPFvinTz4wQ7ZSXxV0lLOfRW12HXcqk4DEzrphjRMJFXuihNg==",
       "dependencies": {
         "ansi-html-community": "^0.0.8",
         "common-path-prefix": "^3.0.0",
@@ -5493,7 +5493,7 @@
       },
       "peerDependencies": {
         "@types/webpack": "4.x || 5.x",
-        "react-refresh": "^0.10.0",
+        "react-refresh": ">=0.10.0 <1.0.0",
         "sockjs-client": "^1.4.0",
         "type-fest": ">=0.17.0 <3.0.0",
         "webpack": ">=4.43.0 <6.0.0",
@@ -32416,7 +32416,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.14.2",
-        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
         "@svgr/webpack": "^5.5.0",
         "babel-jest": "^27.1.0",
         "babel-loader": "^8.2.2",
@@ -36730,9 +36730,9 @@
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.1.tgz",
-      "integrity": "sha512-ccap6o7+y5L8cnvkZ9h8UXCGyy2DqtwCD+/N3Yru6lxMvcdkPKtdx13qd7sAC9s5qZktOmWf9lfUjsGOvSdYhg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.2.tgz",
+      "integrity": "sha512-BWOG6opI9+L5HjQIj6znFLwVXkjDS98PKfRDlbPFvinTz4wQ7ZSXxV0lLOfRW12HXcqk4DEzrphjRMJFXuihNg==",
       "requires": {
         "ansi-html-community": "^0.0.8",
         "common-path-prefix": "^3.0.0",
@@ -52262,7 +52262,7 @@
       "version": "file:packages/react-scripts",
       "requires": {
         "@babel/core": "^7.14.2",
-        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
         "@svgr/webpack": "^5.5.0",
         "babel-jest": "^27.1.0",
         "babel-loader": "^8.2.2",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -29,7 +29,7 @@
   "types": "./lib/react-app.d.ts",
   "dependencies": {
     "@babel/core": "^7.14.2",
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
     "@svgr/webpack": "^5.5.0",
     "babel-jest": "^27.1.0",
     "babel-loader": "^8.2.2",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -29,7 +29,7 @@
   "types": "./lib/react-app.d.ts",
   "dependencies": {
     "@babel/core": "^7.14.2",
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
     "@svgr/webpack": "^5.5.0",
     "babel-jest": "^27.1.0",
     "babel-loader": "^8.2.2",


### PR DESCRIPTION
Not the most familiar with `npm` workspaces, hopefully I bumped correctly 🙈 

- Bumped `@pmmmwh/react-refresh-webpack-plugin` to latest `0.5.3` - an important performance fix was introduced there
- ~Bumped `webpack-dev-server` to latest, which includes security patch to fix ReDoS CVE as well as infinite loop issues~