### PR TITLE
Prevent ending resource in evalSourceMapMiddleware.js

### DIFF
--- a/packages/react-dev-utils/evalSourceMapMiddleware.js
+++ b/packages/react-dev-utils/evalSourceMapMiddleware.js
@@ -34,6 +34,7 @@ module.exports = function createEvalSourceMapMiddleware(server) {
       const id = fileName.match(/webpack-internal:\/\/\/(.+)/)[1];
       if (!id || !server._stats) {
         next();
+        return;
       }
 
       const source = getSourceById(server, id);


### PR DESCRIPTION
Prevent ending resource when validation fails

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
