### PR TITLE
V5 fix react error overlay build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "create-react-app",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
@@ -23420,11 +23419,11 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
-      "integrity": "sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.0.tgz",
+      "integrity": "sha512-LPIisi3Ol4chwAaPP8toUJ3L4qCM1G0wao7L3qNv57Drezxj6+VEyySpPw4B1HSO2Eg/hDY/MNF5XihCAoqnsQ==",
       "dependencies": {
-        "jest-worker": "^27.0.6",
+        "jest-worker": "^27.4.1",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
         "source-map": "^0.6.1",
@@ -24663,9 +24662,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.0.tgz",
-      "integrity": "sha512-MnN0Q1OsvB/GGHETrFeZPQaOelWh/7O+EiFlj8sM9GPjtQkis7k01aAxrg/18kTfoIVcLL+haEVFlXDaSRwKRw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+      "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -24716,9 +24715,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.64.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.4.tgz",
-      "integrity": "sha512-LWhqfKjCLoYJLKJY8wk2C3h77i8VyHowG3qYNZiIqD6D0ZS40439S/KVuc/PY48jp2yQmy0mhMknq8cys4jFMw==",
+      "version": "5.65.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.65.0.tgz",
+      "integrity": "sha512-Q5or2o6EKs7+oKmJo7LaqZaMOlDWQse9Tm5l1WAfU/ujLGN5Pb0SqGeVkN/4bpPmEqEP5RnVhiqsOtWtUVwGRw==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",
@@ -24742,7 +24741,7 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.3.0",
+        "watchpack": "^2.3.1",
         "webpack-sources": "^3.2.2"
       },
       "bin": {
@@ -25838,7 +25837,7 @@
       }
     },
     "packages/babel-plugin-named-asset-import": {
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "MIT",
       "devDependencies": {
         "babel-plugin-tester": "^10.1.0",
@@ -25849,7 +25848,7 @@
       }
     },
     "packages/babel-preset-react-app": {
-      "version": "10.0.0",
+      "version": "10.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -25871,28 +25870,28 @@
       }
     },
     "packages/confusing-browser-globals": {
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "devDependencies": {
         "jest": "^27.4.3"
       }
     },
     "packages/cra-template": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "packages/cra-template-typescript": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "packages/create-react-app": {
-      "version": "4.0.3",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -25933,7 +25932,7 @@
       }
     },
     "packages/eslint-config-react-app": {
-      "version": "6.0.0",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -25941,8 +25940,8 @@
         "@rushstack/eslint-patch": "^1.1.0",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
-        "babel-preset-react-app": "^10.0.0",
-        "confusing-browser-globals": "^1.0.10",
+        "babel-preset-react-app": "^10.0.1",
+        "confusing-browser-globals": "^1.0.11",
         "eslint-plugin-flowtype": "^8.0.3",
         "eslint-plugin-import": "^2.25.3",
         "eslint-plugin-jest": "^25.3.0",
@@ -25959,7 +25958,7 @@
       }
     },
     "packages/react-app-polyfill": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.19.2",
@@ -25974,7 +25973,7 @@
       }
     },
     "packages/react-dev-utils": {
-      "version": "11.0.4",
+      "version": "12.0.0",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
@@ -25996,7 +25995,7 @@
         "open": "^8.4.0",
         "pkg-up": "^3.1.0",
         "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.9",
+        "react-error-overlay": "^6.0.10",
         "recursive-readdir": "^2.2.2",
         "shell-quote": "^1.7.3",
         "strip-ansi": "^6.0.1",
@@ -26019,7 +26018,7 @@
       }
     },
     "packages/react-error-overlay": {
-      "version": "6.0.9",
+      "version": "6.0.10",
       "license": "MIT",
       "devDependencies": {
         "@babel/code-frame": "^7.16.0",
@@ -26027,12 +26026,12 @@
         "anser": "^2.1.0",
         "babel-jest": "^27.4.2",
         "babel-loader": "^8.2.3",
-        "babel-preset-react-app": "^10.0.0",
+        "babel-preset-react-app": "^10.0.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
         "cross-env": "^7.0.3",
         "eslint": "^8.3.0",
-        "eslint-config-react-app": "^6.0.0",
+        "eslint-config-react-app": "^7.0.0",
         "flow-bin": "^0.116.0",
         "html-entities": "^2.3.2",
         "jest": "^27.4.3",
@@ -26041,12 +26040,13 @@
         "promise": "^8.1.0",
         "raw-loader": "^4.0.2",
         "react": "^17.0.2",
-        "react-app-polyfill": "^2.0.0",
+        "react-app-polyfill": "^3.0.0",
         "react-dom": "^17.0.2",
         "rimraf": "^3.0.2",
         "settle-promise": "^1.0.0",
         "source-map": "^0.5.7",
-        "webpack": "^5.64.4"
+        "terser-webpack-plugin": "^5.3.0",
+        "webpack": "^5.65.0"
       }
     },
     "packages/react-error-overlay/node_modules/source-map": {
@@ -26059,7 +26059,7 @@
       }
     },
     "packages/react-scripts": {
-      "version": "4.0.3",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -26067,8 +26067,8 @@
         "@svgr/webpack": "^5.5.0",
         "babel-jest": "^27.4.2",
         "babel-loader": "^8.2.3",
-        "babel-plugin-named-asset-import": "^0.3.7",
-        "babel-preset-react-app": "^10.0.0",
+        "babel-plugin-named-asset-import": "^0.3.8",
+        "babel-preset-react-app": "^10.0.1",
         "bfj": "^7.0.2",
         "browserslist": "^4.18.1",
         "camelcase": "^6.2.1",
@@ -26078,7 +26078,7 @@
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0",
         "eslint": "^8.3.0",
-        "eslint-config-react-app": "^6.0.0",
+        "eslint-config-react-app": "^7.0.0",
         "eslint-webpack-plugin": "^3.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.0",
@@ -26094,8 +26094,8 @@
         "postcss-normalize": "^10.0.1",
         "postcss-preset-env": "^7.0.1",
         "prompts": "^2.4.2",
-        "react-app-polyfill": "^2.0.0",
-        "react-dev-utils": "^11.0.4",
+        "react-app-polyfill": "^3.0.0",
+        "react-dev-utils": "^12.0.0",
         "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",
         "resolve-url-loader": "^4.0.0",
@@ -26105,7 +26105,7 @@
         "style-loader": "^3.3.1",
         "tailwindcss": "^3.0.2",
         "terser-webpack-plugin": "^5.2.5",
-        "webpack": "^5.64.4",
+        "webpack": "^5.65.0",
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
@@ -29113,7 +29113,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.13.0",
@@ -30199,12 +30200,14 @@
     "acorn-import-assertions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw=="
+      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -30316,7 +30319,8 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "alex": {
       "version": "8.2.0",
@@ -32990,7 +32994,8 @@
     "css-blank-pseudo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-2.0.0.tgz",
-      "integrity": "sha512-n7fxEOyuvAVPLPb9kL4XTIK/gnp2fKQ7KFQ+9lj60W9pDn/jTr5LjS/kHHm+rES/YJ3m0S6+uJgYSuAJg9zOyA=="
+      "integrity": "sha512-n7fxEOyuvAVPLPb9kL4XTIK/gnp2fKQ7KFQ+9lj60W9pDn/jTr5LjS/kHHm+rES/YJ3m0S6+uJgYSuAJg9zOyA==",
+      "requires": {}
     },
     "css-declaration-sorter": {
       "version": "6.1.3",
@@ -33087,7 +33092,8 @@
     "css-prefers-color-scheme": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-5.0.0.tgz",
-      "integrity": "sha512-XpzVrdwbppHm+Nnrzcb/hQb8eq1aKv4U8Oh59LsLfTsbIZZ6Fvn9razb66ihH2aTJ0VhO9n9sVm8piyKXJAZMA=="
+      "integrity": "sha512-XpzVrdwbppHm+Nnrzcb/hQb8eq1aKv4U8Oh59LsLfTsbIZZ6Fvn9razb66ihH2aTJ0VhO9n9sVm8piyKXJAZMA==",
+      "requires": {}
     },
     "css-select": {
       "version": "4.1.3",
@@ -33186,7 +33192,8 @@
     "cssnano-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
-      "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ=="
+      "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -34028,8 +34035,8 @@
         "@rushstack/eslint-patch": "^1.1.0",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
-        "babel-preset-react-app": "^10.0.0",
-        "confusing-browser-globals": "^1.0.10",
+        "babel-preset-react-app": "^10.0.1",
+        "confusing-browser-globals": "^1.0.11",
         "eslint-plugin-flowtype": "^8.0.3",
         "eslint-plugin-import": "^2.25.3",
         "eslint-plugin-jest": "^25.3.0",
@@ -34267,7 +34274,8 @@
     "eslint-plugin-react-hooks": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
-      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA=="
+      "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "5.0.1",
@@ -36200,7 +36208,8 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "requires": {}
     },
     "idb": {
       "version": "6.1.5",
@@ -37171,7 +37180,8 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.4.0",
@@ -39994,7 +40004,8 @@
     "postcss-browser-comments": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
-      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg=="
+      "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
+      "requires": {}
     },
     "postcss-calc": {
       "version": "8.0.0",
@@ -40051,7 +40062,8 @@
     "postcss-custom-media": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
-      "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g=="
+      "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
+      "requires": {}
     },
     "postcss-custom-properties": {
       "version": "12.0.0",
@@ -40080,22 +40092,26 @@
     "postcss-discard-comments": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
-      "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg=="
+      "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
-      "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA=="
+      "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
-      "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw=="
+      "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
-      "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q=="
+      "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
+      "requires": {}
     },
     "postcss-double-position-gradients": {
       "version": "3.0.1",
@@ -40116,27 +40132,32 @@
     "postcss-flexbugs-fixes": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
-      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ=="
+      "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
+      "requires": {}
     },
     "postcss-focus-visible": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-6.0.1.tgz",
-      "integrity": "sha512-UddLlBmJ78Nu7OrKME70EKxCPBdxTx7pKIyD3GDNRM8Tnq19zmscT9QzsvR8gygz0i0nNUjMtSz4N3AEWZ5R/Q=="
+      "integrity": "sha512-UddLlBmJ78Nu7OrKME70EKxCPBdxTx7pKIyD3GDNRM8Tnq19zmscT9QzsvR8gygz0i0nNUjMtSz4N3AEWZ5R/Q==",
+      "requires": {}
     },
     "postcss-focus-within": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-5.0.1.tgz",
-      "integrity": "sha512-50v1AZVlFSVzLTNdBQG521Aa54VABf/X1RkhR8Fm/9dDQby0W0XdwOnuo8Juvf0ZZXbKkxyTkyyQD0QaNVZVGg=="
+      "integrity": "sha512-50v1AZVlFSVzLTNdBQG521Aa54VABf/X1RkhR8Fm/9dDQby0W0XdwOnuo8Juvf0ZZXbKkxyTkyyQD0QaNVZVGg==",
+      "requires": {}
     },
     "postcss-font-variant": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
+      "requires": {}
     },
     "postcss-gap-properties": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.0.tgz",
-      "integrity": "sha512-QJOkz1epC/iCuOdhQPm3n9T+F25+P+MYJEEcs5xz/Q+020mc9c6ZRGJkzPJd8FS9hFmT9eEKFEx9PEDl+lH5og=="
+      "integrity": "sha512-QJOkz1epC/iCuOdhQPm3n9T+F25+P+MYJEEcs5xz/Q+020mc9c6ZRGJkzPJd8FS9hFmT9eEKFEx9PEDl+lH5og==",
+      "requires": {}
     },
     "postcss-image-set-function": {
       "version": "4.0.2",
@@ -40149,7 +40170,8 @@
     "postcss-initial": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
-      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ=="
+      "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
+      "requires": {}
     },
     "postcss-js": {
       "version": "3.0.3",
@@ -40202,12 +40224,14 @@
     "postcss-logical": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.0.tgz",
-      "integrity": "sha512-fWEWMn/xf6F9SMzAD7OS0GTm8Qh1BlBmEbVT/YZGYhwipQEwOpO7YOOu+qnzLksDg9JjLRj5tLmeN8OW8+ogIA=="
+      "integrity": "sha512-fWEWMn/xf6F9SMzAD7OS0GTm8Qh1BlBmEbVT/YZGYhwipQEwOpO7YOOu+qnzLksDg9JjLRj5tLmeN8OW8+ogIA==",
+      "requires": {}
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ=="
+      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
+      "requires": {}
     },
     "postcss-merge-longhand": {
       "version": "5.0.4",
@@ -40270,7 +40294,8 @@
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw=="
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -40327,7 +40352,8 @@
     "postcss-normalize-charset": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
-      "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg=="
+      "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -40411,12 +40437,14 @@
     "postcss-overflow-shorthand": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.0.tgz",
-      "integrity": "sha512-4fTapLT68wUoIr4m3Z0sKn1NbXX0lJYvj4aDA2++KpNx8wMSVf55UuLPz0nSjXa7dV1p0xQHlJ0iFJRNrSY2mw=="
+      "integrity": "sha512-4fTapLT68wUoIr4m3Z0sKn1NbXX0lJYvj4aDA2++KpNx8wMSVf55UuLPz0nSjXa7dV1p0xQHlJ0iFJRNrSY2mw==",
+      "requires": {}
     },
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
+      "requires": {}
     },
     "postcss-place": {
       "version": "7.0.1",
@@ -40496,7 +40524,8 @@
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
+      "requires": {}
     },
     "postcss-selector-not": {
       "version": "5.0.0",
@@ -40863,7 +40892,8 @@
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
           "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -41034,7 +41064,7 @@
         "open": "^8.4.0",
         "pkg-up": "^3.1.0",
         "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.9",
+        "react-error-overlay": "^6.0.10",
         "recursive-readdir": "^2.2.2",
         "shell-quote": "^1.7.3",
         "strip-ansi": "^6.0.1",
@@ -41067,12 +41097,12 @@
         "anser": "^2.1.0",
         "babel-jest": "^27.4.2",
         "babel-loader": "^8.2.3",
-        "babel-preset-react-app": "^10.0.0",
+        "babel-preset-react-app": "^10.0.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
         "cross-env": "^7.0.3",
         "eslint": "^8.3.0",
-        "eslint-config-react-app": "^6.0.0",
+        "eslint-config-react-app": "^7.0.0",
         "flow-bin": "^0.116.0",
         "html-entities": "^2.3.2",
         "jest": "^27.4.3",
@@ -41081,12 +41111,13 @@
         "promise": "^8.1.0",
         "raw-loader": "^4.0.2",
         "react": "^17.0.2",
-        "react-app-polyfill": "^2.0.0",
+        "react-app-polyfill": "^3.0.0",
         "react-dom": "^17.0.2",
         "rimraf": "^3.0.2",
         "settle-promise": "^1.0.0",
         "source-map": "^0.5.7",
-        "webpack": "^5.64.4"
+        "terser-webpack-plugin": "^5.3.0",
+        "webpack": "^5.65.0"
       },
       "dependencies": {
         "source-map": {
@@ -41115,8 +41146,8 @@
         "@svgr/webpack": "^5.5.0",
         "babel-jest": "^27.4.2",
         "babel-loader": "^8.2.3",
-        "babel-plugin-named-asset-import": "^0.3.7",
-        "babel-preset-react-app": "^10.0.0",
+        "babel-plugin-named-asset-import": "^0.3.8",
+        "babel-preset-react-app": "^10.0.1",
         "bfj": "^7.0.2",
         "browserslist": "^4.18.1",
         "camelcase": "^6.2.1",
@@ -41126,7 +41157,7 @@
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0",
         "eslint": "^8.3.0",
-        "eslint-config-react-app": "^6.0.0",
+        "eslint-config-react-app": "^7.0.0",
         "eslint-webpack-plugin": "^3.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.0",
@@ -41144,8 +41175,8 @@
         "postcss-preset-env": "^7.0.1",
         "prompts": "^2.4.2",
         "react": "^17.0.2",
-        "react-app-polyfill": "^2.0.0",
-        "react-dev-utils": "^11.0.4",
+        "react-app-polyfill": "^3.0.0",
+        "react-dev-utils": "^12.0.0",
         "react-dom": "^17.0.2",
         "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",
@@ -41156,7 +41187,7 @@
         "style-loader": "^3.3.1",
         "tailwindcss": "^3.0.2",
         "terser-webpack-plugin": "^5.2.5",
-        "webpack": "^5.64.4",
+        "webpack": "^5.65.0",
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
@@ -42892,7 +42923,8 @@
     "style-loader": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ=="
+      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.0.1",
@@ -43990,11 +44022,11 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
-      "integrity": "sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.0.tgz",
+      "integrity": "sha512-LPIisi3Ol4chwAaPP8toUJ3L4qCM1G0wao7L3qNv57Drezxj6+VEyySpPw4B1HSO2Eg/hDY/MNF5XihCAoqnsQ==",
       "requires": {
-        "jest-worker": "^27.0.6",
+        "jest-worker": "^27.4.1",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
         "source-map": "^0.6.1",
@@ -44967,9 +44999,9 @@
       }
     },
     "watchpack": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.0.tgz",
-      "integrity": "sha512-MnN0Q1OsvB/GGHETrFeZPQaOelWh/7O+EiFlj8sM9GPjtQkis7k01aAxrg/18kTfoIVcLL+haEVFlXDaSRwKRw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+      "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -45010,9 +45042,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
-      "version": "5.64.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.4.tgz",
-      "integrity": "sha512-LWhqfKjCLoYJLKJY8wk2C3h77i8VyHowG3qYNZiIqD6D0ZS40439S/KVuc/PY48jp2yQmy0mhMknq8cys4jFMw==",
+      "version": "5.65.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.65.0.tgz",
+      "integrity": "sha512-Q5or2o6EKs7+oKmJo7LaqZaMOlDWQse9Tm5l1WAfU/ujLGN5Pb0SqGeVkN/4bpPmEqEP5RnVhiqsOtWtUVwGRw==",
       "requires": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",
@@ -45036,7 +45068,7 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.3.0",
+        "watchpack": "^2.3.1",
         "webpack-sources": "^3.2.2"
       },
       "dependencies": {
@@ -45193,7 +45225,8 @@
         "ws": {
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
-          "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw=="
+          "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
+          "requires": {}
         }
       }
     },
@@ -45778,7 +45811,8 @@
     "ws": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
+      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "requires": {}
     },
     "x-is-string": {
       "version": "0.1.0",

--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -59,7 +59,8 @@
     "rimraf": "^3.0.2",
     "settle-promise": "^1.0.0",
     "source-map": "^0.5.7",
-    "webpack": "^5.64.4"
+    "terser-webpack-plugin": "^5.3.0",
+    "webpack": "^5.65.0"
   },
   "jest": {
     "setupFiles": [

--- a/packages/react-error-overlay/webpack.config.iframe.js
+++ b/packages/react-error-overlay/webpack.config.iframe.js
@@ -11,6 +11,7 @@ const webpack = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = {
+  target: ['web', 'es5'],
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: './src/iframeScript.js',
   output: {
@@ -74,6 +75,8 @@ module.exports = {
       'process.env': { NODE_ENV: '"production"' },
       // This prevents our bundled React from accidentally hijacking devtools.
       __REACT_DEVTOOLS_GLOBAL_HOOK__: '({})',
+      // webpack 5 does no longer include a polyfill for this Node.js variable
+      process: '({})',
     }),
   ],
   performance: false,

--- a/packages/react-error-overlay/webpack.config.js
+++ b/packages/react-error-overlay/webpack.config.js
@@ -9,13 +9,16 @@
 const path = require('path');
 
 module.exports = {
+  target: ['web', 'es5'],
   mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
   entry: './src/index.js',
   output: {
+    library: {
+      name: 'ReactErrorOverlay',
+      type: 'umd',
+    },
     path: path.join(__dirname, './lib'),
     filename: 'index.js',
-    library: 'ReactErrorOverlay',
-    libraryTarget: 'umd',
   },
   module: {
     rules: [

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -71,7 +71,7 @@
     "style-loader": "^3.3.1",
     "tailwindcss": "^3.0.2",
     "terser-webpack-plugin": "^5.2.5",
-    "webpack": "^5.64.4",
+    "webpack": "^5.65.0",
     "webpack-dev-server": "^4.6.0",
     "webpack-manifest-plugin": "^4.0.2",
     "workbox-webpack-plugin": "^6.4.1"


### PR DESCRIPTION
Webpack 5 removes the automatic polyfill of NodeJS global "process", this pr adds process fallback as empty object.

Aditionally:
* Updated Webpack
* Updated react-error-overlay build script to use Webpack 5 compiler (in v5 the compiler needs to be closed)
* Updated webpack configs for react-error-overlay

Fixes #11773