### PR TITLE
Added missing '-' if starting create-react-app through yarn

### DIFF
--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -18,7 +18,7 @@ npx create-react-app my-app --template typescript
 or
 
 ```sh
-yarn create react-app my-app --template typescript
+yarn create-react-app my-app --template typescript
 ```
 
 > If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` or `yarn global remove create-react-app` to ensure that `npx` always uses the latest version.


### PR DESCRIPTION
Hello,

I was trying the typescript version of create-react-app, and in 'yarn create react-app my-app --template typescript', I noticed that one '-' was missing between 'create' and 'react'.

I fixed one missing '-' in the markdown documentation.

<img src="https://user-images.githubusercontent.com/66289619/187038052-486810fb-5312-4fee-a1dc-b0fb05f22a54.PNG" width="750px" />

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
