### PR TITLE
Fix typo in index.html template comment

### DIFF
--- a/packages/cra-template-typescript/template/public/index.html
+++ b/packages/cra-template-typescript/template/public/index.html
@@ -36,7 +36,7 @@
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.
 
-      To begin the development, run `npm start` or `yarn start`.
+      To begin the development server, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
   </body>

--- a/packages/cra-template/template/public/index.html
+++ b/packages/cra-template/template/public/index.html
@@ -36,7 +36,7 @@
       You can add webfonts, meta tags, or analytics to this file.
       The build step will place the bundled scripts into the <body> tag.
 
-      To begin the development, run `npm start` or `yarn start`.
+      To begin the development server, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
   </body>


### PR DESCRIPTION
this is a very straightforward typo fix. the `cra-template` and `cra-template-typescript` `template/public/index.html` file includes an HTML comment giving instructions on running the project and creating a production bundle. currently, the first sentence is:

> To begin the development, run `npm start` or `yarn start`.

this PR changes the comment in both files to:

> To begin the development server, run `npm start` or `yarn start`.