### PR TITLE
fix: allow creating react app on all networks

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -996,6 +996,20 @@ function getProxy() {
   }
 }
 
+function getRegisrty() {
+  if (process.env.npm_registry) {
+    return process.env.npm_registry;
+  } else {
+    try {
+      // Trying to read registry from .npmrc
+      let httpsProxy = execSync('npm config get registry').toString().trim();
+      return registry !== 'null' ? registry : undefined;
+    } catch (e) {
+      return;
+    }
+  }
+}
+
 // See https://github.com/facebook/create-react-app/pull/3355
 function checkThatNpmCanReadCwd() {
   const cwd = process.cwd();
@@ -1067,12 +1081,19 @@ function checkIfOnline(useYarn) {
 
   return new Promise(resolve => {
     dns.lookup('registry.yarnpkg.com', err => {
-      let proxy;
+      let proxy, registry;
       if (err != null && (proxy = getProxy())) {
         // If a proxy is defined, we likely can't resolve external hostnames.
         // Try to resolve the proxy name as an indication of a connection.
         dns.lookup(url.parse(proxy).hostname, proxyErr => {
           resolve(proxyErr == null);
+        });
+      } else if(err != null && (registry = getRegisrty()) {
+        // When running on a network that has no DNS record for yarnpkg.com,
+        // we would like to look after alternative npm registry that is being used.
+        // Try to resolve the registry defined in the .npmrc file as an indication of a connection.
+        dns.lookup(url.parse(registry).hostname, registryErr => {
+          resolve(registryErr == null);
         });
       } else {
         resolve(err == null);


### PR DESCRIPTION
`create-react-app` uses the `registry.yarnpkg.com`  DNS resolving process as an online status indicator.
This PR propose to use the registry defined in the `.npmrc` file whenever `registry.yarnpkg.com` can't be resolved.
This is essential for organizations that use a network where `registry.yarnpkg.com` DNS record does not exist.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
