### PR TITLE
fix the bug in the @use example code

### DIFF
--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -26,7 +26,7 @@ To share variables between Sass files, you can use Sass's [`@use` rule](https://
 This will allow you to do imports like
 
 ```scss
-@use 'styles/_colors.scss'; // assuming a styles directory under src/
+@use 'styles/colors.scss'; // assuming a styles directory under src/
 @use '~nprogress/nprogress'; // loading a css file from the nprogress node module
 ```
 


### PR DESCRIPTION
for @use, Variables, mixins, and functions (what Sass calls "members") that start with an underscore (_) or hyphen (-) are considered private, and not imported.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
