### PR TITLE
Move tailwindcss to optional peer dependencies

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -69,7 +69,6 @@
     "semver": "^7.3.5",
     "source-map-loader": "^3.0.0",
     "style-loader": "^3.3.1",
-    "tailwindcss": "^3.0.2",
     "terser-webpack-plugin": "^5.2.5",
     "webpack": "^5.64.4",
     "webpack-dev-server": "^4.6.0",
@@ -85,9 +84,13 @@
   },
   "peerDependencies": {
     "react": ">= 16",
+    "tailwindcss": "^3.0.2",
     "typescript": "^3.2.1 || ^4"
   },
   "peerDependenciesMeta": {
+    "tailwindcss": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     }


### PR DESCRIPTION
Fixes #12044

Installing tailwindcss comes with a bunch of junk most people don't need, and at least prettier-plugin-tailwindcss but possibly more subdependecies are unlicensed which makes usage troublesome.
