### PR TITLE
Define process.platform in react-error-overlay's iframe bundle

### DIFF
--- a/packages/react-error-overlay/webpack.config.iframe.js
+++ b/packages/react-error-overlay/webpack.config.iframe.js
@@ -72,6 +72,7 @@ module.exports = {
       // We set process.env.NODE_ENV to 'production' so that React is built
       // in production mode.
       'process.env': { NODE_ENV: '"production"' },
+      'process.platform': '""',
       // This prevents our bundled React from accidentally hijacking devtools.
       __REACT_DEVTOOLS_GLOBAL_HOOK__: '({})',
     }),


### PR DESCRIPTION
`react-error-overlay` is broken since 6.0.10, due to the upgrades in #11624 transitively bring in chalk into the react-error-overlay iframe bundle. 

`chalk` calls `process.platform` which is not available in browsers, making the code crash. This has side effects of causing the iframe overlay to not disappear, preventing the user from being able to click on anything.

This is a quick fix that overrides `process.platform`, to make it not crash.

Fixes: #11773, #12064, #12212
Duplicate of #12121?