### PR TITLE
Add WDS_SOCKET_PROTOCOL env var to WDS

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -59,7 +59,7 @@ if (module.hot && typeof module.hot.dispose === 'function') {
 // Connect to WebpackDevServer via a socket.
 var connection = new WebSocket(
   url.format({
-    protocol: window.location.protocol === 'https:' ? 'wss' : 'ws',
+    protocol: process.env.WDS_SOCKET_PROTOCOL || (window.location.protocol === 'https:' ? 'wss' : 'ws'),
     hostname: process.env.WDS_SOCKET_HOST || window.location.hostname,
     port: process.env.WDS_SOCKET_PORT || window.location.port,
     // Hardcoded in WebpackDevServer


### PR DESCRIPTION
For when running WDS on HTTP and localhost while connecting via https proxy and
- rather not make the WDS run HTTPS
- rather not run the web socket traffic through the proxy

Have confirmed that this works:

<img width="758" alt="image" src="https://user-images.githubusercontent.com/3044707/161227244-45756252-1802-47bf-af9b-f54175307389.png">


