### PR TITLE
Bumps @svgr/webpack dependency to version 6.2.1

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@babel/core": "^7.16.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
-    "@svgr/webpack": "^5.5.0",
+    "@svgr/webpack": "^6.2.1",
     "babel-jest": "^27.4.2",
     "babel-loader": "^8.2.3",
     "babel-plugin-named-asset-import": "^0.3.8",


### PR DESCRIPTION
Regarding the issue https://github.com/facebook/create-react-app/issues/12146 the `@svgr/webpack` dependency has to be updated to fix the security warning related to the transitive `nth-check` dependency.
