### PR TITLE
Add Navigation API to confusing globals

### DIFF
--- a/packages/confusing-browser-globals/index.js
+++ b/packages/confusing-browser-globals/index.js
@@ -31,6 +31,7 @@ module.exports = [
   'moveBy',
   'moveTo',
   'name',
+  'navigation',
   'onblur',
   'onerror',
   'onfocus',


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

This PR adds `navigation` from Navigation API which just landed in Chromium 102. Navigation API is basically an iteration on History API which has a global already listed in this file (`history`).
 - [Chrome Platform Status](https://chromestatus.com/feature/6232287446302720)
 - [Specification](https://wicg.github.io/navigation-api/)