### PR TITLE
Update references of 'master' to 'main' in Deployment doc

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -318,13 +318,13 @@ The `predeploy` script will run automatically before `deploy` is run.
 If you are deploying to a GitHub user page instead of a project page you'll need to make one
 additional modification:
 
-1. Tweak your `package.json` scripts to push deployments to **master**:
+1. Tweak your `package.json` scripts to push deployments to **main**:
 
 ```diff
   "scripts": {
     "predeploy": "npm run build",
 -   "deploy": "gh-pages -d build",
-+   "deploy": "gh-pages -b master -d build",
++   "deploy": "gh-pages -b main -d build",
 ```
 
 ### Step 3: Deploy the site by running `npm run deploy`


### PR DESCRIPTION
**Issue**
The deployments were referring to the _master_ branch for the GitHub Pages documentation (which is now outdated)

**Fix**
Changed references to _main_

**Notes**
I was thinking of adding a disclaimer so people with an old repo were able to follow with master instead of main but ultimately decided not to add it. Let me know if you think we should