### PR TITLE
docs: update Algolia credentials

### DIFF
--- a/docusaurus/website/docusaurus.config.js
+++ b/docusaurus/website/docusaurus.config.js
@@ -43,8 +43,8 @@ const siteConfig = {
       isCloseable: false,
     },
     algolia: {
-      appId: 'create-react-app',
-      apiKey: '3be60f4f8ffc24c75da84857d6323791',
+      appId: 'AUJYIQ70HN',
+      apiKey: '25243dbf9049cf036e87f64b361bd2b9',
       indexName: 'create-react-app',
     },
     navbar: {
@@ -88,8 +88,7 @@ const siteConfig = {
           items: [
             {
               label: 'Stack Overflow',
-              href:
-                'https://stackoverflow.com/questions/tagged/create-react-app',
+              href: 'https://stackoverflow.com/questions/tagged/create-react-app',
             },
             {
               label: 'GitHub Discussions',
@@ -101,8 +100,7 @@ const siteConfig = {
             },
             {
               label: 'Contributor Covenant',
-              href:
-                'https://www.contributor-covenant.org/version/1/4/code-of-conduct',
+              href: 'https://www.contributor-covenant.org/version/1/4/code-of-conduct',
             },
           ],
         },


### PR DESCRIPTION
## Summary

https://github.com/facebook/create-react-app/pull/12113 introduced a change in the Algolia credentials, which made the search throw an error. As the credentials were still the one of our legacy infrastructure, this PR updates them to use the [new infrastructure](https://docsearch.algolia.com/docs/migrating-from-legacy) ones.

Maintainers of the previous application should have receive invites, if it's not the case, please let me know I'll send new ones!

fixes https://github.com/facebook/create-react-app/issues/12164