### PR TITLE
Add missing peer dependencies

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -81,6 +81,15 @@
     "cross-env": "^7.0.3",
     "jest": "^27.4.3"
   },
+  "peerDependencies": {
+    "typescript": ">= 2.7",
+    "webpack": ">= 4"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "scripts": {
     "test": "cross-env FORCE_COLOR=true jest"
   }


### PR DESCRIPTION
Add missing [implicit transitive peer dependencies](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0):
```
➤ YN0002: │ react-dev-utils@npm:11.0.4 doesn't provide typescript (p79ddf), requested by fork-ts-checker-webpack-plugin
➤ YN0002: │ react-dev-utils@npm:11.0.4 doesn't provide webpack (p2af19), requested by fork-ts-checker-webpack-plugin
```