### PR TITLE
chore: update heroku instructions for deployment

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -378,9 +378,11 @@ If, when deploying, you get `Cannot read property 'email' of null`, try the foll
 
 ## [Heroku](https://www.heroku.com/)
 
-Use the [Heroku Buildpack for Create React App](https://github.com/heroku/heroku-buildpack-nodejs).
+**Prequisites:**
+Install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli#install-the-heroku-cli) and [create a Heroku remote](https://devcenter.heroku.com/articles/git#create-a-heroku-remote)
 
-You can find instructions in [Deploying React with Zero Configuration](https://blog.heroku.com/deploying-react-with-zero-configuration).
+**To Deploy:**
+Follow the instructions in [Deploy Your Code](https://devcenter.heroku.com/articles/git#deploy-your-code) in [Heroku's documentation](https://devcenter.heroku.com/categories/reference)
 
 ### Resolving Heroku Deployment Errors
 


### PR DESCRIPTION
Closes: #[12800](https://github.com/facebook/create-react-app/issues/12800)

What's being changed:
Removing outdated Heroku deployment instructions in Create-react-app documentation
Added updated reference links for Heroku deployment

*Screenshot of Updated Documentation*
_NEW_
<img width="1192" alt="HerokuDeploymentinCreateReactAppDocs" src="https://user-images.githubusercontent.com/43575215/198674079-ed220c6b-8aef-420e-84ec-d0ddbea4bc08.png">

_OLD_
<img width="1303" alt="outdatedherokudeployment" src="https://user-images.githubusercontent.com/43575215/198674465-5e907815-be44-44e5-bd52-321580d099fc.png">

_Create-react-app Heroku Buildpack reached End-of-Life_
<img width="1108" alt="create-react-app-EOL" src="https://user-images.githubusercontent.com/43575215/198674768-72d363ed-8052-4398-b83f-57f5cd1d9ec6.png">
