### PR TITLE
Exit the start script when stdin closes

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -152,6 +152,8 @@ checkBrowsers(paths.appPath, isInteractive)
         devServer.close();
         process.exit();
       });
+
+      process.stdin.resume();
     }
   })
   .catch(err => {


### PR DESCRIPTION
The `start` script is supposedly exiting when stdin is closed, however it's no longer the case. See https://github.com/facebook/create-react-app/issues/11255#issuecomment-1257263397 for more details.