### PR TITLE
Remove outdated documentation section from the "Setting Up Your Editor" page

### DIFF
--- a/docusaurus/docs/setting-up-your-editor.md
+++ b/docusaurus/docs/setting-up-your-editor.md
@@ -97,18 +97,6 @@ Start your app by running `npm start`, and start debugging in VS Code by pressin
 
 Having problems with VS Code Debugging? Please see their [troubleshooting guide](https://github.com/Microsoft/vscode-chrome-debug/blob/master/README.md#troubleshooting).
 
-### WebStorm
-
-You need to have [WebStorm](https://www.jetbrains.com/webstorm/) and [JetBrains IDE Support](https://chrome.google.com/webstore/detail/jetbrains-ide-support/hmhgeddbohgjknpmjagkdomcpobmllji) Chrome extension installed.
-
-In the WebStorm menu `Run` select `Edit Configurations...`. Then click `+` and select `JavaScript Debug`. Paste `http://localhost:3000` into the URL field and save the configuration.
-
-> Note: the URL may be different if you've made adjustments via the [HOST or PORT environment variables](advanced-configuration.md).
-
-Start your app by running `npm start`, then press `^D` on macOS or `F9` on Windows and Linux or click the green debug icon to start debugging in WebStorm.
-
-The same way you can debug your application in IntelliJ IDEA Ultimate, PhpStorm, PyCharm Pro, and RubyMine.
-
 ## Formatting Code Automatically
 
 Prettier is an opinionated code formatter with support for JavaScript, CSS and JSON. With Prettier you can format the code you write automatically to ensure a code style within your project. See [Prettier's GitHub page](https://github.com/prettier/prettier) for more information, and look at this [page to see it in action](https://prettier.io/playground/).


### PR DESCRIPTION
### This PR contains adjustments for the ["Setting Up Your Editor"](https://create-react-app.dev/docs/setting-up-your-editor) page

In the scope of this PR, I propose to remove the outdated documentation section pointing to not existing anymore Chrome extension by JetBrains

- Appropriate JetBrains ticket - https://youtrack.jetbrains.com/issue/WEB-49212
- Proof that the extension is removed from the Chrome store - https://chrome-stats.com/d/hmhgeddbohgjknpmjagkdomcpobmllji