### PR TITLE
fix: Trailing spaces in environment variables

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -25,7 +25,7 @@ function getBrowserEnv() {
   // Attempt to honor this environment variable.
   // It is specific to the operating system.
   // See https://github.com/sindresorhus/open#app for documentation.
-  const value = process.env.BROWSER;
+  const value = (process.env.BROWSER || "").trim();
   const args = process.env.BROWSER_ARGS
     ? process.env.BROWSER_ARGS.split(' ')
     : [];


### PR DESCRIPTION
See issue #12440 .

In `package.json`, with the following script `"start": "set BROWSER=none && react-scripts start"`,
the value of `process.env.browser` will be `"none "` on Windows, which will open the browser since it is different from `"none"`.