### PR TITLE
allow ignored variables when destructuring arrays

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -84,6 +84,7 @@ module.exports = {
           {
             args: 'none',
             ignoreRestSiblings: true,
+            destructuredArrayIgnorePattern: '^_',
           },
         ],
         'no-useless-constructor': 'off',
@@ -178,6 +179,7 @@ module.exports = {
       {
         args: 'none',
         ignoreRestSiblings: true,
+        destructuredArrayIgnorePattern: '^_',
       },
     ],
     'no-use-before-define': [


### PR DESCRIPTION
Adds the `destructuredArrayIgnorePattern: '^_'` option to the `no-unused-vars` eslint rule.

This allows you to write code like `const [_, dispatch] = useContext(AppContext)` without getting a lint warning.
