### PR TITLE
Remove "import React" statement from cra-template-typescript

### DIFF
--- a/packages/cra-template-typescript/template/src/App.test.tsx
+++ b/packages/cra-template-typescript/template/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 

--- a/packages/cra-template-typescript/template/src/App.tsx
+++ b/packages/cra-template-typescript/template/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

- Removed `import React from 'react';` statement from `cra-template-typescript` since the new JSX runtime is introduced in React.js v17 and the current version of `create-react-app` uses React.js v18.