### PR TITLE
Make banner change to fit size

### DIFF
--- a/docusaurus/website/src/css/custom.css
+++ b/docusaurus/website/src/css/custom.css
@@ -60,13 +60,13 @@ div[class^='announcementBarContent'] a:hover {
 }
 
 @media only screen and (max-width: 768px) {
-  .announcement {
+  div[class^='announcementBarContent'] {
     font-size: 18px;
   }
 }
 
 @media only screen and (max-width: 500px) {
-  .announcement {
+  div[class^='announcementBarContent'] {
     font-size: 15px;
     line-height: 22px;
     padding: 6px 30px;


### PR DESCRIPTION
# Problem
This problem is copied over most of the meta projects.

![Problem](https://user-images.githubusercontent.com/78584173/166878998-61fae26f-16e3-4ffc-b5e8-260adc71e1d1.png)

# Code
![Code](https://user-images.githubusercontent.com/78584173/166879153-4d41ab02-89c5-4be4-a17f-e9054169d4c7.png)

In media, the class `.announcement` does not exist.
It should be `div[class^='announcementBarContent']` as the banner class contains `announcementBarContent` with id after it.