### PR TITLE
Faster builds with `react-scripts build --dev`

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -53,9 +53,10 @@ if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
 
 const argv = process.argv.slice(2);
 const writeStatsJson = argv.indexOf('--stats') !== -1;
+const productionMode = argv.indexOf('--dev') === -1;
 
 // Generate configuration
-const config = configFactory('production');
+const config = configFactory(productionMode ? 'production' : 'development');
 
 // We require that you explicitly set browsers and do not fall back to
 // browserslist defaults.


### PR DESCRIPTION
Hello,

I'll be honest, I've been going straight for the simplest solution, and I haven't actually tested it. Definitely review this before merging. I'm mostly doing this PR to try and prompt the maintainers to let such a thing exist.

I feel like there's too big a leap from `start` to `build`, as one also spawns a server (not required for my usecase), whereas the other only does production-optimized builds.

This might not be the cleanest way to do it, but I think this would allow a middle ground where one can run fast builds without spawning a server (useful when an other server is already serving the build folder).

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
