### PR TITLE
Ensure posix compliant joins for urls in middleware

### DIFF
--- a/packages/react-dev-utils/noopServiceWorkerMiddleware.js
+++ b/packages/react-dev-utils/noopServiceWorkerMiddleware.js
@@ -11,7 +11,7 @@ const path = require('path');
 
 module.exports = function createNoopServiceWorkerMiddleware(servedPath) {
   return function noopServiceWorkerMiddleware(req, res, next) {
-    if (req.url === path.join(servedPath, 'service-worker.js')) {
+    if (req.url === path.posix.join(servedPath, 'service-worker.js')) {
       res.setHeader('Content-Type', 'text/javascript');
       res.send(
         `// This service worker file is effectively a 'no-op' that will reset any

--- a/packages/react-dev-utils/redirectServedPathMiddleware.js
+++ b/packages/react-dev-utils/redirectServedPathMiddleware.js
@@ -19,7 +19,7 @@ module.exports = function createRedirectServedPathMiddleware(servedPath) {
     ) {
       next();
     } else {
-      const newPath = path.join(servedPath, req.path !== '/' ? req.path : '');
+      const newPath = path.posix.join(servedPath, req.path !== '/' ? req.path : '');
       res.redirect(newPath);
     }
   };


### PR DESCRIPTION
This avoids issues encountered on non-posix compliant systems.

The issue was first identified from a Windows system attempting to utilize noopServiceWorkerMiddleware. The platform-specific separator implemented by path.join would render a mismatch in any non-empty path provided and thus would not result in the service-worker.js file being provided through the middleware.

Further investigation of the react-dev-utils found a similar scenario in redirectServedPathMiddleware. Both path.join calls were adjusted to path.posix.join to ensure that posix compliance is preserved in urls for both of these middleware, in their comparison or redirection.

At present there are several open issues which may be impacted by this pull request. If needed I can do sufficient investigation to compile a list of the most likely candidates directly.