### PR TITLE
Name the default git branch main instead of master

### DIFF
--- a/packages/react-scripts/scripts/init.js
+++ b/packages/react-scripts/scripts/init.js
@@ -47,8 +47,8 @@ function tryGitInit() {
     if (isInGitRepository() || isInMercurialRepository()) {
       return false;
     }
-
-    execSync('git init', { stdio: 'ignore' });
+    // Initialize a git repository and rename the branch to "main"
+    execSync('git init && git checkout -b main', { stdio: 'ignore' });
     return true;
   } catch (e) {
     console.warn('Git repo not initialized', e);


### PR DESCRIPTION
This change adds a command to name the default branch "main" instead of "master"

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
