### PR TITLE
Updated tsconfig.json：modify the compilation target from es5 to es6

### DIFF
--- a/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
+++ b/packages/react-scripts/scripts/utils/verifyTypeScriptSetup.js
@@ -118,8 +118,8 @@ function verifyTypeScriptSetup() {
     // tsconfig.json
     // 'parsedValue' matches the output value from ts.parseJsonConfigFileContent()
     target: {
-      parsedValue: ts.ScriptTarget.ES5,
-      suggested: 'es5',
+      parsedValue: ts.ScriptTarget.ES6,
+      suggested: 'es6',
     },
     lib: { suggested: ['dom', 'dom.iterable', 'esnext'] },
     allowJs: { suggested: true },


### PR DESCRIPTION
I ran into a problem yesterday, as follows:

```
type XxxType = 'aaa' | 'bbb' | 'ccc'
interface Xxx {
    type: XxxType
}
interface MyXxx {
    name: string
    xxx: Xxx
}
interface MyObj {
    arr: Iterable<MyXxx>
}

const myObj: MyObj = {
    arr: [ { name: 'aaa', xxx: { type: 'aaa' } } ]
}
```

<br>

emm...

```
Type '{ name: string; xxx: { type: string; }; }[]' is not assignable to type 'Iterable<MyXxx>'.
...
Type 'string' is not assignable to type 'XxxType'. ts[2322]
```

It's maddening and unbelievable.

I think there is nothing wrong with what I wrote.



<br>

Finally, I found the reason.

```diff
{
  "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
    ...
  }
}
```

> ES6 also called ES2015 



<br>

**ES5 seems like a very long time ago.**
So I suggest changing the default ES5 to ES6.

