### PR TITLE
added additionalManifestEntries for manifest.json to webpack.config

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -688,6 +688,7 @@ module.exports = function (webpackEnv) {
           swSrc,
           dontCacheBustURLsMatching: /\.[0-9a-f]{8}\./,
           exclude: [/\.map$/, /asset-manifest\.json$/, /LICENSE/],
+          additionalManifestEntries: ['manifest.json'],
           // Bump up the default maximum size (2mb) that's precached,
           // to make lazy-loading failure scenarios less likely.
           // See https://github.com/cra-template/pwa/issues/13#issuecomment-722667270


### PR DESCRIPTION
If someone creates a PWA using `cra-template-pwa`, the manifest.json is not part of the precached asset list.
With this little improvement it would be added so the publisher can be sure its always cached on the device.
You can find a discussion here: https://twitter.com/devpato/status/1446049950480179200