### PR TITLE
Add peer dependencies for fork-ts-checker-webpack-plugin

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -81,6 +81,10 @@
     "cross-env": "^7.0.2",
     "jest": "^27.1.0"
   },
+  "peerDependencies": {
+    "typescript": ">=2.7",
+    "webpack": ">=4"
+  },
   "scripts": {
     "test": "cross-env FORCE_COLOR=true jest"
   }


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
When using create-react-app with yarn 3, every run of `yarn install` produces these warnings:
```
➤ YN0002: │ react-dev-utils@npm:11.0.4 doesn't provide typescript (p79ddf), requested by fork-ts-checker-webpack-plugin
➤ YN0002: │ react-dev-utils@npm:11.0.4 doesn't provide webpack (p2af19), requested by fork-ts-checker-webpack-plugin
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
```
even though `typescript` and `webpack` are already provided elsewhere. By specifying these as peer dependencies of react-dev-utils, the warnings are silenced without changing what dependencies are installed.

Example output before the change:
![image](https://user-images.githubusercontent.com/25109429/136663751-c6748c89-548d-46b1-86e2-b6b0e1b25826.png)
And after the change:
![image](https://user-images.githubusercontent.com/25109429/136663790-922b3e55-162c-428e-a052-acdfe5ca7061.png)

To prove this change doesn't affect the dependency tree, here's the output of `npm ls typescript` after the change:
![image](https://user-images.githubusercontent.com/25109429/136663879-451b9e58-e18b-401b-a3a4-2cbafdf6ce60.png)
And `npm ls webpack`:
![image](https://user-images.githubusercontent.com/25109429/136664099-f4a67339-7f42-4112-8893-1ade95954669.png)
