### PR TITLE
Update resolve-url-loader@^5.0.0 (with PostCSS v8)

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -64,7 +64,7 @@
     "react-dev-utils": "^12.0.1",
     "react-refresh": "^0.11.0",
     "resolve": "^1.20.0",
-    "resolve-url-loader": "^4.0.0",
+    "resolve-url-loader": "^5.0.0",
     "sass-loader": "^12.3.0",
     "semver": "^7.3.5",
     "source-map-loader": "^3.0.0",


### PR DESCRIPTION
This upgrades to the latest version of [resolve-url-loader](https://github.com/bholloway/resolve-url-loader/tree/v5/packages/resolve-url-loader) which itself upgrades to PostCSS@8. I have been encountering version conflicts related to this dependency and others that also depend on PostCSS that block CRA Webpack builds with this error:

```
> react-scripts build

Creating an optimized production build...
Failed to compile.

static/css/main.a6b5f62b.css from Css Minimizer plugin
Error: PostCSS plugin postcss-discard-comments requires PostCSS 8.
Migration guide for end-users:
https://github.com/postcss/postcss/wiki/PostCSS-8-for-end-users
```

The only usage of resolve-url-loader in react-scripts is requiring it in the Webpack config, so this upgrade is straightforward and in my testing causes no issue with the dev server or building for production.

I reported more details about the conflict here and created a reproduction here:

https://github.com/storybookjs/storybook/issues/19218

Currently I am working around this with npm v8's overrides feature.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
