### PR TITLE
fix: replace https to server to support Webpack 5

### DIFF
--- a/packages/react-scripts/config/getServerConfig.js
+++ b/packages/react-scripts/config/getServerConfig.js
@@ -51,24 +51,30 @@ function readEnvFile(file, type) {
   return fs.readFileSync(file);
 }
 
-// Get the https config
-// Return cert files if provided in env, otherwise just true or false
-function getHttpsConfig() {
+// Get the server config
+// Return server option if provided in env, otherwise just string
+function getServerConfig() {
   const { SSL_CRT_FILE, SSL_KEY_FILE, HTTPS } = process.env;
-  const isHttps = HTTPS === 'true';
+  const protocolType = HTTPS === 'true' ? 'https' : 'http';
 
-  if (isHttps && SSL_CRT_FILE && SSL_KEY_FILE) {
-    const crtFile = path.resolve(paths.appPath, SSL_CRT_FILE);
-    const keyFile = path.resolve(paths.appPath, SSL_KEY_FILE);
-    const config = {
-      cert: readEnvFile(crtFile, 'SSL_CRT_FILE'),
-      key: readEnvFile(keyFile, 'SSL_KEY_FILE'),
-    };
+  if (protocolType === 'https') {
+    if (SSL_CRT_FILE && SSL_KEY_FILE) {
+      const crtFile = path.resolve(paths.appPath, SSL_CRT_FILE);
+      const keyFile = path.resolve(paths.appPath, SSL_KEY_FILE);
+      const config = {
+        type: protocolType,
+        options: {
+          cert: readEnvFile(crtFile, 'SSL_CRT_FILE'),
+          key: readEnvFile(keyFile, 'SSL_KEY_FILE'),
+        },
+      };
 
-    validateKeyAndCerts({ ...config, keyFile, crtFile });
-    return config;
+      validateKeyAndCerts({ ...config.options, keyFile, crtFile });
+      return config;
+    }
+    return protocolType;
   }
-  return isHttps;
+  return protocolType;
 }
 
-module.exports = getHttpsConfig;
+module.exports = getServerConfig;

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -14,7 +14,7 @@ const noopServiceWorkerMiddleware = require('react-dev-utils/noopServiceWorkerMi
 const ignoredFiles = require('react-dev-utils/ignoredFiles');
 const redirectServedPath = require('react-dev-utils/redirectServedPathMiddleware');
 const paths = require('./paths');
-const getHttpsConfig = require('./getHttpsConfig');
+const getServerConfig = require('./getServerConfig');
 
 const host = process.env.HOST || '0.0.0.0';
 const sockHost = process.env.WDS_SOCKET_HOST;
@@ -98,8 +98,9 @@ module.exports = function (proxy, allowedHost) {
       // remove last slash so user can land on `/test` instead of `/test/`
       publicPath: paths.publicUrlOrPath.slice(0, -1),
     },
-
-    https: getHttpsConfig(),
+    // https is deprecated from webpack-dev-server v4.4.0+ in favor of server option.
+    // see https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#440-2021-10-27
+    server: getServerConfig(),
     host,
     historyApiFallback: {
       // Paths with dots should still use the history fallback.


### PR DESCRIPTION
### Describe the bug
Project CRA 5, with a `.env.development.local` file configured with HTTPS settings, gives deprecation warning.

### Actual behavior
A deprecation warning is issued on bootstrap, app still works properly.
Screenshot:
![image](https://user-images.githubusercontent.com/28497046/146750810-a13ddfb0-46cd-4502-a3d1-b4b1d4cd2f82.png)

### Core idea
https://github.com/facebook/create-react-app/blob/20edab4894b301f6b90dad0f90a2f82c52a7ac66/packages/react-scripts/config/webpackDevServer.config.js#L102

Replace `https: getHttpsConfig(): {
        cert: Buffer;
        key: Buffer;
    } | boolean`
with `server: getServerConfig(): "http" | "https" | { type: "https"; options: { cert: Buffer; key: Buffer; }; }`

```javascript
function getServerConfig() {
  const { SSL_CRT_FILE, SSL_KEY_FILE, HTTPS } = process.env;
  const protocolType = HTTPS === 'true' ? 'https' : 'http';

  if (protocolType === 'https') {
    if (SSL_CRT_FILE && SSL_KEY_FILE) {
      const crtFile = path.resolve(paths.appPath, SSL_CRT_FILE);
      const keyFile = path.resolve(paths.appPath, SSL_KEY_FILE);
      const config = {
        type: protocolType,
        options: {
          cert: readEnvFile(crtFile, 'SSL_CRT_FILE'),
          key: readEnvFile(keyFile, 'SSL_KEY_FILE'),
        },
      };

      validateKeyAndCerts({ ...config.options, keyFile, crtFile });
      return config;
    }
    return protocolType;
  }
  return protocolType;
}
```
Modify the function to move https config into "server" options and align schemas

### After fixing
The deprecation warning is eliminated successfully.
Screenshot:
![image](https://user-images.githubusercontent.com/28497046/146754449-59fd70b1-a7e1-41d5-a96b-7f8eb9e3b702.png)
