### PR TITLE
Fix 'ERR_STREAM_WRITE_AFTER_END' error in proxy

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -285,17 +285,22 @@ function onProxyError(proxy) {
     if (res.writeHead && !res.headersSent) {
       res.writeHead(500);
     }
-    res.end(
-      'Proxy error: Could not proxy request ' +
-        req.url +
-        ' from ' +
-        host +
-        ' to ' +
-        proxy +
-        ' (' +
-        err.code +
-        ').'
-    );
+
+    // In some cases `res` will already be finished. Trying to
+    // double end it can result in ERR_STREAM_WRITE_AFTER_END.
+    if (!res.finished) {
+      res.end(
+        'Proxy error: Could not proxy request ' +
+         req.url +
+         ' from ' +
+         host +
+         ' to ' +
+         proxy +
+         ' (' +
+         err.code +
+         ').'
+      );
+    }
   };
 }
 


### PR DESCRIPTION
In my project when using the CRA proxy configuration my team has started to hit transient ERR_STREAM_WRITE_AFTER_END errors that crash the dev server. This would result in an stack trace like the following:

```
[wds] Proxy error: Could not proxy request /api/graphql from localhost:3000 to http://localhost:8080/.
[wds] See https://nodejs.org/api/errors.html#errors_common_system_errors for more information (ECONNRESET).
[wds]
[wds] events.js:377
[wds]       throw er; // Unhandled 'error' event
[wds]       ^
[wds]
[wds] Error [ERR_STREAM_WRITE_AFTER_END]: write after end
[wds]     at new NodeError (internal/errors.js:322:7)
[wds]     at writeAfterEnd (_http_outgoing.js:694:15)
[wds]     at ServerResponse.end (_http_outgoing.js:815:7)
[wds]     at ServerResponse.end (project_root/node_modules/compression/index.js:107:21)
[wds]     at ProxyServer.<anonymous> (project_root/node_modules/react-dev-utils/WebpackDevServerUtils.js:288:9)
[wds]     at ProxyServer.emit (project_root/http-proxy/node_modules/eventemitter3/index.js:210:27)
[wds]     at ClientRequest.proxyError (project_root/node_modules/http-proxy/lib/http-proxy/passes/web-incoming.js:165:18)
[wds]     at ClientRequest.emit (events.js:400:28)
[wds]     at TLSSocket.socketErrorListener (_http_client.js:475:9)
[wds]     at TLSSocket.emit (events.js:400:28)
[wds] Emitted 'error' event on ServerResponse instance at:
[wds]     at writeAfterEndNT (_http_outgoing.js:753:7)
[wds]     at processTicksAndRejections (internal/process/task_queues.js:83:21) {
[wds]   code: 'ERR_STREAM_WRITE_AFTER_END'
[wds] }
```

I've not been able to fully determine what is ending the request before it gets to the 'onError' function, but I've confirmed that reproducing the CRA proxy using `setupProxy.js` with this change resolves the crash.