### PR TITLE
fix(react-scripts): wrong glob for excluded typescript files on webpack config

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -754,7 +754,7 @@ module.exports = function (webpackEnv) {
             ],
             exclude: [
               { file: '**/src/**/__tests__/**' },
-              { file: '**/src/**/?(*.){spec|test}.*' },
+              { file: '**/src/**/?(*.){spec,test}.*' },
               { file: '**/src/setupProxy.*' },
               { file: '**/src/setupTests.*' },
             ],


### PR DESCRIPTION
Using the digitalocean [Glob tools](https://www.digitalocean.com/community/tools/glob) i tested the wrong glob and the correct glob, so I changed the code with the correct glob

### Wrong glob

<img width="300" alt="image" src="https://user-images.githubusercontent.com/2581560/169720238-3223ccec-e86e-4df8-bb5e-21d1f650330e.png">

### Correct glob

<img width="300" alt="image" src="https://user-images.githubusercontent.com/2581560/169720212-5aa48e50-24e2-41ae-bd0b-69dfeb0fabb0.png">
