### PR TITLE
fix: Support Typescript composite projects (#7147)

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -740,6 +740,7 @@ module.exports = function (webpackEnv) {
             diagnosticOptions: {
               syntactic: true,
             },
+            build: true,
             mode: 'write-references',
             // profile: true,
           },


### PR DESCRIPTION
TypeScript 3.0 introduced project references / composite projects. This allows to split a TypeScript build into sub-projects, while automatically keeping track of dependencies.

Currently `react-scripts` uses the legacy build TypeScript build mode without composite project support. Composite projects are supported for a long time by `fork-ts-checker-webpack-plugin` but wasn't enabled in the Webpack. This commit enables the `build` flag for TypeScript Webpack config, and fixes support for composite projects.

Closes facebook/create-react-app#7147

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
