### PR TITLE
fix:Fixing webpack5 cache invalidation

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -76,7 +76,7 @@ checkBrowsers(paths.appPath, isInteractive)
     return build(previousFileSizes);
   })
   .then(
-    ({ stats, previousFileSizes, warnings }) => {
+    ({ stats, previousFileSizes, warnings, compiler }) => {
       if (warnings.length) {
         console.log(chalk.yellow('Compiled with warnings.\n'));
         console.log(warnings.join('\n\n'));
@@ -115,6 +115,12 @@ checkBrowsers(paths.appPath, isInteractive)
         buildFolder,
         useYarn
       );
+      compiler.close(err => {
+        if (err && err.message) {
+          console.log(err.message);
+          process.exit(1);
+        }
+      });
     },
     err => {
       const tscCompileOnError = process.env.TSC_COMPILE_ON_ERROR === 'true';
@@ -203,6 +209,7 @@ function build(previousFileSizes) {
         stats,
         previousFileSizes,
         warnings: messages.warnings,
+        compiler,
       };
 
       if (writeStatsJson) {


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Currently, webpack5 caching is not working

If the cache was in effect, it would generate files with a '.pack' suffix, like ：

![rs5-has-cache](https://user-images.githubusercontent.com/33254923/205924602-d7854f9e-2d86-4daa-9436-43ffced21ad8.png)

And now, the generated result looks like this：

![rs5-no-cache](https://user-images.githubusercontent.com/33254923/205924744-76fc4c3f-73d8-49a7-8213-f5a9774e0523.png)

The reason is that 'compiler.close()' is not called

webpack will generate the cache in 'compiler.close()'

Run 'npm run build' to verify the effect

has a huge impact on compilation speed in a project
