### PR TITLE
allow disabling of clearConsole() via env var

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -123,7 +123,7 @@ checkBrowsers(paths.appPath, isInteractive)
     const devServer = new WebpackDevServer(serverConfig, compiler);
     // Launch WebpackDevServer.
     devServer.startCallback(() => {
-      if (isInteractive) {
+      if (isInteractive && process.env.CRA_CLEAR_CONSOLE !== 'false') {
         clearConsole();
       }
 


### PR DESCRIPTION
This PR proposes an unobtrusive workaround for the pain described in #7233 that results in a bad development experience. With this PR, setting the `CRA_CLEAR_CONSOLE` env var to `false` causes `clearConsole()` not to be called.

I'm not particularly attached to the variable name, but I could not find a clear convention to match from this repo.