### PR TITLE
fix process is not defined

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -100,6 +100,7 @@ function getClientEnvironment(publicUrl) {
     );
   // Stringify all values so we can feed into webpack DefinePlugin
   const stringified = {
+    'process': {},
     'process.env': Object.keys(raw).reduce((env, key) => {
       env[key] = JSON.stringify(raw[key]);
       return env;


### PR DESCRIPTION
Since Webpack 5 no longer shims node builtins, the `process` global is not defined, causing the ["Adding Custom Environment Variables"](https://create-react-app.dev/docs/adding-custom-environment-variables/) functionality to be broken.

<img width="1789" alt="image" src="https://user-images.githubusercontent.com/11806915/156679898-eb612516-4aee-4690-889f-cb1150fa1f4f.png">

This PR proposes a minimal fix that doesn't involve any external packages like ["process"](https://www.npmjs.com/package/process).

I verified the fix by locally modifying `packages/react-scripts/config/env.js` file.
<img width="1871" alt="image" src="https://user-images.githubusercontent.com/11806915/156681496-2b26b803-ebb3-4403-801d-8d8d3fb22217.png">