### PR TITLE
changed div tag to main tag in index.html reference to issue #13204

### DIFF
--- a/packages/cra-template-typescript/template/public/index.html
+++ b/packages/cra-template-typescript/template/public/index.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <main id="root"></main>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/packages/cra-template/template/public/index.html
+++ b/packages/cra-template/template/public/index.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <main id="root"></main>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.


### PR DESCRIPTION

I changed the cra- template folder in which we have index.html in the public directory , we have,
div of id root which could be changed to main of id root  in order to:

- Better document readability for the developer
- Screenreader landmarks and inferred roles.
- Improved Semantics (through differentiation from
- elements).
- Element-level selector distinction in CSS (low specificity).

This is made in accordance to the issue #13204 that is raised recently.
I made appropriate changes in both the cra-template part as well as cra-template for typescript as well. I will be attaching a screenshot below of the change made for better understanding,

![image](https://github.com/facebook/create-react-app/assets/72154312/4c860ada-5a1b-40a7-9c8a-e8c1e1093ff5)
