### PR TITLE
Added app name as hash salt for css modules ident

### DIFF
--- a/packages/react-dev-utils/__tests__/getCSSModuleLocalIdent.test.js
+++ b/packages/react-dev-utils/__tests__/getCSSModuleLocalIdent.test.js
@@ -11,7 +11,11 @@ const getCSSModuleLocalIdent = require('../getCSSModuleLocalIdent');
 
 const rootContext = '/path';
 const defaultClassName = 'class';
-const options = { context: undefined, hashPrefix: '', regExp: null };
+const defaultOptions = {
+  context: undefined,
+  hashSalt: undefined,
+  regExp: null,
+};
 
 const tests = [
   {
@@ -27,14 +31,40 @@ const tests = [
     expected: 'file_class__dINZX',
   },
   {
+    resourcePath: '/path/to/file.module.sass',
+    expected: 'file_class__9vVbt',
+    options: {
+      hashSalt: 'my-app',
+    },
+  },
+  {
     resourcePath: '/path/to/file.name.module.css',
     expected: 'file_name_class__XpUJW',
+  },
+  {
+    resourcePath: '/path/to/file.name.module.css',
+    expected: 'file_name_class__OS1Yg',
+    options: {
+      hashSalt: 'my-app',
+    },
+  },
+  {
+    resourcePath: '/path/to/file.name.module.css',
+    expected: 'file_name_class__uMbcn',
+    options: {
+      hashSalt: 'my-app-123',
+    },
   },
 ];
 
 describe('getCSSModuleLocalIdent', () => {
   tests.forEach(test => {
-    const { className = defaultClassName, expected, resourcePath } = test;
+    const {
+      className = defaultClassName,
+      expected,
+      resourcePath,
+      options = defaultOptions,
+    } = test;
     it(JSON.stringify({ resourcePath, className }), () => {
       const ident = getCSSModuleLocalIdent(
         {

--- a/packages/react-dev-utils/getCSSModuleLocalIdent.js
+++ b/packages/react-dev-utils/getCSSModuleLocalIdent.js
@@ -22,9 +22,13 @@ module.exports = function getLocalIdent(
   )
     ? '[folder]'
     : '[name]';
-  // Create a hash based on a the file location and class name. Will be unique across a project, and close to globally unique.
+  // Create a hash based on the relative file location, class name and hashSalt (if given).
+  // Will be unique across a project and globally unique with a suitable hashSalt.
+  const hashSalt = options.hashSalt || '';
   const hash = loaderUtils.getHashDigest(
-    path.posix.relative(context.rootContext, context.resourcePath) + localName,
+    hashSalt +
+      path.posix.relative(context.rootContext, context.resourcePath) +
+      localName,
     'md5',
     'base64',
     5

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -95,6 +95,8 @@ const hasJsxRuntime = (() => {
   }
 })();
 
+const appName = require(paths.appPackageJson).name;
+
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 module.exports = function (webpackEnv) {
@@ -537,6 +539,7 @@ module.exports = function (webpackEnv) {
                 modules: {
                   mode: 'local',
                   getLocalIdent: getCSSModuleLocalIdent,
+                  localIdentHashSalt: appName,
                 },
               }),
             },
@@ -577,6 +580,7 @@ module.exports = function (webpackEnv) {
                   modules: {
                     mode: 'local',
                     getLocalIdent: getCSSModuleLocalIdent,
+                    localIdentHashSalt: appName,
                   },
                 },
                 'sass-loader'


### PR DESCRIPTION
Fixes CSS Module class name collisions (#9134 and #10190) by adding the app name as a hash salt. The change preserves #6875. The css module hash is stable within the project but globally unique (as long as the app name is unique).

Test steps:
- Create an application
- Create a App.module.css, import and use it in App.js
- Start the application and check the generated hash
- Stop the application and change appName in package.json
- Start the application and check the generated hash

Previous: The generate css module hash stays the same.

Now: The generate css module hash changes as the app name has been changed.

Please let me know if you need more information.