### PR TITLE
Upgrade address to fix urls.lanUrlForConfig not getting defined

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@babel/code-frame": "^7.16.0",
-    "address": "^1.1.2",
+    "address": "^1.2.0",
     "browserslist": "^4.18.1",
     "chalk": "^4.1.2",
     "cross-spawn": "^7.0.3",


### PR DESCRIPTION
When using node 18 the old `address` library is unable to resolve ip addresses. This causes running a local server to fail with

```
Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
 - options.allowedHosts[0] should be a non-empty string.
```

similarly to the issue reported in #11762 

The latest version of `address` [fixes](https://github.com/node-modules/address/commit/fe81a415403ba46d7bc09d76a2f9fc46bc2fc803) this issue.

This will also relieve part of the pain that #11877 tries to solve (although that PR is still necessary in case the address resolution fails for other reasons).

