### PR TITLE
fix webpack hmr for new api

### DIFF
--- a/packages/react-dev-utils/webpackHotDevClient.js
+++ b/packages/react-dev-utils/webpackHotDevClient.js
@@ -277,18 +277,13 @@ function tryApplyUpdates(onHotUpdateSuccess) {
     }
   }
 
-  // https://webpack.github.io/docs/hot-module-replacement.html#check
-  var result = module.hot.check(/* autoApply */ true, handleApplyUpdates);
-
-  // // webpack 2 returns a Promise instead of invoking a callback
-  if (result && result.then) {
-    result.then(
-      function (updatedModules) {
-        handleApplyUpdates(null, updatedModules);
-      },
-      function (err) {
-        handleApplyUpdates(err, null);
-      }
-    );
-  }
+  // https://webpack.js.org/api/hot-module-replacement
+  module.hot
+    .check(/* autoApply */ true)
+    .then(function (updatedModules) {
+      handleApplyUpdates(null, updatedModules);
+    })
+    .catch(function (err) {
+      handleApplyUpdates(err, null);
+    });
 }


### PR DESCRIPTION
Current methods are located [here](https://github.com/webpack/webpack/blob/main/lib/hmr/HotModuleReplacement.runtime.js#L191) and [here](https://github.com/webpack/webpack/blob/main/lib/hmr/HotModuleReplacement.runtime.js#L192)

Implementation of the validation method [check]|(https://github.com/webpack/webpack/blob/main/lib/hmr/HotModuleReplacement.runtime.js#L259) always return Promise with [null](https://github.com/webpack/webpack/blob/main/lib/hmr/HotModuleReplacement.runtime.js#L269) or Array of modules

Implementation of the validation method [apply]|(https://github.com/webpack/webpack/blob/main/lib/hmr/HotModuleReplacement.runtime.js#L309) always return Promise with Array of modules
