### PR TITLE
prevent both npm and yarn commands from being copied

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -13,9 +13,9 @@ To start a new Create React App project with [TypeScript](https://www.typescript
 
 ```sh
 npx create-react-app my-app --template typescript
-
-# or
-
+```
+or
+```sh
 yarn create react-app my-app --template typescript
 ```
 
@@ -27,9 +27,9 @@ To add [TypeScript](https://www.typescriptlang.org/) to an existing Create React
 
 ```sh
 npm install --save typescript @types/node @types/react @types/react-dom @types/jest
-
-# or
-
+```
+or
+```sh
 yarn add typescript @types/node @types/react @types/react-dom @types/jest
 ```
 


### PR DESCRIPTION
This change isolates npm command and yarn command because if it is in the same shell code then both gets copied at the same time when copy button is clicked.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
