### PR TITLE
Removing import "React" line from App.tsx

### DIFF
--- a/packages/cra-template-typescript/template/src/App.tsx
+++ b/packages/cra-template-typescript/template/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 


### PR DESCRIPTION
Can we just remove `import React from 'react';` line?
I think we don't need it as we are using `"jsx": "react-jsx"` in `tsconfig.json` file
