### PR TITLE
Mention cra-envs

### DIFF
--- a/docusaurus/docs/adding-custom-environment-variables.md
+++ b/docusaurus/docs/adding-custom-environment-variables.md
@@ -12,7 +12,7 @@ Your project can consume variables declared in your environment as if they were 
 >
 > Environment variables are embedded into the build, meaning anyone can view them by inspecting your app's files.
 
-**The environment variables are embedded during the build time**. Since Create React App produces a static HTML/CSS/JS bundle, it can’t possibly read them at runtime. To read them at runtime, you would need to load HTML into memory on the server and replace placeholders in runtime, as [described here](title-and-meta-tags.md#injecting-data-from-the-server-into-the-page). Alternatively you can rebuild the app on the server anytime you change them.
+**The environment variables are embedded during the build time**. Since Create React App produces a static HTML/CSS/JS bundle, it can’t possibly read them at runtime. To read them at runtime, you would need to load HTML into memory on the server and replace placeholders in runtime, as [described here](title-and-meta-tags.md#injecting-data-from-the-server-into-the-page). You also have the possibility to use a third party tool like [cra-envs](https://github.com/etalab/cra-envs) that will handle the heavy lifting for you. Alternatively you can rebuild the app on the server anytime you change them.
 
 > Note: You must create custom environment variables beginning with `REACT_APP_`. Any other variables except `NODE_ENV` will be ignored to avoid accidentally [exposing a private key on the machine that could have the same name](https://github.com/facebook/create-react-app/issues/865#issuecomment-252199527). Changing any environment variables will require you to restart the development server if it is running.
 

--- a/docusaurus/docs/title-and-meta-tags.md
+++ b/docusaurus/docs/title-and-meta-tags.md
@@ -46,3 +46,5 @@ Similarly to the previous section, you can leave some placeholders in the HTML t
 ```
 
 Then, on the server, you can replace `__SERVER_DATA__` with a JSON of real data right before sending the response. The client code can then read `window.SERVER_DATA` to use it. **Make sure to [sanitize the JSON before sending it to the client](https://medium.com/node-security/the-most-common-xss-vulnerability-in-react-js-applications-2bdffbcc1fa0) as it makes your app vulnerable to XSS attacks.**
+
+There is a third party tool that implements this approach: [cra-envs](https://github.com/etalab/cra-envs).


### PR DESCRIPTION
Hi,  
We created a tool that enables environment variables to be injected at **launch** time. (Instead of at build time.)
It enables to ship customizable create-react-app.  

I invite you to have a link at the repo:  [etalab/cra-envs](https://github.com/etalab/cra-envs).  

We took care of respecting all the conventions you adopted. It even goes as far as complying with [the non-official support of EJS in the `public/index.html` file](https://github.com/facebook/create-react-app/issues/3112#issuecomment-328829771).  

We are committed to maintaining this project for the foreseeable future.  

This PR mentions the existence of the `cra-envs`.  
Let us know if there is anything you would like us to change in order to get this project referenced.  

Best regards,