### PR TITLE
fix code splitting link

### DIFF
--- a/packages/react-dev-utils/FileSizeReporter.js
+++ b/packages/react-dev-utils/FileSizeReporter.js
@@ -92,7 +92,7 @@ function printFileSizesAfterBuild(
     );
     console.log(
       chalk.yellow(
-        'Consider reducing it with code splitting: https://goo.gl/9VhYWB'
+        'Consider reducing it with code splitting: https://create-react-app.dev/docs/code-splitting/'
       )
     );
     console.log(


### PR DESCRIPTION
I noticed the code splitting link when doing a production build could be pointing directly to the documentation instead of taking the user through some non-optimal redirects and clicks.