### PR TITLE
feat: ignore .vscode local settings folder

### DIFF
--- a/packages/cra-template-typescript/template/gitignore
+++ b/packages/cra-template-typescript/template/gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# IDE settings
+/.vscode


### PR DESCRIPTION
Most of the time, we tend to customize our IDE to suit our needs, however these settings should not be added to source control for the team. If a team needs to have common settings, the alternative case of commenting on this folder matcher can work.
 
