### PR TITLE
Update: directory hierarchy README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,14 @@ my-app
 ├── README.md
 ├── node_modules
 ├── package.json
+├── package-lock.json
 ├── .gitignore
 ├── public
 │   ├── favicon.ico
 │   ├── index.html
-│   └── manifest.json
+│   ├── logo*.png
+│   ├── manifest.json
+│   └── robots.txt
 └── src
     ├── App.css
     ├── App.js
@@ -87,7 +90,7 @@ my-app
     ├── index.css
     ├── index.js
     ├── logo.svg
-    └── serviceWorker.js
+    ├── reportWebVitals.js
     └── setupTests.js
 ```
 


### PR DESCRIPTION
The directory structure mentioned in the [README.md](https://github.com/facebook/create-react-app/blob/main/README.md) is a little outdated as it is still like this,  
![image](https://user-images.githubusercontent.com/67514541/147881336-600daf61-ed3d-47ac-8746-8527301d7ba8.png)

But the structure after `npx create-react-app my-app` is like following,

![image](https://user-images.githubusercontent.com/67514541/147881457-200cd25e-5c72-497b-8408-d111305a594f.png)

so following changes are made,

![image](https://user-images.githubusercontent.com/67514541/147881497-4e4dc386-05fc-49d3-a4f8-a826d54270cb.png)


