### PR TITLE
Add a loading indicator for slower connections

### DIFF
--- a/packages/cra-template/template/public/index.html
+++ b/packages/cra-template/template/public/index.html
@@ -28,7 +28,16 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <div id="root">
+      <div style="min-height: 100vh; background-color: #282c34; display: grid; place-items: center">
+        <h1 style="margin: 0; color: #fff">Loading ...</h1>
+      </div>
+      <!--
+        This is a loader div.
+        If you open it directly in the browser, you will jsut see this.
+        You can add a custom loader here but beware it will be replaced by app as soon as it loads
+    -->
+    </div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.


### PR DESCRIPTION
On devices with slower connection (<4G) the initial response (this file) shows a blank white page while bundle gets loaded.
Users (and even me as a developer) have experienced this and mistake the site for being unavailable/broken when actually the initial response is sent and JavaScript gets loading.
This should not be the default behavior - even a simple text `Loading ...` with zero styling text gives some information. It does not leave me worrying if the page is broken - but that something is going on and I should wait.
Adding a fancy svg loader like [here](https://gracious-jackson-c3ea90.netlify.app/) does not add to file size (1.9 vs 2.3kB).

Thus something as simple as this would work fine and it will be replaced by react after load anyways.
```
<div id="root">
  <p> Loading ... </p>
</div>
```

While this not an issue when using frameworks like Next, Gatsby or Remix and the load times can be reduced with code splitting, create-react-app should come out of the box being able to be deployed.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
