### PR TITLE
fix: remove extra period in jest config error message

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -129,7 +129,7 @@ module.exports = (resolve, rootDir, isEjecting) => {
               supportedKeys
                 .map(key => chalk.bold('  \u2022 ' + key))
                 .join('\n') +
-              '.\n\n' +
+              '\n\n' +
               'These options in your package.json Jest configuration ' +
               'are not currently supported by Create React App:\n\n' +
               unsupportedKeys


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

There's an extra period in an error message for the jest config.

The period is after the last item in the list. (In this case "watchPathIgnorePatterns")

Visual|
------|
![JestConfigError](https://user-images.githubusercontent.com/8048702/165801053-66d54259-2900-417e-aba8-54340621b58b.png)|

For correct grammar, the list should not have end punctuation (see "Punctuation Bullet Points" section on [this article](https://www.businesswritingblog.com/business_writing/2012/01/punctuating-bullet-points.html) if a reference is desired) 
