### PR TITLE
fix: webpack.config.js process.env.TSC_COMPILE_ON_ERROR

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -29,7 +29,7 @@ const modules = require('./modules');
 const getClientEnvironment = require('./env');
 const ModuleNotFoundPlugin = require('react-dev-utils/ModuleNotFoundPlugin');
 const ForkTsCheckerWebpackPlugin =
-  process.env.TSC_COMPILE_ON_ERROR === 'true'
+  process.env.TSC_COMPILE_ON_ERROR !== 'true'
     ? require('react-dev-utils/ForkTsCheckerWarningWebpackPlugin')
     : require('react-dev-utils/ForkTsCheckerWebpackPlugin');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -117,7 +117,7 @@ checkBrowsers(paths.appPath, isInteractive)
       );
     },
     err => {
-      const tscCompileOnError = process.env.TSC_COMPILE_ON_ERROR === 'true';
+      const tscCompileOnError = process.env.TSC_COMPILE_ON_ERROR !== 'true';
       if (tscCompileOnError) {
         console.log(
           chalk.yellow(


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
in `/packages/react-scripts/scripts/build.js` and  `/packages/react-scripts/config/webpack.config.js` file. When process.env.TSC_COMPILE_ON_ERROR === true, 
we should report errors instead of warnings
