### PR TITLE
fix: exclude .spec and .test files from type checking

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -752,7 +752,7 @@ module.exports = function (webpackEnv) {
             ],
             exclude: [
               { file: '**/src/**/__tests__/**' },
-              { file: '**/src/**/?(*.){spec|test}.*' },
+              { file: '**/src/**/?(*.){spec,test}.*' },
               { file: '**/src/setupProxy.*' },
               { file: '**/src/setupTests.*' },
             ],


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

This PR fixes `react-scripts@5` including test files when type checking during `npm start` and `npm build`. This was changed in the upgrade to `webpack@5` https://github.com/facebook/create-react-app/pull/11201/files#diff-8e25c4f6f592c1fcfc38f0d43d62cbd68399f44f494c1b60f0cf9ccd7344d697R732 however the syntax does not exclude `.spec` and `.test` files.

There is a reproduction repo at https://github.com/jwalton9/cra-test-type-error which introduces a type error to `src/App.test.tsx`. Running `npm start` causes these issues to be reported.

The changes were validated by using `npm link` and running `npm start`

Fixes #11979