### PR TITLE
Update getting started doc about npx install

### DIFF
--- a/docusaurus/docs/getting-started.md
+++ b/docusaurus/docs/getting-started.md
@@ -18,6 +18,9 @@ npm start
 
 _([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))_
 
+If the bug persists, you can run : npx create-react-app@latest {project name}
+https://github.com/facebook/create-react-app/issues/11816
+
 Then open [http://localhost:3000/](http://localhost:3000/) to see your app.
 
 When you’re ready to deploy to production, create a minified bundle with `npm run build`.


### PR DESCRIPTION
You are running `create-react-app` 4.0.3, which is behind the latest release (5.0.1).

We no longer support global installation of Create React App.

I have this bug like many others when I run npx install, even after removing the global package. 
So the fix can be to precise lastest version (for the moment).