### PR TITLE
Use textContent instead of innerHTML when assigning script

### DIFF
--- a/packages/react-error-overlay/src/index.js
+++ b/packages/react-error-overlay/src/index.js
@@ -146,7 +146,7 @@ function update() {
         'script'
       );
       script.type = 'text/javascript';
-      script.innerHTML = iframeScript;
+      script.textContent = iframeScript;
       iframeDocument.body.appendChild(script);
     }
   };


### PR DESCRIPTION
Currently, `packages/react-error-overlay/src/index.js` has a code where script is assigned using `innerHTML`.
This causes a problem in document under [Trusted Types](https://web.dev/trusted-types/) enforcement, because assignment to `innerHTML` requires  `TrustedHTML`, but resulting html will be treated as script and therefore requires `TrustedScript`.

This change modifies script assignment using `textContent` which wouldn't require `TrustedHTML`, and therefore `TrustedScript` can be assigned (through default policy in Trusted Types).

Note: further change would be required if this library wants to be compatible with Trusted Types. However, this change only aims to allow this library to operate using default policy (which is not ideal but just a work around).