### PR TITLE
docs: fix external links in "Adding a Router"

### DIFF
--- a/docusaurus/docs/adding-a-router.md
+++ b/docusaurus/docs/adding-a-router.md
@@ -17,6 +17,6 @@ Alternatively you may use `yarn`:
 yarn add react-router-dom
 ```
 
-To try it, delete all the code in `src/App.js` and replace it with any of the examples on its website. The [Basic Example](https://reactrouter.com/docs/examples/basic) is a good place to get started. For more info on adding routes, check out [the React Router docs on adding routes](https://reactrouter.com/docs/getting-started/tutorial#add-some-routes).
+To try it, delete all the code in `src/App.js` and replace it with any of the examples on its website. The [Basic Example](https://v5.reactrouter.com/web/example/basic) is a good place to get started. For more info on adding routes, check out [the React Router docs on adding routes](https://reactrouter.com/en/start/tutorial#adding-a-router).
 
 Note that [you may need to configure your production server to support client-side routing](deployment.md#serving-apps-with-client-side-routing) before deploying your app.


### PR DESCRIPTION
1. Changed https://reactrouter.com/docs/examples/basic (404) to https://v5.reactrouter.com/web/example/basic
1. Changed https://reactrouter.com/docs/getting-started/tutorial#add-some-routes (404) to https://reactrouter.com/en/start/tutorial#adding-a-router