### PR TITLE
Bump react-dev-tools (resolves #11523)

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dev-utils",
-  "version": "11.0.4",
+  "version": "11.0.5",
   "description": "webpack utilities used by Create React App",
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://github.com/facebook/create-react-app/pull/11364 bumped immer to 9.0.6, but didn't bump the version.

