### PR TITLE
fix(template): upgrade `@testing-library/user-event`

### DIFF
--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -3,7 +3,7 @@
     "dependencies": {
       "@testing-library/jest-dom": "^5.14.1",
       "@testing-library/react": "^13.0.0",
-      "@testing-library/user-event": "^13.2.1",
+      "@testing-library/user-event": "^14.2.0",
       "@types/jest": "^27.0.1",
       "@types/node": "^16.7.13",
       "@types/react": "^18.0.0",

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -3,7 +3,7 @@
     "dependencies": {
       "@testing-library/jest-dom": "^5.14.1",
       "@testing-library/react": "^13.0.0",
-      "@testing-library/user-event": "^13.2.1",
+      "@testing-library/user-event": "^14.2.0",
       "web-vitals": "^2.1.0"
     },
     "eslintConfig": {


### PR DESCRIPTION
`@testing-library/user-event@14` has been [released](https://github.com/testing-library/user-event/releases/tag/v14.0.0) on 2022-03-29.

`13.5.0` is no longer maintained.

We're very happy that `user-event` is included in the templates, but it is a frustrating experience for developers new to the ecosystem as well as maintainers of the library when people run into already resolved issues with a fresh installation.

This PR replaces #12217 with the minimal change to the templates and without updates to `package.json` or `package-lock.json`, hoping that this will be approved or at least receive any comment what I could do to help this being merged.