### PR TITLE
Make CSS processing the same in dev and prod

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -117,8 +117,7 @@ module.exports = function (webpackEnv) {
   // common function to get style loaders
   const getStyleLoaders = (cssOptions, preProcessor) => {
     const loaders = [
-      isEnvDevelopment && require.resolve('style-loader'),
-      isEnvProduction && {
+      {
         loader: MiniCssExtractPlugin.loader,
         // css is located in `static/css`, use '../../' to locate index.html folder
         // in production `paths.publicUrlOrPath` can be a relative path
@@ -505,9 +504,7 @@ module.exports = function (webpackEnv) {
             // "postcss" loader applies autoprefixer to our CSS.
             // "css" loader resolves paths in CSS and adds assets as dependencies.
             // "style" loader turns CSS into JS modules that inject <style> tags.
-            // In production, we use MiniCSSExtractPlugin to extract that CSS
-            // to a file, but in development "style" loader enables hot editing
-            // of CSS.
+            // We use MiniCssExtractPlugin to extract that CSS to a file.
             // By default we support CSS Modules with the extension .module.css
             {
               test: cssRegex,
@@ -662,13 +659,14 @@ module.exports = function (webpackEnv) {
       // a plugin that prints an error when you attempt to do this.
       // See https://github.com/facebook/create-react-app/issues/240
       isEnvDevelopment && new CaseSensitivePathsPlugin(),
-      isEnvProduction &&
-        new MiniCssExtractPlugin({
-          // Options similar to the same options in webpackOptions.output
-          // both options are optional
-          filename: 'static/css/[name].[contenthash:8].css',
-          chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
-        }),
+      new MiniCssExtractPlugin({
+        filename: isEnvProduction
+          ? 'static/css/[name].[contenthash:8].css'
+          : isEnvDevelopment && 'static/css/[name].css',
+        chunkFilename: isEnvProduction
+          ? 'static/css/[name].[contenthash:8].chunk.css'
+          : isEnvDevelopment && 'static/css/[name].chunk.css',
+      }),
       // Generate an asset manifest file with the following content:
       // - "files" key: Mapping of all asset filenames to their corresponding
       //   output file so that tools can pick it up without having to parse

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -68,7 +68,6 @@
     "sass-loader": "^12.3.0",
     "semver": "^7.3.5",
     "source-map-loader": "^3.0.0",
-    "style-loader": "^3.3.1",
     "tailwindcss": "^3.0.2",
     "terser-webpack-plugin": "^5.2.5",
     "webpack": "^5.64.4",


### PR DESCRIPTION
This pull request is a revival of https://github.com/facebook/create-react-app/pull/8148 given that react-scripts is now on webpack 5 and MiniCssExtractPlugin now supports hot reloading.

With this pull request, we can make CSS processing the same between dev and prod builds which helps in avoiding hard to debug issues where some CSS works fine locally but doesn't work when deployed due to ordering conflicts or similar. It's a problem I ran into recently and currently have to work-around by manually patching react-scripts in postinstall.

Tagging @andriijas @elektronik2k5 @vatz88 who participated in the original pull request.