### PR TITLE
docs: update react-testing-library section

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -90,7 +90,7 @@ When you encounter bugs caused by changing components, you will gain a deeper in
 If you’d like to test components in isolation from the child components they render, we recommend using `react-testing-library`. [`react-testing-library`](https://github.com/testing-library/react-testing-library) is a library for testing React components in a way that resembles the way the components are used by end users. It is well suited for unit, integration, and end-to-end testing of React components and applications. It works more directly with DOM nodes, and therefore it's recommended to use with [`jest-dom`](https://github.com/testing-library/jest-dom) for improved assertions.
 
 To install `react-testing-library` and `jest-dom`, you can run:
-> Note: `@testing-library/react` and `@testing-library/jest-dom` come by default with `react-scripts@3.3.0` and higher and require zero configuration.
+> Note: `@testing-library/react` and `@testing-library/jest-dom` come by default with `react-scripts@3.3.0` and higher, and require zero configuration.
 ```sh
 npm install --save @testing-library/react @testing-library/jest-dom
 ```

--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -90,7 +90,7 @@ When you encounter bugs caused by changing components, you will gain a deeper in
 If you’d like to test components in isolation from the child components they render, we recommend using `react-testing-library`. [`react-testing-library`](https://github.com/testing-library/react-testing-library) is a library for testing React components in a way that resembles the way the components are used by end users. It is well suited for unit, integration, and end-to-end testing of React components and applications. It works more directly with DOM nodes, and therefore it's recommended to use with [`jest-dom`](https://github.com/testing-library/jest-dom) for improved assertions.
 
 To install `react-testing-library` and `jest-dom`, you can run:
-
+> Note: `@testing-library/react` and `@testing-library/jest-dom` come by default with `react-scripts@3.3.0` and higher and require zero configuration.
 ```sh
 npm install --save @testing-library/react @testing-library/jest-dom
 ```


### PR DESCRIPTION
What: 

Updates the section on react-testing-library where the docs imply an installation of both `@testing-library/react` and `@testing-library/jest-dom` is necessary.

Why:

`react-scripts` version 3.3.0 adds `@testing-library/react` and `@testing-library/jest-dom` as default testing library/utility which eliminates the need for installation and/or configuration in `src/setupTests.js`

Source: https://github.com/facebook/create-react-app/pull/7881 and https://github.com/facebook/create-react-app/releases?after=react-scripts%403.3.1

How:

I added a similar "Note: " block that is used throughout the docs.

Screenshots:

_Before_

![image](https://user-images.githubusercontent.com/57100733/137232331-405ae877-7544-4866-9bc4-b77ddcd0c4c5.png)

_After_

![image](https://user-images.githubusercontent.com/57100733/137233733-5d9c75b1-f981-46c8-95ea-fbc5ade3e5f3.png)

