### PR TITLE
Add README install for Yarn 2+ using 'yarn dlx'

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,15 @@ npm init react-app my-app
 
 _`npm init <initializer>` is available in npm 6+_
 
-### Yarn
+### Yarn version 2+
+
+```sh
+yarn dlx create-react-app ./my-app
+```
+
+_[`yarn dlx <package>`](https://yarnpkg.com/cli/dlx) is available in Yarn 2+_
+
+### Yarn version 1
 
 ```sh
 yarn create react-app my-app


### PR DESCRIPTION
This commit brings the README up to date with yarn latest.

See <https://yarnpkg.com/>

Yarn 3 is the latest stable version of `yarn`,
such as installed by running this command:

```sh
$ yarn set version latest
```

Yarn 2 introduced the new command 'yarn dlx' which downloads and executes
a package in a temporary environment. This is the preferred way to work with
Yarn 2 and Yarn 3, as explained on the Yarn website page about 'yarn dlx'.

See <https://yarnpkg.com/cli/dlx>

Yarn 1 is helpful to still have in the instructions because some developers
still use it for historical reasons, such as needing to manage a third-party 
package that has not been updated to work with Yarn 2 or Yarn 3.
However, the Yarn 1 instructions do not work correctly with Yarn latest.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
