### PR TITLE
feat(webpack): svg loader rules have been updated

### DIFF
--- a/docusaurus/docs/adding-images-fonts-and-files.md
+++ b/docusaurus/docs/adding-images-fonts-and-files.md
@@ -47,21 +47,24 @@ An alternative way of handling static assets is described in the next section.
 
 > Note: this feature is available with `react-scripts@2.0.0` and higher, and `react@16.3.0` and higher.
 
-One way to add SVG files was described in the section above. You can also import SVGs directly as React components. You can use either of the two approaches. In your code it would look like this:
+One way to add SVG files was described in the section above, but you need to add `?url` as query string to import it as URL. You can also import SVGs directly as React components. You can use either of the two approaches. In your code it would look like this:
 
 ```js
-import { ReactComponent as Logo } from './logo.svg';
+import Logo from './logo.svg';
+import logo from './logo.svg?url';
 
 function App() {
   return (
     <div>
       {/* Logo is an actual React component */}
       <Logo />
+      {/* logo as url */}
+      <img src={logo} alt="logo" />
     </div>
   );
 }
 ```
 
-This is handy if you don't want to load SVG as a separate file. Don't forget the curly braces in the import! The `ReactComponent` import name is significant and tells Create React App that you want a React component that renders an SVG, rather than its filename.
+This is handy if you don't want to load SVG as a separate file.
 
 > **Tip:** The imported SVG React Component accepts a `title` prop along with other props that a `svg` element accepts. Use this prop to add an accessible title to your svg component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29793,21 +29793,21 @@
       }
     },
     "packages/cra-template": {
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "packages/cra-template-typescript": {
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "packages/create-react-app": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -29848,7 +29848,7 @@
       }
     },
     "packages/eslint-config-react-app": {
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -29889,7 +29889,7 @@
       }
     },
     "packages/react-dev-utils": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
@@ -29911,7 +29911,7 @@
         "open": "^8.4.0",
         "pkg-up": "^3.1.0",
         "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.10",
+        "react-error-overlay": "^6.0.11",
         "recursive-readdir": "^2.2.2",
         "shell-quote": "^1.7.3",
         "strip-ansi": "^6.0.1",
@@ -29934,7 +29934,7 @@
       }
     },
     "packages/react-error-overlay": {
-      "version": "6.0.10",
+      "version": "6.0.11",
       "license": "MIT",
       "devDependencies": {
         "@babel/code-frame": "^7.16.0",
@@ -29946,17 +29946,6 @@
         "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
         "cross-env": "^7.0.3",
-        "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
-<<<<<<< HEAD
-=======
-=======
-<<<<<<< HEAD
->>>>>>> f21e2137 (Publish)
-=======
->>>>>>> 9f8d75e5 (chore(lint): lint all files)
->>>>>>> fb003998 (chore(lint): lint all files)
->>>>>>> f301bfe4 (chore(lint): lint all files)
         "flow-bin": "^0.116.0",
         "html-entities": "^2.3.2",
         "jest": "^27.4.3",
@@ -29983,7 +29972,7 @@
       }
     },
     "packages/react-scripts": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -30002,7 +29991,7 @@
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0",
         "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
+        "eslint-config-react-app": "^7.0.1",
         "eslint-webpack-plugin": "^3.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.0",
@@ -30019,7 +30008,7 @@
         "postcss-preset-env": "^7.0.1",
         "prompts": "^2.4.2",
         "react-app-polyfill": "^3.0.0",
-        "react-dev-utils": "^12.0.0",
+        "react-dev-utils": "^12.0.1",
         "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",
         "resolve-url-loader": "^4.0.0",
@@ -47301,7 +47290,7 @@
         "open": "^8.4.0",
         "pkg-up": "^3.1.0",
         "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.10",
+        "react-error-overlay": "^6.0.11",
         "recursive-readdir": "^2.2.2",
         "shell-quote": "^1.7.3",
         "strip-ansi": "^6.0.1",
@@ -47337,19 +47326,6 @@
         "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
         "cross-env": "^7.0.3",
-<<<<<<< HEAD
-        "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
-=======
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-        "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
-=======
->>>>>>> 9f8d75e5 (chore(lint): lint all files)
->>>>>>> fb003998 (chore(lint): lint all files)
->>>>>>> f301bfe4 (chore(lint): lint all files)
         "flow-bin": "^0.116.0",
         "html-entities": "^2.3.2",
         "jest": "^27.4.3",
@@ -47506,7 +47482,7 @@
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0",
         "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
+        "eslint-config-react-app": "^7.0.1",
         "eslint-webpack-plugin": "^3.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.0",
@@ -47525,7 +47501,7 @@
         "prompts": "^2.4.2",
         "react": "^18.0.0",
         "react-app-polyfill": "^3.0.0",
-        "react-dev-utils": "^12.0.0",
+        "react-dev-utils": "^12.0.1",
         "react-dom": "^18.0.0",
         "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",

--- a/packages/babel-plugin-named-asset-import/index.test.js
+++ b/packages/babel-plugin-named-asset-import/index.test.js
@@ -36,16 +36,16 @@ pluginTester.default({
       output: 'import { logo } from "logo.svg";',
     },
     svgReactComponentNamedImport: {
-      code: 'import { ReactComponent as logo } from "logo.svg";',
-      output:
-        'import { ReactComponent as logo } from "@svgr/webpack?-svgo!logo.svg";',
+      code: 'import Logo from "logo.svg";',
+      output: 'import Logo from "@svgr/webpack?-svgo!logo.svg";',
     },
     svgMultipleImport: {
-      code: 'import logo, { logoUrl , ReactComponent as Logo } from "logo.svg";',
+      code:
+        'import logoUrl from "logo.svg?url";\n' +
+        'import Logo from "logo.svg";',
       output:
-        'import logo from "logo.svg";\n' +
-        'import { logoUrl } from "logo.svg";\n' +
-        'import { ReactComponent as Logo } from "@svgr/webpack?-svgo!logo.svg";',
+        'import logoUrl from "logo.svg?url";\n' +
+        'import Logo from "@svgr/webpack?-svgo!logo.svg";',
     },
     defaultExport: {
       code: 'export default logo;',
@@ -80,19 +80,19 @@ pluginTester.default({
       output: 'export * from "logo.svg";',
     },
     svgReactComponentNamedExport: {
-      code: 'export { ReactComponent as Logo } from "logo.svg";',
-      output:
-        'export { ReactComponent as Logo } from "@svgr/webpack?-svgo!logo.svg";',
+      code: 'export Logo from "logo.svg";',
+      output: 'export Logo from "@svgr/webpack?-svgo!logo.svg";',
     },
     svgReactComponentExport: {
       code: 'export { ReactComponent } from "logo.svg";',
       output: 'export { ReactComponent } from "@svgr/webpack?-svgo!logo.svg";',
     },
     svgMultipleExport: {
-      code: 'export { logoUrl , ReactComponent as Logo } from "logo.svg";',
+      code:
+        'export logoUrl from "logo.svg?url";' + 'export Logo from "logo.svg";',
       output:
-        'export { logoUrl } from "logo.svg";\n' +
-        'export { ReactComponent as Logo } from "@svgr/webpack?-svgo!logo.svg";',
+        'export logoUrl from "logo.svg?url";\n' +
+        'export Logo from "@svgr/webpack?-svgo!logo.svg";',
     },
   },
 });

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -386,29 +386,30 @@ module.exports = function (webpackEnv) {
               },
             },
             {
-              test: /\.svg$/,
-              use: [
-                {
-                  loader: require.resolve('@svgr/webpack'),
-                  options: {
-                    prettier: false,
-                    svgo: false,
-                    svgoConfig: {
-                      plugins: [{ removeViewBox: false }],
-                    },
-                    titleProp: true,
-                    ref: true,
-                  },
-                },
-                {
-                  loader: require.resolve('file-loader'),
-                  options: {
-                    name: 'static/media/[name].[hash].[ext]',
-                  },
-                },
-              ],
+              test: /\.svg$/i,
               issuer: {
                 and: [/\.(ts|tsx|js|jsx|md|mdx)$/],
+              },
+              type: 'asset',
+              resourceQuery: /url/, // *.svg?url
+            },
+            {
+              test: /\.svg$/i,
+              issuer: {
+                and: [/\.(ts|tsx|js|jsx|md|mdx)$/],
+              },
+              resourceQuery: { not: [/url/] }, // exclude react component if *.svg?url
+              use: {
+                loader: require.resolve('@svgr/webpack'),
+                options: {
+                  prettier: false,
+                  svgo: false,
+                  svgoConfig: {
+                    plugins: [{ removeViewBox: false }],
+                  },
+                  titleProp: true,
+                  ref: true,
+                },
               },
             },
             // Process application JS with Babel.

--- a/packages/react-scripts/fixtures/kitchensink/template/src/features/webpack/SvgComponent.js
+++ b/packages/react-scripts/fixtures/kitchensink/template/src/features/webpack/SvgComponent.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { ReactComponent as Logo } from './assets/logo.svg';
+import Logo from './assets/logo.svg';
 
 const SvgComponent = () => {
   return <Logo id="feature-svg-component" />;

--- a/packages/react-scripts/lib/react-app.d.ts
+++ b/packages/react-scripts/lib/react-app.d.ts
@@ -44,15 +44,16 @@ declare module '*.webp' {
   export default src;
 }
 
-declare module '*.svg' {
-  import * as React from 'react';
+declare module '*.svg?url' {
+  const content: string;
+  export default content;
+}
 
-  export const ReactComponent: React.FunctionComponent<
+declare module '*.svg' {
+  const ReactComponent: React.FunctionComponent<
     React.SVGProps<SVGSVGElement> & { title?: string }
   >;
-
-  const src: string;
-  export default src;
+  export default ReactComponent;
 }
 
 declare module '*.module.css' {


### PR DESCRIPTION
When SVG files are imported (both as ReactComponent or url) and thus inlined in the bundle are also included, in a mistaken way, in the `build/static/media` and consequence into the `asset-manifest.json`.

This behaviour is critical when using Service Worker because at the start of the application the browser will send all the pre-cache request for all these SVG files that don't need at all.

This PR resolves [#9167](https://github.com/facebook/create-react-app/issues/9167)

This is a working example created by ejecting the config of a cra template:
[my-app.zip](https://github.com/facebook/create-react-app/files/9288917/my-app.zip)

![Screenshot 2022-08-09 at 11 05 30](https://user-images.githubusercontent.com/34305269/183610229-a74b3d80-a959-487d-8e44-b060476c7935.png)
