### PR TITLE
Add an environment variable for disabling compression on the proxy server

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -66,6 +66,14 @@ DANGEROUSLY_DISABLE_HOST_CHECK=true
 
 We don’t recommend this approach.
 
+## Server Sent Events (SSE) not being received by client
+
+This may be caused due to the fact that compression is enabled on the development server. You can try disabling compression by adding the following line to `.env.development` in the root of your project:
+
+```
+WDS_COMPRESSION=false
+```
+
 ## Configuring the Proxy Manually
 
 > Note: this feature is available with `react-scripts@2.0.0` and higher.

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -20,6 +20,7 @@ const host = process.env.HOST || '0.0.0.0';
 const sockHost = process.env.WDS_SOCKET_HOST;
 const sockPath = process.env.WDS_SOCKET_PATH; // default: '/ws'
 const sockPort = process.env.WDS_SOCKET_PORT;
+const compress = process.env.WDS_COMPRESSION !== 'false';
 
 module.exports = function (proxy, allowedHost) {
   const disableFirewall =
@@ -50,7 +51,7 @@ module.exports = function (proxy, allowedHost) {
       'Access-Control-Allow-Headers': '*',
     },
     // Enable gzip compression of generated files.
-    compress: true,
+    compress,
     static: {
       // By default WebpackDevServer serves physical files from current directory
       // in addition to all the virtual build products that it serves from memory.


### PR DESCRIPTION
This commit adds an environment variable 'WDS_COMPRESSION' which can be set to 'false' to opt -out of compression. This is desirable when using Server Sent Events as the proxy fails to pass Server Sent Events when compression is enabled

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
