### PR TITLE
Fix react-error-overlay iframe overlay 

### DIFF
--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -118,6 +118,7 @@ const iframeStyle = {
   height: '100%',
   border: 'none',
   'z-index': 2147483647,
+  'pointer-event': 'none',
 };
 
 const overlayStyle = (theme: Theme) => ({

--- a/packages/react-error-overlay/src/styles.js
+++ b/packages/react-error-overlay/src/styles.js
@@ -118,7 +118,7 @@ const iframeStyle = {
   height: '100%',
   border: 'none',
   'z-index': 2147483647,
-  'pointer-event': 'none',
+  'pointer-events': 'none',
 };
 
 const overlayStyle = (theme: Theme) => ({


### PR DESCRIPTION
Sometimes when working on a project, it creates this container around the entire app during hot reload. It happens during `create-react-app: 4.x.x`

Upon further inspection it looks like it is an which is rendered in the browswer as this:
```
<iframe style="position: fixed; top: 0px; left: 0px; width: 100%; height: 100%; border: none; z-index: 2147483647;"></iframe>
```

This solution uses CSS to make this particular iframe never a target of pointer events.

Fixes:
- https://stackoverflow.com/questions/70499543/create-react-app-creates-this-iframe-that-prevents-me-from-clicking-or-editing
- https://stackoverflow.com/questions/69051008/react-injecting-iframe-with-max-z-index-on-reload-after-changes-development

Closes #11773