### PR TITLE
chore: add fullySpecified to webpack configuration

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -354,6 +354,9 @@ module.exports = function (webpackEnv) {
           enforce: 'pre',
           exclude: /@babel(?:\/|\\{1,2})runtime/,
           test: /\.(js|mjs|jsx|ts|tsx|css)$/,
+          resolve: {
+            fullySpecified: false,
+          },
           loader: require.resolve('source-map-loader'),
         },
         {


### PR DESCRIPTION
Since webpack 5.0.0-beta.30, you're required to specify extensions when using imports in .mjs files or any .js files with a package.json with "type": "module".

For more information see issue #11865