### PR TITLE
Package "recursive-readdir" dependency removal

### DIFF
--- a/packages/react-dev-utils/FileSizeReporter.js
+++ b/packages/react-dev-utils/FileSizeReporter.js
@@ -11,7 +11,7 @@ var fs = require('fs');
 var path = require('path');
 var chalk = require('chalk');
 var filesize = require('filesize');
-var recursive = require('recursive-readdir');
+var recursive = require('./recursiveReaddir');
 var stripAnsi = require('strip-ansi');
 var gzipSize = require('gzip-size').sync;
 

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -45,6 +45,7 @@
     "openChrome.applescript",
     "printBuildError.js",
     "printHostingInstructions.js",
+    "recursiveReaddir.js",
     "redirectServedPathMiddleware.js",
     "refreshOverlayInterop.js",
     "typescriptFormatter.js",

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -72,7 +72,6 @@
     "pkg-up": "^3.1.0",
     "prompts": "^2.4.2",
     "react-error-overlay": "^6.0.11",
-    "recursive-readdir": "^2.2.2",
     "shell-quote": "^1.7.3",
     "strip-ansi": "^6.0.1",
     "text-table": "^0.2.0"

--- a/packages/react-dev-utils/recursiveReaddir.js
+++ b/packages/react-dev-utils/recursiveReaddir.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Roughly based on recursive-readdir which is not maintained
+// See: https://github.com/jergason/recursive-readdir/blob/master/index.js
+
+var fs = require('fs');
+var p = require('path');
+
+function readdir(path, callback) {
+  if (!callback) {
+    return new Promise(function (resolve, reject) {
+      readdir(path, function (err, data) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      });
+    });
+  }
+
+  var list = [];
+
+  fs.readdir(path, function (err, files) {
+    if (err) {
+      return callback(err);
+    }
+
+    var pending = files.length;
+    if (!pending) {
+      // we are done, woop woop
+      return callback(null, list);
+    }
+
+    files.forEach(function (file) {
+      var filePath = p.join(path, file);
+      fs.stat(filePath, function (_err, stats) {
+        if (_err) {
+          return callback(_err);
+        }
+
+        if (stats.isDirectory()) {
+          readdir(filePath, function (__err, res) {
+            if (__err) {
+              return callback(__err);
+            }
+
+            list = list.concat(res);
+            pending -= 1;
+            if (!pending) {
+              return callback(null, list);
+            }
+          });
+        } else {
+          list.push(filePath);
+          pending -= 1;
+          if (!pending) {
+            return callback(null, list);
+          }
+        }
+      });
+    });
+  });
+}
+
+module.exports = readdir;


### PR DESCRIPTION
Removed non-maintained package `recursive-readdir` (which has high severety security alert due to dependency on `"minimatch": "3.0.4"`)  from `react-dev-utils` deps