### PR TITLE
add missing `peerDependencies` to `react-dev-utils`

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -81,6 +81,10 @@
     "cross-env": "^7.0.3",
     "jest": "^27.4.3"
   },
+  "peerDependencies": {
+    "typescript": "*",
+    "webpack": "*"
+  },
   "scripts": {
     "test": "cross-env FORCE_COLOR=true jest"
   }


### PR DESCRIPTION
Resolving this `npm install`/`yarn install` warning:

```
➤ YN0002: │ react-dev-utils@npm:11.0.4 doesn't provide typescript (p79ddf), requested by fork-ts-checker-webpack-plugin
➤ YN0002: │ react-dev-utils@npm:11.0.4 doesn't provide webpack (p2af19), requested by fork-ts-checker-webpack-plugin
```

I just put a blanket `*` version, but if you know a specific version (e.g. major version), that's a good change. I figured anything is better than nothing for a first release.