### PR TITLE
Fix missing build error paths

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -21,10 +21,12 @@ function formatMessage(message) {
     lines = message.split('\n');
   } else if ('message' in message) {
     lines = message['message'].split('\n');
+    lines.unshift(`TypeScript error in ${message['file']}`);
   } else if (Array.isArray(message)) {
     message.forEach(message => {
       if ('message' in message) {
         lines = message['message'].split('\n');
+        lines.unshift(`TypeScript error in ${message['file']}`);
       }
     });
   }


### PR DESCRIPTION
Fixes #12043.

Due to [this commit](https://github.com/facebook/create-react-app/commit/b172b5ed5eb2951394bb03e54c98c4500bd1903e), the file path indicating where a TypeScript build error came from was lost. See [this comment](https://github.com/facebook/create-react-app/issues/12043#issuecomment-1036604832) for a comparison of CRA v5 vs v4.

This is a very problematic bug, with an easy fix.

### Before

```
Creating an optimized production build...
Failed to compile.

TS6133: 'React' is declared but its value is never read.
    1 | // Imports
  > 2 | import React from 'react';
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    3 | import { render } from '@testing-library/react';
    4 | import Settings from './';
    5 | import { MemoryRouter } from 'react-router-dom';
```

### After

```
Creating an optimized production build...
Failed to compile.

TypeScript error in src/components/sections/settings/index.test.tsx:2:1
TS6133: 'React' is declared but its value is never read.
    1 | // Imports
  > 2 | import React from 'react';
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    3 | import { render } from '@testing-library/react';
    4 | import Settings from './';
    5 | import { MemoryRouter } from 'react-router-dom';
```