### PR TITLE
fix: webpack noise printed only if error or warning

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -198,6 +198,8 @@ module.exports = function (webpackEnv) {
 
   return {
     target: ['browserslist'],
+    // Webpack noise constrained to errors and warnings
+    stats: 'errors-warnings',
     mode: isEnvProduction ? 'production' : isEnvDevelopment && 'development',
     // Stop compilation early in production
     bail: isEnvProduction,


### PR DESCRIPTION
This is a proposed fix for issue https://github.com/facebook/create-react-app/issues/12229. Following the webpack documentation, `stats` is set such that only errors or warnings are printed by webpack. This was tested by running `npm start` locally.

![Screenshot 2022-04-04 195343](https://user-images.githubusercontent.com/11377188/161612355-e7da7e58-fbf5-4524-ac73-e3e1c347fd98.png)

