### PR TITLE
Update deployment.md

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -87,7 +87,7 @@ On a production build, and when you've [opted-in](making-a-progressive-web-app.m
 a [service worker](https://developers.google.com/web/fundamentals/primers/service-workers/) will automatically handle all navigation requests, like for
 `/todos/42`, by serving the cached copy of your `index.html`. This
 service worker navigation routing can be configured or disabled by
-[`eject`ing](available-scripts.md#npm-run-eject) and then modifying the
+[`ejecting`](available-scripts.md#npm-run-eject) and then modifying the
 [`navigateFallback`](https://github.com/GoogleChrome/sw-precache#navigatefallback-string)
 and [`navigateFallbackWhitelist`](https://github.com/GoogleChrome/sw-precache#navigatefallbackwhitelist-arrayregexp)
 options of the `SWPrecachePlugin` configuration.


### PR DESCRIPTION
Small Fix for "ejecting" style on the phrase "This service worker navigation routing can be configured or disabled by ejecting"

Before:
![image](https://user-images.githubusercontent.com/15106466/171284894-704b6ca4-44d6-4a51-9f04-eef2b0002c2e.png)

After:
![image](https://user-images.githubusercontent.com/15106466/171285017-57005627-b7d9-4a89-a636-bd4d53e04208.png)


<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
