### PR TITLE
Update links for code splitting and dependencies

### DIFF
--- a/packages/react-dev-utils/FileSizeReporter.js
+++ b/packages/react-dev-utils/FileSizeReporter.js
@@ -92,12 +92,12 @@ function printFileSizesAfterBuild(
     );
     console.log(
       chalk.yellow(
-        'Consider reducing it with code splitting: https://goo.gl/9VhYWB'
+        'Consider reducing it with code splitting: https://create-react-app.dev/docs/code-splitting/'
       )
     );
     console.log(
       chalk.yellow(
-        'You can also analyze the project dependencies: https://goo.gl/LeUzfb'
+        'You can also analyze the project dependencies: https://create-react-app.dev/docs/analyzing-the-bundle-size/'
       )
     );
   }


### PR DESCRIPTION
Save users a few redirects and 2 clicks by linking to the current docs for code splitting and analyzing bundle size.

More specifically, previously, the link for code splitting pointed to https://goo.gl/9VhYWB, which pointed to https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#code-splitting, which redirects to https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/template/README.md#code-splitting, which displayed a "This file has moved here" pointing to https://github.com/facebook/create-react-app/blob/main/packages/cra-template/template/README.md, which links to the new docs: https://create-react-app.dev/docs/code-splitting/

Similarly, previously, the link for analyzing dependencies/bundle size pointed to  https://goo.gl/LeUzfb, which pointed to https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#analyzing-the-bundle-size, which redirected to https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/template/README.md#analyzing-the-bundle-size, which displayed a message "This file has moved here" pointing to https://github.com/facebook/create-react-app/blob/main/packages/cra-template/template/README.md, which links to the new docs: https://create-react-app.dev/docs/analyzing-the-bundle-size/

```sh
The bundle size is significantly larger than recommended.
Consider reducing it with code splitting: https://goo.gl/9VhYWB
You can also analyze the project dependencies: https://goo.gl/LeUzfb
```
<img width="944" alt="file_has_moved" src="https://user-images.githubusercontent.com/177059/147612147-0de201d5-07b3-424e-a836-d4df8e1d18d7.png">
<img width="837" alt="file_has_moved_2" src="https://user-images.githubusercontent.com/177059/147612151-e4c49958-931b-4b08-b4ad-dde85878e3ec.png">

