### PR TITLE
Upgrade recursive-readdir, to avoid minimatch/3.0.4 vulnerability

### DIFF
--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -72,7 +72,7 @@
     "pkg-up": "^3.1.0",
     "prompts": "^2.4.2",
     "react-error-overlay": "^6.0.11",
-    "recursive-readdir": "^2.2.2",
+    "recursive-readdir": "^2.2.3",
     "shell-quote": "^1.7.3",
     "strip-ansi": "^6.0.1",
     "text-table": "^0.2.0"


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
1 Known vulnerability of minimatch/3.0.4 in react-dev-utils
![image](https://user-images.githubusercontent.com/29649008/199148793-577c69fd-a647-4775-a71d-bb5fd30d0479.png)

![image](https://user-images.githubusercontent.com/29649008/199148717-0b8ac9b2-6558-48b0-b4f8-95627b387471.png)
