### PR TITLE
Fix `getPackageInfo` version check breaking `--template file:`

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -723,12 +723,6 @@ function getPackageInfo(installPackage) {
     return Promise.resolve({
       name: installPackage.match(/([^/]+)\.git(#.*)?$/)[1],
     });
-  } else if (installPackage.match(/.+@/)) {
-    // Do not match @scope/ when stripping off @version or @tag
-    return Promise.resolve({
-      name: installPackage.charAt(0) + installPackage.substr(1).split('@')[0],
-      version: installPackage.split('@')[1],
-    });
   } else if (installPackage.match(/^file:/)) {
     const installPackagePath = installPackage.match(/^file:(.*)?$/)[1];
     const { name, version } = require(path.join(
@@ -736,6 +730,12 @@ function getPackageInfo(installPackage) {
       'package.json'
     ));
     return Promise.resolve({ name, version });
+  } else if (installPackage.match(/.+@/)) {
+    // Do not match @scope/ when stripping off @version or @tag
+    return Promise.resolve({
+      name: installPackage.charAt(0) + installPackage.substr(1).split('@')[0],
+      version: installPackage.split('@')[1],
+    });
   }
   return Promise.resolve({ name: installPackage });
 }


### PR DESCRIPTION
It's common for developers to namespace directories with an organization or company name like this:

* `/user/tyler/code/@company/path/to/cta-template-custom`
* `/user/tyler/code/@organization/path/to/cta-template-custom`

This convention breaks our ability to use `--template file:path/to/cta-template` because `function getPackageInfo` checks for `@` before `file:`, falsely identifying the create react app type.

This PR resolves https://github.com/facebook/create-react-app/issues/12610
