### PR TITLE
Fixed the vulnerability message due to an issue with @svgr/webpack

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@babel/core": "^7.16.0",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
-    "@svgr/webpack": "^5.5.0",
+    "@svgr/webpack": "^8.0.1",
     "babel-jest": "^27.4.2",
     "babel-loader": "^8.2.3",
     "babel-plugin-named-asset-import": "^0.3.8",


### PR DESCRIPTION
Fixes #11174, #13186, #13227 thanks to #12132

When running `npm audit`, this message shows:
![image](https://github.com/facebook/create-react-app/assets/91056752/89b87eb2-4167-42d4-80a8-1277247e02bd)

And after modifying it to version 8.0.1, it shows:
![image](https://github.com/facebook/create-react-app/assets/91056752/0d339c66-5176-4f92-8811-e4975635ead9)