### PR TITLE
feature: allow for custom error messaging in ModuleScopePlugin

### DIFF
--- a/packages/react-dev-utils/ModuleScopePlugin.js
+++ b/packages/react-dev-utils/ModuleScopePlugin.js
@@ -12,10 +12,11 @@ const path = require('path');
 const os = require('os');
 
 class ModuleScopePlugin {
-  constructor(appSrc, allowedFiles = []) {
+  constructor(appSrc, allowedFiles = [], errorMessage) {
     this.appSrcs = Array.isArray(appSrc) ? appSrc : [appSrc];
     this.allowedFiles = new Set(allowedFiles);
     this.allowedPaths = [...allowedFiles].map(path.dirname).filter(p => path.relative(p, process.cwd()) !== '');
+    this.errorMessage = errorMessage;
   }
 
   apply(resolver) {
@@ -70,8 +71,7 @@ class ModuleScopePlugin {
             );
           })
         ) {
-          const scopeError = new Error(
-            `You attempted to import ${chalk.cyan(
+          const message = !!this.errorMessage ? this.errorMessage : `You attempted to import ${chalk.cyan(
               request.__innerRequest_request
             )} which falls outside of the project ${chalk.cyan(
               'src/'
@@ -85,7 +85,7 @@ class ModuleScopePlugin {
               )}, or add a symlink to it from project's ${chalk.cyan(
                 'node_modules/'
               )}.`
-          );
+          const scopeError = new Error(message);
           Object.defineProperty(scopeError, '__module_scope_plugin', {
             value: true,
             writable: false,


### PR DESCRIPTION
This is purely related to https://github.com/facebook/create-react-app/discussions/11977 as a proof of concept for what I'm proposing. It would allow folks who directly use this webpack plugin to customize the error output. Broader use of this error through other means in CRA would need more development.

This change allows the developer to pass in an error message so that they can provide a custom error message for the missing module in the event that it is ejected from CRA OR when the developer is using `react-dev-utils` directly for their own use case (which is my current way of using this). So this allows developers who use this to get a more fine grain result for their end users with a better error message.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
