### PR TITLE
update `react-dev-utils` `peerDependencies`

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -81,6 +81,10 @@
     "cross-env": "^7.0.3",
     "jest": "^27.4.3"
   },
+  "peerDependencies": {
+    "typescript": ">3.6.0",
+    "webpack": "^5.11.0"
+  },
   "scripts": {
     "test": "cross-env FORCE_COLOR=true jest"
   }


### PR DESCRIPTION
Resolves this warning on install by adding the peer dependencies as defined by `fork-ts-checker-webpack-plugin` [in its `package.json` file](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/blob/main/package.json#L71).

```
➤ YN0002: │ react-dev-utils@npm:12.0.1 doesn't provide typescript (p59348), requested by fork-ts-checker-webpack-plugin
➤ YN0002: │ react-dev-utils@npm:12.0.1 doesn't provide webpack (p1012e), requested by fork-ts-checker-webpack-plugin
```
