### PR TITLE
fix broken urls: from reacttraining.com to v5.reactrouter.com

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -112,7 +112,7 @@ This will let Create React App correctly infer the root path to use in the gener
 
 **Note**: If you are using `react-router@^4`, you can root `<Link>`s using the `basename` prop on any `<Router>`.
 
-More information [here](https://reacttraining.com/react-router/web/api/BrowserRouter/basename-string).
+More information [here](https://v5.reactrouter.com/web/api/BrowserRouter/basename-string).
 
 For example:
 
@@ -355,7 +355,7 @@ mywebsite.com
 
 GitHub Pages doesn’t support routers that use the HTML5 `pushState` history API under the hood (for example, React Router using `browserHistory`). This is because when there is a fresh page load for a url like `http://user.github.io/todomvc/todos/42`, where `/todos/42` is a frontend route, the GitHub Pages server returns 404 because it knows nothing of `/todos/42`. If you want to add a router to a project hosted on GitHub Pages, here are a couple of solutions:
 
-- You could switch from using HTML5 history API to routing with hashes. If you use React Router, you can switch to `hashHistory` for this effect, but the URL will be longer and more verbose (for example, `http://user.github.io/todomvc/#/todos/42?_k=yknaj`). [Read more](https://reacttraining.com/react-router/web/api/Router) about different history implementations in React Router.
+- You could switch from using HTML5 history API to routing with hashes. If you use React Router, you can switch to `hashHistory` for this effect, but the URL will be longer and more verbose (for example, `http://user.github.io/todomvc/#/todos/42?_k=yknaj`). [Read more](https://v5.reactrouter.com/web/api/Router) about different history implementations in React Router.
 - Alternatively, you can use a trick to teach GitHub Pages to handle 404s by redirecting to your `index.html` page with a custom redirect parameter. You would need to add a `404.html` file with the redirection code to the `build` folder before deploying your project, and you’ll need to add code handling the redirect parameter to `index.html`. You can find a detailed explanation of this technique [in this guide](https://github.com/rafrex/spa-github-pages).
 
 ### Troubleshooting

--- a/package-lock.json
+++ b/package-lock.json
@@ -29793,21 +29793,21 @@
       }
     },
     "packages/cra-template": {
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "packages/cra-template-typescript": {
-      "version": "1.1.3",
+      "version": "1.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=14"
       }
     },
     "packages/create-react-app": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -29848,7 +29848,7 @@
       }
     },
     "packages/eslint-config-react-app": {
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -29889,7 +29889,7 @@
       }
     },
     "packages/react-dev-utils": {
-      "version": "12.0.0",
+      "version": "12.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
@@ -29911,7 +29911,7 @@
         "open": "^8.4.0",
         "pkg-up": "^3.1.0",
         "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.10",
+        "react-error-overlay": "^6.0.11",
         "recursive-readdir": "^2.2.2",
         "shell-quote": "^1.7.3",
         "strip-ansi": "^6.0.1",
@@ -29934,7 +29934,7 @@
       }
     },
     "packages/react-error-overlay": {
-      "version": "6.0.10",
+      "version": "6.0.11",
       "license": "MIT",
       "devDependencies": {
         "@babel/code-frame": "^7.16.0",
@@ -29946,17 +29946,6 @@
         "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
         "cross-env": "^7.0.3",
-        "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
-<<<<<<< HEAD
-=======
-=======
-<<<<<<< HEAD
->>>>>>> f21e2137 (Publish)
-=======
->>>>>>> 9f8d75e5 (chore(lint): lint all files)
->>>>>>> fb003998 (chore(lint): lint all files)
->>>>>>> f301bfe4 (chore(lint): lint all files)
         "flow-bin": "^0.116.0",
         "html-entities": "^2.3.2",
         "jest": "^27.4.3",
@@ -29983,7 +29972,7 @@
       }
     },
     "packages/react-scripts": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -30002,7 +29991,7 @@
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0",
         "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
+        "eslint-config-react-app": "^7.0.1",
         "eslint-webpack-plugin": "^3.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.0",
@@ -30019,7 +30008,7 @@
         "postcss-preset-env": "^7.0.1",
         "prompts": "^2.4.2",
         "react-app-polyfill": "^3.0.0",
-        "react-dev-utils": "^12.0.0",
+        "react-dev-utils": "^12.0.1",
         "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",
         "resolve-url-loader": "^4.0.0",
@@ -47301,7 +47290,7 @@
         "open": "^8.4.0",
         "pkg-up": "^3.1.0",
         "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.10",
+        "react-error-overlay": "^6.0.11",
         "recursive-readdir": "^2.2.2",
         "shell-quote": "^1.7.3",
         "strip-ansi": "^6.0.1",
@@ -47337,19 +47326,6 @@
         "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
         "cross-env": "^7.0.3",
-<<<<<<< HEAD
-        "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
-=======
-<<<<<<< HEAD
-=======
-<<<<<<< HEAD
-        "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
-=======
->>>>>>> 9f8d75e5 (chore(lint): lint all files)
->>>>>>> fb003998 (chore(lint): lint all files)
->>>>>>> f301bfe4 (chore(lint): lint all files)
         "flow-bin": "^0.116.0",
         "html-entities": "^2.3.2",
         "jest": "^27.4.3",
@@ -47506,7 +47482,7 @@
         "dotenv": "^10.0.0",
         "dotenv-expand": "^5.1.0",
         "eslint": "^8.3.0",
-        "eslint-config-react-app": "^7.0.0",
+        "eslint-config-react-app": "^7.0.1",
         "eslint-webpack-plugin": "^3.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.0",
@@ -47525,7 +47501,7 @@
         "prompts": "^2.4.2",
         "react": "^18.0.0",
         "react-app-polyfill": "^3.0.0",
-        "react-dev-utils": "^12.0.0",
+        "react-dev-utils": "^12.0.1",
         "react-dom": "^18.0.0",
         "react-refresh": "^0.11.0",
         "resolve": "^1.20.0",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

The PR incudes fix of

1. Access the page with the typo or broken link: https://reacttraining.com/react-router/web/api/Router </br>
<img width="420" alt="image" src="https://github.com/facebook/create-react-app/assets/24918810/ab2c99c7-5dd5-4314-ac1c-cc5920a13954"> </br>
2. Verify that the link is not working or that there is a typo. </br>
3. Made the change to the link by replacing "https://reacttraining.com/react-router/web/api/Router" with "https://v5.reactrouter.com/web/api/Router)" </br>
4.   <img width="420" alt="image" src="https://github.com/facebook/create-react-app/assets/24918810/ad5e3e27-9d5b-4b63-a2c2-2280dfda4f0b">
5. Verify that the link now works or that the typo has been corrected. </br>
 