### PR TITLE
fix: 未定义的环境变量导致的安全问题

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -99,12 +99,11 @@ function getClientEnvironment(publicUrl) {
       }
     );
   // Stringify all values so we can feed into webpack DefinePlugin
-  const stringified = {
-    'process.env': Object.keys(raw).reduce((env, key) => {
-      env[key] = JSON.stringify(raw[key]);
-      return env;
-    }, {}),
-  };
+  const stringified = Object.keys(raw).reduce((env, key) => {
+    env['process.env.' + key] = JSON.stringify(raw[key]);
+    return env;
+  }, {});
+  stringified["process.env"] = 'Object()';
 
   return { raw, stringified };
 }


### PR DESCRIPTION
将`process.env`设置为'Object'，以防止未定义的环境变量导致的安全问题。
[#9171](https://github.com/facebook/create-react-app/pull/9171#issue-640036148)
[#8389](https://github.com/facebook/create-react-app/pull/8389#issue-556595203)
[#8961](https://github.com/facebook/create-react-app/issues/8961#issue-612709727)
如果我破坏了什么，请在此处告诉我