### PR TITLE
fix: webpack hanging under certain circumstance, use process.exitCode…

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -128,7 +128,7 @@ checkBrowsers(paths.appPath, isInteractive)
       } else {
         console.log(chalk.red('Failed to compile.\n'));
         printBuildError(err);
-        process.exit(1);
+        process.exitCode = 1;
       }
     }
   )
@@ -136,7 +136,7 @@ checkBrowsers(paths.appPath, isInteractive)
     if (err && err.message) {
       console.log(err.message);
     }
-    process.exit(1);
+    process.exitCode = 1;
   });
 
 // Create the production build and print the deployment instructions.


### PR DESCRIPTION
sometimes i found out `react-scripts buld` hangs under certain circumstances, like: 
![81ae142a7d27fafa6e422f0f81b49f2](https://user-images.githubusercontent.com/15656042/163397827-d15a3664-2112-4512-a9fc-6d82cfdad15f.jpg)
when i changed process.exit(1) to process.exitCode = 1, it can end up with failure:
![3ee6070794b767f955ca547ec3270fb](https://user-images.githubusercontent.com/15656042/163398382-4bf75170-cd55-49ba-9da4-7840477813f9.jpg)

According to https://nodejs.org/dist/latest-v16.x/docs/api/process.html#processexitcode_1:
> Rather than calling process.exit() directly, the code should set the process.exitCode and allow the process to exit naturally by avoiding scheduling any additional work for the event loop:

I also find that `webpack` and `webpack-cli` also have simlar issues fixed: 
[fix: fix webpack hanging under certain circumstance](https://github.com/webpack/webpack-cli/pull/1078)
[Fix webpack hanging under certain circumstance, use process.exitCode instead of process.exit in compilerCallback](https://github.com/webpack/webpack/pull/6193)
[misc(refactor): reduce code duplication use process.exitCode instead of process.exit](https://github.com/webpack/webpack-cli/pull/272)