### PR TITLE
Fixed proxy middleware documentation for CRA v5.0.0

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -99,8 +99,7 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function(app) {
   app.use(
-    '/api',
-    createProxyMiddleware({
+    createProxyMiddleware('/api',{
       target: 'http://localhost:5000',
       changeOrigin: true,
     })


### PR DESCRIPTION
In the ticket #11762, @marr noticed a confusion in the configuration of a custom development proxy.

This confusion actually comes from the original [documentation](https://create-react-app.dev/docs/proxying-api-requests-in-development/#configuring-the-proxy-manually).
The snippet does not behave appropriately as of v5.0.0.

This PR intends to fix the documentation to make the custom proxy configuration worked as intended on CRA v5.0.0.