### PR TITLE
Update clearConsole.js

### DIFF
--- a/packages/react-dev-utils/clearConsole.js
+++ b/packages/react-dev-utils/clearConsole.js
@@ -8,6 +8,10 @@
 'use strict';
 
 function clearConsole() {
+  if(process.env.DISABLE_CLEAR_CONSOLE) {
+    return;
+  }
+  
   process.stdout.write(
     process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H'
   );


### PR DESCRIPTION
Add DISABLE_CLEAR_CONSOLE environment variable to allow developers to disable the clearing of the console during app startup. Useful if running multiple services at the same time and one service fails during startup. 

Suggested usage in package.json: `DISABLE_CLEAR_CONSOLE=true npm start`

Note: this variable will prevent any usage of clearConsole.

ref https://github.com/facebook/create-react-app/issues/611

Testing: Add suggested change to package.json, run code and notice the other service logs still in the console once the app starts.
