### PR TITLE
fix(react-scripts): do not set allowedHosts if undefined

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -22,8 +22,12 @@ const sockPath = process.env.WDS_SOCKET_PATH; // default: '/ws'
 const sockPort = process.env.WDS_SOCKET_PORT;
 
 module.exports = function (proxy, allowedHost) {
-  const disableFirewall =
-    !proxy || process.env.DANGEROUSLY_DISABLE_HOST_CHECK === 'true';
+  let allowedHosts;
+  if (!proxy || process.env.DANGEROUSLY_DISABLE_HOST_CHECK === 'true') {
+    allowedHosts = 'all';
+  } else if (allowedHost != null) {
+    allowedHosts = [allowedHost];
+  }
   return {
     // WebpackDevServer 2.4.3 introduced a security fix that prevents remote
     // websites from potentially accessing local content through DNS rebinding:
@@ -43,7 +47,7 @@ module.exports = function (proxy, allowedHost) {
     // really know what you're doing with a special environment variable.
     // Note: ["localhost", ".localhost"] will support subdomains - but we might
     // want to allow setting the allowedHosts manually for more complex setups
-    allowedHosts: disableFirewall ? 'all' : [allowedHost],
+    allowedHosts,
     headers: {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': '*',


### PR DESCRIPTION
Fixes #11762.

`urls.lanUrlForConfig` may be `undefined`, if the `HOST` is set, the IP address is not private, or the IP address retrival has failed.

TEST PLAN: manual testing with the steps to reproduce from #11762.
