### PR TITLE
Add missing step when adding TS to an existing project

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -33,6 +33,37 @@ npm install --save typescript @types/node @types/react @types/react-dom @types/j
 yarn add typescript @types/node @types/react @types/react-dom @types/jest
 ```
 
+Add a [`tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) to the root directory of the project. 
+
+```json
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ]
+}
+```
+
 Next, rename any file to be a TypeScript file (e.g. `src/index.js` to `src/index.tsx`) and **restart your development server**!
 
 Type errors will show up in the same console as the build one. You'll have to fix these type errors before you continue development or build your project. For advanced configuration, [see here](advanced-configuration.md).


### PR DESCRIPTION
There is one step missing if one is trying to add TS to an existing project.

I ran into this issue when I was following the current docs:

<img width="1380" alt="CleanShot 2021-12-21 at 14 24 32@2x" src="https://user-images.githubusercontent.com/284515/146972556-7c047e2a-aae8-42d7-aa86-f02eb6c82bb5.png">

I had to create a new application using the TypeScript template and found out that the `tsconfig.json` was missing from the docs.