### PR TITLE
react-dev-utils: fix openBrowser

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -115,15 +115,10 @@ function startBrowserProcess(browser, url, args) {
     browser = undefined;
   }
 
-  // If there are arguments, they must be passed as array with the browser
-  if (typeof browser === 'string' && args.length > 0) {
-    browser = [browser].concat(args);
-  }
-
   // Fallback to open
   // (It will always open new tab)
   try {
-    var options = { app: browser, wait: false, url: true };
+    var options = { app: { name: browser, arguments: args }, wait: false };
     open(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;
   } catch (err) {


### PR DESCRIPTION
The "open" package had a breaking change in v8: https://github.com/sindresorhus/open/commit/8c00bd89d4604f9ec70568dce466a2162b30bcb1

The `react-dev-utils` dependency on this package was updated in https://github.com/facebook/create-react-app/commit/3afbbc0ab922fb982bb275ccb3fe5beecdf5f889 without taking this into account.

This updates the call to `open()` in `openBrowser.js` to use the new options properties.

Without this change, the `BROWSER` environment variable is ignored when running `yarn start`.

This has been tested by manually editing my local install with the same change.

Fixes #12275

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
