### PR TITLE
Update analyzing-the-bundle-size.md

### DIFF
--- a/docusaurus/docs/analyzing-the-bundle-size.md
+++ b/docusaurus/docs/analyzing-the-bundle-size.md
@@ -33,7 +33,16 @@ Then in `package.json`, add the following line to `scripts`:
 Then to analyze the bundle run the production build then run the analyze
 script.
 
+Using `npm`:
+
 ```sh
 npm run build
 npm run analyze
+```
+
+Using `yarn`:
+
+```sh
+yarn build
+yarn analyze
 ```


### PR DESCRIPTION
Instructions to build/analyse using yarn, not just npm (given the alternate for installing via yarn is presented earlier, this makes sense).