### PR TITLE
Include missing cjs and mjs files from collectCoverageFrom

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -25,7 +25,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
   const config = {
     roots: ['<rootDir>/src'],
 
-    collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}', '!src/**/*.d.ts'],
+    collectCoverageFrom: ['src/**/*.{js,jsx,mjs,cjs,ts,tsx}', '!src/**/*.d.ts'],
 
     setupFiles: [
       isEjecting


### PR DESCRIPTION
Those file are transformed and usable in node and webpack. Their transpiled javascript will be included in production build, so we need to be able to see how they are covered inside nyc output.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
