### PR TITLE
Replace deprecated https with server, replace deprecated onBeforeSetupMiddleware, onAfterSetupMiddleware with setupMiddlewares

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -90,7 +90,7 @@ module.exports = function (proxy, allowedHost) {
       // remove last slash so user can land on `/test` instead of `/test/`
       publicPath: paths.publicUrlOrPath.slice(0, -1),
     },
-    server: {
+    server: !getHttpsConfig() ? 'http' : {
       type: 'https',
       options: getHttpsConfig(),
     },


### PR DESCRIPTION
Upgrade webpackV5, Replace deprecated https with server, replace deprecated onBeforeSetupMiddleware, onAfterSetupMiddleware with setupMiddlewares

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
