### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/babel-plugin-named-asset-import/index.js
+++ b/packages/babel-plugin-named-asset-import/index.js
@@ -6,7 +6,7 @@ function namedAssetImportPlugin({ types: t }) {
   const visited = new WeakSet();
 
   function generateNewSourcePath(loaderMap, moduleName, sourcePath) {
-    const ext = extname(sourcePath).substr(1);
+    const ext = extname(sourcePath).slice(1);
     const extMap = loaderMap[ext];
     return extMap[moduleName]
       ? extMap[moduleName].replace(/\[path\]/, sourcePath)
@@ -15,7 +15,7 @@ function namedAssetImportPlugin({ types: t }) {
 
   function replaceMatchingSpecifiers(path, loaderMap, callback) {
     const sourcePath = path.node.source.value;
-    const ext = extname(sourcePath).substr(1);
+    const ext = extname(sourcePath).slice(1);
 
     if (visited.has(path.node) || sourcePath.indexOf('!') !== -1) {
       return;

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -733,7 +733,7 @@ function getPackageInfo(installPackage) {
   } else if (installPackage.match(/.+@/)) {
     // Do not match @scope/ when stripping off @version or @tag
     return Promise.resolve({
-      name: installPackage.charAt(0) + installPackage.substr(1).split('@')[0],
+      name: installPackage.charAt(0) + installPackage.slice(1).split('@')[0],
       version: installPackage.split('@')[1],
     });
   } else if (installPackage.match(/^file:/)) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.