### PR TITLE
Security Fix for Command Injection

### DIFF
--- a/packages/react-dev-utils/openBrowser.js
+++ b/packages/react-dev-utils/openBrowser.js
@@ -9,6 +9,7 @@
 
 var chalk = require('chalk');
 var execSync = require('child_process').execSync;
+var execFileSync = require('child_process').execFileSync;
 var spawn = require('cross-spawn');
 var open = require('open');
 
@@ -91,12 +92,9 @@ function startBrowserProcess(browser, url, args) {
         // Try our best to reuse existing tab
         // on OSX Chromium-based browser with AppleScript
         execSync('ps cax | grep "' + chromiumBrowser + '"');
-        execSync(
-          'osascript openChrome.applescript "' +
-            encodeURI(url) +
-            '" "' +
-            chromiumBrowser +
-            '"',
+        execFileSync(
+          'osascript',
+          ['openChrome.applescript', encodeURI(url), chromiumBrowser],
           {
             cwd: __dirname,
             stdio: 'ignore',


### PR DESCRIPTION
Q | A
Version Affected | *
Bug Fix | YES

## Description Pull Request
Used `child_process.execFileSync()` instead of `child_process.execSync()`.
## Description Vulnerability
The use of the `child_process` function `execSync()` is highly discouraged if you accept user input and don't sanitize/escape them.
In the program, `url` param was passed into function `openBrowser()` will go to `startBrowserProcess()` and be used by `execFileSync()` ([L92-L102](https://github.com/facebook/create-react-app/blob/22f46a8d5dfc46fe0f613cd7efbc82344823f461/packages/react-dev-utils/openBrowser.js#L92-L102)). `url` was encoded by `encodeURI()`, but `encodeURI()` is not encoded some special characters `;,/?:@&=+$#-_.!~*'()` so attacker could put `$(command)` into URL string and arbitrarily execute command. In addition, the `$IFS` to bypass `white space` encoded by `encodeURI()`.
## PoC
Create a .js file with the content below and run it, then the file `/tmp/th13ntc` can be illegally created.

```js
// poc.js
var openBrowser = require('react-dev-utils/openBrowser');

openBrowser('http://example.com/#$(touch$IFS/tmp/th13ntc)');
```

## Proof of Fix (PoF)
Use:
```js
//code fixed
execFileSync(
  "osascript",
  ["openChrome.applescript", encodeURI(url), chromiumBrowser],
  {
    cwd: __dirname,
    stdio: "ignore",
  }
);
```
Replace:
```js
execSync(
  'osascript openChrome.applescript "' +
    encodeURI(url) +
    '" "' +
    chromiumBrowser +
    '"',
  {
    cwd: __dirname,
    stdio: "ignore",
  }
);
```
## User Acceptance Testing (UAT)
```js
var openBrowser = require('react-dev-utils/openBrowser');
openBrowser('http://example.com/'); //works correctly
```
## References
1. Credit to thientc from VNG Cloud Security Team with [CodeQL Agent](https://github.com/vovikhangcdv/codeql-agent) supported.
2. Past context: https://github.com/facebook/create-react-app/pull/10644
## Occurrences
[#L92-L102](https://github.com/facebook/create-react-app/blob/22f46a8d5dfc46fe0f613cd7efbc82344823f461/packages/react-dev-utils/openBrowser.js#L92-L102)