### PR TITLE
Ensure order of keys in process.env doesn't affect build output

### DIFF
--- a/packages/react-scripts/config/env.js
+++ b/packages/react-scripts/config/env.js
@@ -71,6 +71,8 @@ const REACT_APP = /^REACT_APP_/i;
 function getClientEnvironment(publicUrl) {
   const raw = Object.keys(process.env)
     .filter(key => REACT_APP.test(key))
+    // Ensure bundle hashes are unaffected by the key order in `process.env`.
+    .sort()
     .reduce(
       (env, key) => {
         env[key] = process.env[key];


### PR DESCRIPTION
Fixes #12992 .  Please see that issue for the problem description and a reproducible example including the fix.

I wasn't able to get the automated test suite running locally, so I haven't added any tests for this.  But I'd be happy to add them if someone can point me in the right direction.