### PR TITLE
Bugfix: Add missing .cjs extension to babel loader test in the webpack config

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -414,7 +414,7 @@ module.exports = function (webpackEnv) {
             // Process application JS with Babel.
             // The preset includes JSX, Flow, TypeScript, and some ESnext features.
             {
-              test: /\.(js|mjs|jsx|ts|tsx)$/,
+              test: /\.(js|mjs|cjs|jsx|ts|tsx)$/,
               include: paths.appSrc,
               loader: require.resolve('babel-loader'),
               options: {
@@ -466,7 +466,7 @@ module.exports = function (webpackEnv) {
             // Process any JS outside of the app with Babel.
             // Unlike the application JS, we only compile the standard ES features.
             {
-              test: /\.(js|mjs)$/,
+              test: /\.(js|mjs|cjs)$/,
               exclude: /@babel(?:\/|\\{1,2})runtime/,
               loader: require.resolve('babel-loader'),
               options: {


### PR DESCRIPTION
This PR adds the missed .cjs extension to the webpack config loader section.  According to webpack docs found [here](https://webpack.js.org/guides/ecma-script-modules/#flagging-modules-as-esm) to force the module type of a file you can use the .cjs extension similarly to .mjs for ESM. Without this extension explicitly added to the loader test rule, packages using .cjs file as a `main` in there package.json will not work at all. The index.cjs file is picked up by the file loader and treated as an asset. A good example of this behavior are all prosemirror packages witch are not usable in CRA app.

I tested my changes on a the codebase of a relatively complex project I am working on and the change is not breaking anything so far. Sorry but I cannot share screens from this project :)