### PR TITLE
Update formatWebpackMessages.js (to re-add missing filename to error message)

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -21,6 +21,9 @@ function formatMessage(message) {
     lines = message.split('\n');
   } else if ('message' in message) {
     lines = message['message'].split('\n');
+    if('file' in message){
+      lines.unshift(message['file']);
+    }
   } else if (Array.isArray(message)) {
     message.forEach(message => {
       if ('message' in message) {


### PR DESCRIPTION
This PR simply prints out the filename as the first line: 
```
  } else if ('message' in message) {
    lines = message['message'].split('\n');
    if('file' in message){
      lines.unshift(message['file']);
    }
```
...which seems expected by row 77

```
  // Clean up file name
  lines[0] = lines[0].replace(/^(.*) \d+:\d+-\d+$/, '$1');
```

I use it normally as a local adjustment to my node_modules folder...

![image](https://user-images.githubusercontent.com/84977889/188642523-fbeecb39-564b-4d80-a5a1-74745e36cec8.png)
