### PR TITLE
Use non-null assertion

### DIFF
--- a/packages/cra-template-typescript/template/src/index.tsx
+++ b/packages/cra-template-typescript/template/src/index.tsx
@@ -5,7 +5,7 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById('root')!
 );
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

It's more type safe to use non-null assertions over unnecessary type assertions in TypeScript, since type assertions are bivariant, and non-null assertions are not.

Here are some benefits to using non-null assertions to render React elements:
- Readability (using the right syntax to represent a non-null value, and not a type assertion that can imply other things)
- You won't get a type error if you render to an `Element` that isn't an `HTMLElement`, such as `<svg>`/`SVGSVGElement`
- You will get a type error if you render something that isn't just an `Element`, such as `Element | boolean`