### PR TITLE
chore: upgrade rtl version to support react 18

### DIFF
--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -2,7 +2,7 @@
   "package": {
     "dependencies": {
       "@testing-library/jest-dom": "^5.14.1",
-      "@testing-library/react": "^12.0.0",
+      "@testing-library/react": "^13.0.0",
       "@testing-library/user-event": "^13.2.1",
       "@types/jest": "^27.0.1",
       "@types/node": "^16.7.13",

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -2,7 +2,7 @@
   "package": {
     "dependencies": {
       "@testing-library/jest-dom": "^5.14.1",
-      "@testing-library/react": "^12.0.0",
+      "@testing-library/react": "^13.0.0",
       "@testing-library/user-event": "^13.2.1",
       "web-vitals": "^2.1.0"
     },


### PR DESCRIPTION
RTL version 13 was released to support React 18.

Thanks @eps1lon for the hard work on version 13 :)
