### PR TITLE
Remove the deprecated package's url

### DIFF
--- a/docusaurus/docs/pre-rendering-into-static-html-files.md
+++ b/docusaurus/docs/pre-rendering-into-static-html-files.md
@@ -4,7 +4,7 @@ title: Pre-Rendering into Static HTML Files
 sidebar_label: Pre-Rendering Static HTML
 ---
 
-If you’re hosting your `build` with a static hosting provider you can use [react-snapshot](https://www.npmjs.com/package/react-snapshot) or [react-snap](https://www.npmjs.com/package/react-snap) to generate HTML pages for each route, or relative link, in your application. These pages will then seamlessly become active, or “hydrated”, when the JavaScript bundle has loaded.
+If you’re hosting your `build` with a static hosting provider you can use [react-snap](https://www.npmjs.com/package/react-snap) to generate HTML pages for each route, or relative link, in your application. These pages will then seamlessly become active, or “hydrated”, when the JavaScript bundle has loaded.
 
 There are also opportunities to use this outside of static hosting, to take the pressure off the server when generating and caching routes.
 


### PR DESCRIPTION
[Here](https://github.com/geelen/react-snapshot) it is mentioned that it was deprecated

<img width="958" alt="Screenshot 2022-12-15 at 4 57 03 PM" src="https://user-images.githubusercontent.com/24503078/207847779-399c393d-6118-4036-9386-493439a383f8.png">
