### PR TITLE
feat: removed unnecessary react imports

### DIFF
--- a/packages/cra-template-typescript/template/src/App.test.tsx
+++ b/packages/cra-template-typescript/template/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 

--- a/packages/cra-template-typescript/template/src/App.tsx
+++ b/packages/cra-template-typescript/template/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 


### PR DESCRIPTION
We no longer need to import React from "react". Starting from the release 17 of React, JSX is automatically transformed without using React.createElement. 
https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html 