### PR TITLE
fix: babel-preset-react-app missing env in  ESLint

### DIFF
--- a/packages/babel-preset-react-app/README.md
+++ b/packages/babel-preset-react-app/README.md
@@ -56,7 +56,7 @@ Make sure you have a `tsconfig.json` file at the root directory. You can also us
 
 Absolute paths are enabled by default for imports. To use relative paths instead, set the `absoluteRuntime` option in `.babelrc` to `false`:
 
-```
+```json
 {
   "presets": [["react-app", { "absoluteRuntime": false }]]
 }

--- a/packages/babel-preset-react-app/index.js
+++ b/packages/babel-preset-react-app/index.js
@@ -15,6 +15,6 @@ module.exports = function (api, opts) {
   // https://github.com/babel/babel/issues/4539
   // https://github.com/facebook/create-react-app/issues/720
   // It’s also nice that we can enforce `NODE_ENV` being specified.
-  const env = process.env.BABEL_ENV || process.env.NODE_ENV;
+  const env = process.env.BABEL_ENV || process.env.NODE_ENV || 'production';
   return create(api, opts, env);
 };


### PR DESCRIPTION
Fixes #12070