### PR TITLE
Update running-tests.md - fix jest urls

### DIFF
--- a/docusaurus/docs/running-tests.md
+++ b/docusaurus/docs/running-tests.md
@@ -60,9 +60,9 @@ it('sums numbers', () => {
 });
 ```
 
-All `expect()` matchers supported by Jest are [extensively documented here](https://jestjs.io/docs/en/expect.html#content).
+All `expect()` matchers supported by Jest are [extensively documented here](https://jestjs.io/docs/en/expect#content).
 
-You can also use [`jest.fn()` and `expect(fn).toBeCalled()`](https://jestjs.io/docs/en/expect.html#tohavebeencalled) to create “spies” or mock functions.
+You can also use [`jest.fn()`](https://jestjs.io/docs/en/jest-object#jestfnimplementation) and [`expect(fn).toHaveBeenCalled()`](https://jestjs.io/docs/en/expect#tohavebeencalled) to create “spies” or mock functions.
 
 ## Testing Components
 
@@ -188,24 +188,24 @@ The [default configuration](https://github.com/facebook/create-react-app/blob/ma
 
 Supported overrides:
 
-- [`clearMocks`](https://jestjs.io/docs/en/configuration.html#clearmocks-boolean)
-- [`collectCoverageFrom`](https://jestjs.io/docs/en/configuration.html#collectcoveragefrom-array)
+- [`clearMocks`](https://jestjs.io/docs/en/configuration#clearmocks-boolean)
+- [`collectCoverageFrom`](https://jestjs.io/docs/en/configuration#collectcoveragefrom-array)
 - [`coveragePathIgnorePatterns`](https://jestjs.io/docs/en/configuration#coveragepathignorepatterns-arraystring)
-- [`coverageReporters`](https://jestjs.io/docs/en/configuration.html#coveragereporters-array-string)
-- [`coverageThreshold`](https://jestjs.io/docs/en/configuration.html#coveragethreshold-object)
-- [`displayName`](https://jestjs.io/docs/en/configuration.html#displayname-string-object)
-- [`extraGlobals`](https://jestjs.io/docs/en/configuration.html#extraglobals-array-string)
-- [`globalSetup`](https://jestjs.io/docs/en/configuration.html#globalsetup-string)
-- [`globalTeardown`](https://jestjs.io/docs/en/configuration.html#globalteardown-string)
-- [`moduleNameMapper`](https://jestjs.io/docs/en/configuration.html#modulenamemapper-object-string-string)
-- [`resetMocks`](https://jestjs.io/docs/en/configuration.html#resetmocks-boolean)
-- [`resetModules`](https://jestjs.io/docs/en/configuration.html#resetmodules-boolean)
+- [`coverageReporters`](https://jestjs.io/docs/en/configuration#coveragereporters-arraystring--string-options)
+- [`coverageThreshold`](https://jestjs.io/docs/en/configuration#coveragethreshold-object)
+- [`displayName`](https://jestjs.io/docs/en/configuration#displayname-string-object)
+- [`extraGlobals`](https://jestjs.io/docs/en/configuration#extraglobals-array-string)
+- [`globalSetup`](https://jestjs.io/docs/en/configuration#globalsetup-string)
+- [`globalTeardown`](https://jestjs.io/docs/en/configuration#globalteardown-string)
+- [`moduleNameMapper`](https://jestjs.io/docs/en/configuration#modulenamemapper-object-string-string)
+- [`resetMocks`](https://jestjs.io/docs/en/configuration#resetmocks-boolean)
+- [`resetModules`](https://jestjs.io/docs/en/configuration#resetmodules-boolean)
 - [`restoreMocks`](https://jestjs.io/docs/en/configuration#restoremocks-boolean)
-- [`snapshotSerializers`](https://jestjs.io/docs/en/configuration.html#snapshotserializers-array-string)
+- [`snapshotSerializers`](https://jestjs.io/docs/en/configuration#snapshotserializers-arraystring)
 - [`testMatch`](https://jestjs.io/docs/en/configuration#testmatch-arraystring)
-- [`transform`](https://jestjs.io/docs/en/configuration.html#transform-object-string-pathtotransformer-pathtotransformer-object)
-- [`transformIgnorePatterns`](https://jestjs.io/docs/en/configuration.html#transformignorepatterns-array-string)
-- [`watchPathIgnorePatterns`](https://jestjs.io/docs/en/configuration.html#watchpathignorepatterns-array-string)
+- [`transform`](https://jestjs.io/docs/en/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object)
+- [`transformIgnorePatterns`](https://jestjs.io/docs/en/configuration#transformignorepatterns-arraystring)
+- [`watchPathIgnorePatterns`](https://jestjs.io/docs/en/configuration#watchpathignorepatterns-arraystring)
 
 Example package.json:
 


### PR DESCRIPTION
Links to Jest docs do not work as expected when there's an extension (.html). Removed these extensions from the URLs.