### PR TITLE
fix: Fix the fixed filename

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -220,7 +220,7 @@ module.exports = function (webpackEnv) {
       // In development, it does not produce real files.
       filename: isEnvProduction
         ? 'static/js/[name].[contenthash:8].js'
-        : isEnvDevelopment && 'static/js/bundle.js',
+        : isEnvDevelopment && 'static/js/[name].js',
       // There are also additional JS chunk files if you use code splitting.
       chunkFilename: isEnvProduction
         ? 'static/js/[name].[contenthash:8].chunk.js'


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->


WHY: 
When I define two entry points.
![image](https://user-images.githubusercontent.com/18487314/167835537-3f8e4234-eb52-47c8-b621-97b2f54577c8.png)
The service will jam. I think two identical files will be produced.

HOW:
Make filename dynamic, it works.
![image](https://user-images.githubusercontent.com/18487314/167836016-4bbfc61f-0875-408e-818c-e867a3dee773.png)
