### PR TITLE
chore: upgrade webpack-dev-server

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -72,7 +72,7 @@
     "tailwindcss": "^3.0.2",
     "terser-webpack-plugin": "^5.2.5",
     "webpack": "^5.64.4",
-    "webpack-dev-server": "^4.6.0",
+    "webpack-dev-server": "^4.9.0",
     "webpack-manifest-plugin": "^4.0.2",
     "workbox-webpack-plugin": "^6.4.1"
   },


### PR DESCRIPTION
Updates `webpack-dev-server` to remove prototype pollution in transitive dependency.

From `yarn audit`:
`react-scripts > webpack-dev-server > portfinder > async` surfaces advisory: https://www.npmjs.com/advisories/1070206
