### PR TITLE
Allow manual mocks with same name

### DIFF
--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -58,6 +58,9 @@ module.exports = (resolve, rootDir, isEjecting) => {
       '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
       ...(modules.jestAliases || {}),
     },
+    modulePathIgnorePatterns: [
+      '<rootDir>/src/.*/__mocks__',
+    ],
     moduleFileExtensions: [...paths.moduleFileExtensions, 'node'].filter(
       ext => !ext.includes('mjs')
     ),


### PR DESCRIPTION
_fix warning of jest-haste-map:
jest-haste-map: duplicate manual mock found: index
  The following files share their name; please delete one of them:

Allow manual mocks with same name #11148