### PR TITLE
Update `Learn React` URL -> `https://react.dev`

### DIFF
--- a/packages/cra-template/template/src/App.js
+++ b/packages/cra-template/template/src/App.js
@@ -11,7 +11,7 @@ function App() {
         </p>
         <a
           className="App-link"
-          href="https://reactjs.org"
+          href="https://react.dev"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
Hello, dear friends.
I just changed the url of create-react-app template to point correct url


