### PR TITLE
The "More Information here" link fix

### DIFF
--- a/docusaurus/docs/deployment.md
+++ b/docusaurus/docs/deployment.md
@@ -112,7 +112,7 @@ This will let Create React App correctly infer the root path to use in the gener
 
 **Note**: If you are using `react-router@^4`, you can root `<Link>`s using the `basename` prop on any `<Router>`.
 
-More information [here](https://reacttraining.com/react-router/web/api/BrowserRouter/basename-string).
+More information [here](https://reactrouter.com/en/main/routers/create-browser-router#basename).
 
 For example:
 


### PR DESCRIPTION
Closes #13165 

Fixed URL that navigates to newer React Router docs