### PR TITLE
Add missing instruction if you are adding typescript

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -37,7 +37,9 @@ or
 yarn add typescript @types/node @types/react @types/react-dom @types/jest
 ```
 
-Next, rename any file to be a TypeScript file (e.g. `src/index.js` to `src/index.tsx`) and **restart your development server**!
+Next, rename any file to be a TypeScript file (e.g. `src/index.js` to `src/index.tsx`) and create tsconfig.json if it's not in the root of your project [`tsconfig.json` file](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
+
+Finally **restart your development server**!
 
 Type errors will show up in the same console as the build one. You'll have to fix these type errors before you continue development or build your project. For advanced configuration, [see here](advanced-configuration.md).
 


### PR DESCRIPTION
When adding typescript to an existing Create React App project you have to have tsconfig.json in the project, I believe this change should clarify it for beginners getting stuck on this step. Not sure if providing an example would be too much so I have added a link to the tsconfig.json instead.