### PR TITLE
fix: ignore webpack warnings by source-map-loader

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -790,5 +790,11 @@ module.exports = function (webpackEnv) {
     // Turn off performance processing because we utilize
     // our own hints via the FileSizeReporter
     performance: false,
+    ignoreWarnings: [
+      // Ignore warnings raised by source-map-loader.
+      // some third party packages may ship miss-configured sourcemaps, that interrupts the build
+      // See: https://github.com/facebook/create-react-app/discussions/11278#discussioncomment-1780169
+      { message: /source-map-loader/ },
+    ],
   };
 };


### PR DESCRIPTION
Some third party packages may ship miss-configured sourcemaps, that interrupts the build
See: https://github.com/facebook/create-react-app/discussions/11278#discussioncomment-1780169
