### PR TITLE
Bump webpack-dev-server to fix CVE-2022-1650

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -72,7 +72,7 @@
     "tailwindcss": "^3.0.2",
     "terser-webpack-plugin": "^5.2.5",
     "webpack": "^5.64.4",
-    "webpack-dev-server": "^4.6.0",
+    "webpack-dev-server": "^4.9.1",
     "webpack-manifest-plugin": "^4.0.2",
     "workbox-webpack-plugin": "^6.4.1"
   },


### PR DESCRIPTION
Fix was made in webpack-dev-server with this push: https://github.com/webpack/webpack-dev-server/commit/e765182e426cbca9c3c09294b02ac2d9737c1d74

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
