### PR TITLE
Fix writing an absolute path to modulePaths in Jest config when ejecting

### DIFF
--- a/packages/react-scripts/config/modules.js
+++ b/packages/react-scripts/config/modules.js
@@ -36,7 +36,10 @@ function getAdditionalModulePaths(options = {}) {
 
   // Allow the user set the `baseUrl` to `appSrc`.
   if (path.relative(paths.appSrc, baseUrlResolved) === '') {
-    return [paths.appSrc];
+    return {
+      resolved: [paths.appSrc],
+      relative: [baseUrl],
+    };
   }
 
   // If the path is equal to the root directory we ignore it here.

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -308,7 +308,9 @@ module.exports = function (webpackEnv) {
       // if there are any conflicts. This matches Node resolution mechanism.
       // https://github.com/facebook/create-react-app/issues/253
       modules: ['node_modules', paths.appNodeModules].concat(
-        modules.additionalModulePaths || []
+        modules.additionalModulePaths
+          ? modules.additionalModulePaths.resolved
+          : []
       ),
       // These are the reasonable defaults supported by the Node ecosystem.
       // We also include JSX as a common component filename extension to support

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -53,11 +53,11 @@ module.exports = (resolve, rootDir, isEjecting) => {
       '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$',
       '^.+\\.module\\.(css|sass|scss)$',
     ],
-    modulePaths: Array.isArray(modules.additionalModulePaths)
-      ? modules.additionalModulePaths.map(
+    modulePaths: modules.additionalModulePaths
+      ? modules.additionalModulePaths.relative.map(
           // Absolute paths will cause issues if the ejected jest config is applied on other
-          // machines, so we translate them to relative paths to rootDir
-          modulePath => `<rootDir>/${path.basename(modulePath)}`
+          // machines, so we translate them to relative paths to the rootDir
+          modulePath => path.join('<rootDir>', modulePath)
         )
       : [],
     moduleNameMapper: {


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Resolves #8965 

# Problem & Cause

As described in the linked issue, when a CRA project is ejected, the `modulePaths` entry of the jest config includes an array of absolute paths, if a `baseUrl` is defined in the `tsconfig.json` or `jsconfig.json`.

The array is created [here](https://github.com/mkarajohn/create-react-app/blob/main/packages/react-scripts/config/modules.js#L38) exported as `additionalModulePaths`.

Since this exported array of `additionalModulePaths` is also used in the `webpack.config.js` [here](https://github.com/mkarajohn/create-react-app/blob/main/packages/react-scripts/config/webpack.config.js#L311), where absolute paths  are in fact needed, we cannot be directly modifying the way the `additionalModulePaths` array contents are created.

# Solution
What this PR does in order to fix the issue, is to translate the absolute paths to relative ones in the `createJestConfig.js` file [here](https://github.com/mkarajohn/create-react-app/blob/main/packages/react-scripts/scripts/utils/createJestConfig.js#L55), since adding absolute paths in the `modulePaths` is problematic, in cases such as CI pipelines, or simply someone else trying to run the tests on their own machine. Making them relative to the `rootDir` solves any issues.

Before:
![image](https://user-images.githubusercontent.com/3789226/179768781-0ed5dcbc-4e69-4e1d-baad-00f7ca77d2bc.png)


After:
![image](https://user-images.githubusercontent.com/3789226/179767619-82e7f1eb-e2d7-42b2-8c8e-a059b36889b1.png)


