### PR TITLE
Fix incorrect glob pattern in webpack config

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -752,7 +752,7 @@ module.exports = function (webpackEnv) {
             ],
             exclude: [
               { file: '**/src/**/__tests__/**' },
-              { file: '**/src/**/?(*.){spec|test}.*' },
+              { file: '**/src/**/?(*.){spec,test}.*' },
               { file: '**/src/setupProxy.*' },
               { file: '**/src/setupTests.*' },
             ],


### PR DESCRIPTION
After upgrading to `react-scripts` v5, we noticed unexpected Typescript errors related to test files when running the dev server.  

It seems that one of the "exclude" rules has not been adapted correctly during the upgrade in #11201
