### PR TITLE
fix: add missing dependency to babel-preset-react-app

### DIFF
--- a/packages/babel-preset-react-app/package.json
+++ b/packages/babel-preset-react-app/package.json
@@ -28,6 +28,7 @@
     "@babel/plugin-proposal-numeric-separator": "^7.16.0",
     "@babel/plugin-proposal-optional-chaining": "^7.16.0",
     "@babel/plugin-proposal-private-methods": "^7.16.0",
+    "@babel/plugin-proposal-private-property-in-object": "^7.16.0",
     "@babel/plugin-transform-flow-strip-types": "^7.16.0",
     "@babel/plugin-transform-react-display-name": "^7.16.0",
     "@babel/plugin-transform-runtime": "^7.16.4",


### PR DESCRIPTION
This dependency is required by the code but is not listed in the package dependencies list. This makes Yarn PnP not work.