### PR TITLE
chore(test): make all tests install with `npm ci`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ jobs:
         with:
           node-version: '14'
           cache: 'npm'
-      - name: Install npm@7
-        run: npm i -g npm@7
+      - name: Install npm@8
+        run: npm i -g npm@8
       - name: Install
         run: npm ci --prefer-offline
       - name: Build

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'
-      - name: Install npm@7
-        run: npm i -g npm@7
+      - name: Install npm@8
+        run: npm i -g npm@8
       - name: Install yarn
         run: npm i -g yarn
       - name: Install packages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,8 @@ jobs:
         with:
           node-version: '14'
           cache: 'npm'
-      - name: Install npm@7
-        run: npm i -g npm@7
+      - name: Install npm@8
+        run: npm i -g npm@8
       - name: Install
         run: npm ci --prefer-offline
       - name: Alex

--- a/azure-pipelines-test-job.yml
+++ b/azure-pipelines-test-job.yml
@@ -31,8 +31,8 @@ jobs:
           versionSpec: $(nodeVersion)
         displayName: 'Install Node.js'
 
-      - script: npm i -g npm@7
-        displayName: 'Update npm to v7'
+      - script: npm i -g npm@8
+        displayName: 'Update npm to v8'
 
       - script: npm ci
         displayName: 'Run npm ci'

--- a/tasks/e2e-behavior.sh
+++ b/tasks/e2e-behavior.sh
@@ -61,14 +61,6 @@ set -x
 cd ..
 root_path=$PWD
 
-if hash npm 2>/dev/null
-then
-  npm i -g --force npm@latest
-fi
-
-# Bootstrap monorepo
-npm install
-
 # ******************************************************************************
 # First, publish the monorepo.
 # ******************************************************************************

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -83,14 +83,6 @@ set -x
 cd ..
 root_path=$PWD
 
-if hash npm 2>/dev/null
-then
-  npm i -g npm@latest
-fi
-
-# Bootstrap monorepo
-npm install
-
 # ******************************************************************************
 # First, publish the monorepo.
 # ******************************************************************************

--- a/tasks/e2e-kitchensink-eject.sh
+++ b/tasks/e2e-kitchensink-eject.sh
@@ -69,14 +69,6 @@ if [ "$AGENT_OS" == 'Windows_NT' ]; then
   root_path=$(cmd //c cd)
 fi
 
-if hash npm 2>/dev/null
-then
-  npm i -g npm@latest
-fi
-
-# Bootstrap monorepo
-npm install
-
 # ******************************************************************************
 # First, publish the monorepo.
 # ******************************************************************************

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -69,14 +69,6 @@ if [ "$AGENT_OS" == 'Windows_NT' ]; then
   root_path=$(cmd //c cd)
 fi
 
-if hash npm 2>/dev/null
-then
-  npm i -g npm@latest
-fi
-
-# Bootstrap monorepo
-npm install
-
 # ******************************************************************************
 # First, publish the monorepo.
 # ******************************************************************************

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -76,14 +76,6 @@ if [ "$EXPECTED" != "$ACTUAL" ]; then
   exit 1
 fi
 
-if hash npm 2>/dev/null
-then
-  npm i -g npm@latest
-fi
-
-# Bootstrap monorepo
-npm install
-
 # Start the local NPM registry
 startLocalRegistry "$root_path"/tasks/verdaccio.yaml
 

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -28,7 +28,6 @@ root_path=$PWD
 
 if [ -n "$(git status --porcelain)" ]; then
   echo "Your git status is not clean. Aborting.";
-  git diff
   exit 1;
 fi
 

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -28,6 +28,7 @@ root_path=$PWD
 
 if [ -n "$(git status --porcelain)" ]; then
   echo "Your git status is not clean. Aborting.";
+  git diff
   exit 1;
 fi
 


### PR DESCRIPTION
Previously, individual tests were updating `npm` and running `npm install`, which was redundant with the config in the test runner.

This also updates all test runners to `npm@8` and fixes the local Docker test runner, which wasn't working previously.
