### PR TITLE
Bug Fixed: Create react app won't work on Windows if there are spaces…

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -253,6 +253,12 @@ function createApp(name, verbose, version, template, useYarn, usePnp) {
   const root = path.resolve(name);
   const appName = path.basename(root);
 
+  // We check if (the user is on windows and the project path contains a space)
+  if (isWindows() && stringContainsSpace(root)) {
+    console.error('Project path cannot contain spaces on Windows.');
+    process.exit(1);
+  }
+
   checkAppName(appName);
   fs.ensureDirSync(name);
   if (!isSafeToCreateProjectIn(root, name)) {
@@ -1115,6 +1121,13 @@ function checkForLatestVersion() {
         reject();
       });
   });
+}
+function isWindows() {
+  // https://nodejs.org/api/process.html#processplatform
+  return process.platform === 'win32';
+}
+function stringContainsSpace(string) {
+  return string.indexOf(' ') >= 0;
 }
 
 module.exports = {


### PR DESCRIPTION
… in your username #6512

Added code to check if a user is on Windows platform and if the path to create react app project contains space, then console.error a helpful message, and process.exit(1)

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Hey, didn't change any code, just added some new code.
This PR aims to resolve [issue #6512](https://github.com/facebook/create-react-app/issues/6512) and provide a helpful error message to Windows users in case the path of the project contains space.
Regards,
Ali Mansoor