### PR TITLE
fix(react-scripts): use react-scripts' own postcss dependencies

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -135,6 +135,7 @@ module.exports = function (webpackEnv) {
         // Adds vendor prefixing based on your specified browser support in
         // package.json
         loader: require.resolve('postcss-loader'),
+        implementation: require.resolve("postcss"),
         options: {
           postcssOptions: {
             // Necessary for external CSS imports to work
@@ -143,9 +144,9 @@ module.exports = function (webpackEnv) {
             config: false,
             plugins: !useTailwind
               ? [
-                  'postcss-flexbugs-fixes',
+                  require('postcss-flexbugs-fixes'),
                   [
-                    'postcss-preset-env',
+                    require('postcss-preset-env'),
                     {
                       autoprefixer: {
                         flexbox: 'no-2009',
@@ -156,13 +157,13 @@ module.exports = function (webpackEnv) {
                   // Adds PostCSS Normalize as the reset css with default options,
                   // so that it honors browserslist config in package.json
                   // which in turn let's users customize the target behavior as per their needs.
-                  'postcss-normalize',
+                  require('postcss-normalize'),
                 ]
               : [
-                  'tailwindcss',
-                  'postcss-flexbugs-fixes',
+                  require('tailwindcss'),
+                  require('postcss-flexbugs-fixes'),
                   [
-                    'postcss-preset-env',
+                    require('postcss-preset-env'),
                     {
                       autoprefixer: {
                         flexbox: 'no-2009',


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Fixes #12177 

When using npm 8, in some cases there are no `postcss-flexbugs-fixes` in the node_modules directory, instead they appear in `node_modules/react-scripts/node_modules`:

```bash
ls -l node_modules/react-scripts/node_modules | grep postcss
```

![postess-color-functional-notation copy](https://user-images.githubusercontent.com/41503212/162796569-47c3674b-a5d6-44c8-b994-260d7771992e.png)


Therefore, we should use react-scripts' own postcss plugin dependencies, as well as postcss implementation.

