### PR TITLE
Fix doccs link typo 12141

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Here are a few common cases where you might want to try something else:
 
 - If you need to **integrate React code with a server-side template framework** like Rails, Django or Symfony, or if you’re **not building a single-page app**, consider using [nwb](https://github.com/insin/nwb), or [Neutrino](https://neutrino.js.org/) which are more flexible. For Rails specifically, you can use [Rails Webpacker](https://github.com/rails/webpacker). For Symfony, try [Symfony's webpack Encore](https://symfony.com/doc/current/frontend/encore/reactjs.html).
 
-- If you need to **publish a React component**, [nwb](https://github.com/insin/nwb) can [also do this](https://github.com/insin/nwb#react-components-and-libraries), as well as [Neutrino's react-components preset](https://neutrino.js.org/packages/react-components/).
+- If you need to **publish a React component**, [nwb](https://github.com/insin/nwb) can [also do this](https://github.com/insin/nwb#react-components-and-libraries), as well as [Neutrino's react-components preset](https://neutrinojs.org/packages/react-components/).
 
 - If you want to do **server rendering** with React and Node.js, check out [Next.js](https://nextjs.org/) or [Razzle](https://github.com/jaredpalmer/razzle). Create React App is agnostic of the backend, and only produces static HTML/JS/CSS bundles.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Here are a few common cases where you might want to try something else:
 
 - If you want to **try React** without hundreds of transitive build tool dependencies, consider [using a single HTML file or an online sandbox instead](https://reactjs.org/docs/getting-started.html#try-react).
 
-- If you need to **integrate React code with a server-side template framework** like Rails, Django or Symfony, or if you’re **not building a single-page app**, consider using [nwb](https://github.com/insin/nwb), or [Neutrino](https://neutrino.js.org/) which are more flexible. For Rails specifically, you can use [Rails Webpacker](https://github.com/rails/webpacker). For Symfony, try [Symfony's webpack Encore](https://symfony.com/doc/current/frontend/encore/reactjs.html).
+- If you need to **integrate React code with a server-side template framework** like Rails, Django or Symfony, or if you’re **not building a single-page app**, consider using [nwb](https://github.com/insin/nwb), or [Neutrino](https://neutrinojs.org/) which are more flexible. For Rails specifically, you can use [Rails Webpacker](https://github.com/rails/webpacker). For Symfony, try [Symfony's webpack Encore](https://symfony.com/doc/current/frontend/encore/reactjs.html).
 
 - If you need to **publish a React component**, [nwb](https://github.com/insin/nwb) can [also do this](https://github.com/insin/nwb#react-components-and-libraries), as well as [Neutrino's react-components preset](https://neutrinojs.org/packages/react-components/).
 
@@ -181,7 +181,7 @@ Here are a few common cases where you might want to try something else:
 
 - If your website is **mostly static** (for example, a portfolio or a blog), consider using [Gatsby](https://www.gatsbyjs.org/) or [Next.js](https://nextjs.org/). Unlike Create React App, Gatsby pre-renders the website into HTML at build time. Next.js supports both server rendering and pre-rendering.
 
-- Finally, if you need **more customization**, check out [Neutrino](https://neutrino.js.org/) and its [React preset](https://neutrino.js.org/packages/react/).
+- Finally, if you need **more customization**, check out [Neutrino](https://neutrinojs.org/) and its [React preset](https://neutrinojs.org/packages/react/).
 
 All of the above tools can work with little to no configuration.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29793,21 +29793,21 @@
       }
     },
     "packages/cra-template": {
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "packages/cra-template-typescript": {
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "packages/create-react-app": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -29848,7 +29848,7 @@
       }
     },
     "packages/eslint-config-react-app": {
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -29889,7 +29889,7 @@
       }
     },
     "packages/react-dev-utils": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
@@ -29911,7 +29911,7 @@
         "open": "^8.4.0",
         "pkg-up": "^3.1.0",
         "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.10",
+        "react-error-overlay": "^6.0.11",
         "recursive-readdir": "^2.2.2",
         "shell-quote": "^1.7.3",
         "strip-ansi": "^6.0.1",
@@ -29934,7 +29934,7 @@
       }
     },
     "packages/react-error-overlay": {
-      "version": "6.0.10",
+      "version": "6.0.11",
       "license": "MIT",
       "devDependencies": {
         "@babel/code-frame": "^7.16.0",
@@ -29946,17 +29946,6 @@
         "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
         "cross-env": "^7.0.3",
-        "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
-<<<<<<< HEAD
-=======
-=======
-<<<<<<< HEAD
->>>>>>> f21e2137 (Publish)
-=======
->>>>>>> 9f8d75e5 (chore(lint): lint all files)
->>>>>>> fb003998 (chore(lint): lint all files)
->>>>>>> f301bfe4 (chore(lint): lint all files)
         "flow-bin": "^0.116.0",
         "html-entities": "^2.3.2",
         "jest": "^27.4.3",
@@ -29983,7 +29972,7 @@
       }
     },
     "packages/react-scripts": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -30002,7 +29991,7 @@
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0",
         "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
+        "eslint-config-react-app": "^7.0.1",
         "eslint-webpack-plugin": "^3.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.0",
@@ -30019,7 +30008,7 @@
         "postcss-preset-env": "^7.0.1",
         "prompts": "^2.4.2",
         "react-app-polyfill": "^3.0.0",
-        "react-dev-utils": "^12.0.0",
+        "react-dev-utils": "^12.0.1",
         "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",
         "resolve-url-loader": "^4.0.0",
@@ -47301,7 +47290,7 @@
         "open": "^8.4.0",
         "pkg-up": "^3.1.0",
         "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.10",
+        "react-error-overlay": "^6.0.11",
         "recursive-readdir": "^2.2.2",
         "shell-quote": "^1.7.3",
         "strip-ansi": "^6.0.1",
@@ -47337,19 +47326,6 @@
         "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
         "cross-env": "^7.0.3",
-<<<<<<< HEAD
-        "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
-=======
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-        "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
-=======
->>>>>>> 9f8d75e5 (chore(lint): lint all files)
->>>>>>> fb003998 (chore(lint): lint all files)
->>>>>>> f301bfe4 (chore(lint): lint all files)
         "flow-bin": "^0.116.0",
         "html-entities": "^2.3.2",
         "jest": "^27.4.3",
@@ -47506,7 +47482,7 @@
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0",
         "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
+        "eslint-config-react-app": "^7.0.1",
         "eslint-webpack-plugin": "^3.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.0",
@@ -47525,7 +47501,7 @@
         "prompts": "^2.4.2",
         "react": "^18.0.0",
         "react-app-polyfill": "^3.0.0",
-        "react-dev-utils": "^12.0.0",
+        "react-dev-utils": "^12.0.1",
         "react-dom": "^18.0.0",
         "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

The PR incudes 

1. Access the page with the typo or broken link: https://neutrino.js.org/packages/react-components/ </br>
<img width="420" alt="image" src="https://github.com/facebook/create-react-app/assets/24918810/af624521-0830-412c-b421-c6a06df4b170"></br>
2. Verify that the link is not working or that there is a typo.</br>
3. Made the change to the link by replacing "neutrino.js.org" with "neutrinojs.org".</br>
4. Verify that the link now works or that the typo has been corrected.</br>
<img width="420" alt="image" src="https://github.com/facebook/create-react-app/assets/24918810/7c05c8f4-4595-40fe-8c6d-1d2420cfb948"></br>

