### PR TITLE
feat: add worker-url plugin to support worklets and workers

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -24,6 +24,7 @@ const WorkboxWebpackPlugin = require('workbox-webpack-plugin');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
 const ESLintPlugin = require('eslint-webpack-plugin');
+const WorkerUrlPlugin = require('worker-url/plugin');
 const paths = require('./paths');
 const modules = require('./modules');
 const getClientEnvironment = require('./env');
@@ -605,6 +606,8 @@ module.exports = function (webpackEnv) {
             : undefined
         )
       ),
+      // worker-url allows to generate worklets and workers
+      new WorkerUrlPlugin(),
       // Inlines the webpack runtime script. This script is too small to warrant
       // a network request.
       // https://github.com/facebook/create-react-app/issues/5358

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -73,7 +73,8 @@
     "webpack": "5.41.1",
     "webpack-dev-server": "4.0.0-rc.0",
     "webpack-manifest-plugin": "3.1.1",
-    "workbox-webpack-plugin": "6.1.5"
+    "workbox-webpack-plugin": "6.1.5",
+    "worker-url": "^1.1.0"
   },
   "devDependencies": {
     "react": "^17.0.1",


### PR DESCRIPTION
fixes #3660 and fixes #10641

I added the worker-url plugin so that people can work with web workers and web worklets on CRA apps.

The plugin doesn't require configuration so it's ideal for the CRA project.

https://www.npmjs.com/package/worker-url