### PR TITLE
Start devServer dual-stack by default

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -16,7 +16,7 @@ const redirectServedPath = require('react-dev-utils/redirectServedPathMiddleware
 const paths = require('./paths');
 const getHttpsConfig = require('./getHttpsConfig');
 
-const host = process.env.HOST || '0.0.0.0';
+const host = process.env.HOST || '::';
 const sockHost = process.env.WDS_SOCKET_HOST;
 const sockPath = process.env.WDS_SOCKET_PATH; // default: '/ws'
 const sockPort = process.env.WDS_SOCKET_PORT;

--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -53,7 +53,7 @@ if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
 
 // Tools like Cloud9 rely on this.
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
-const HOST = process.env.HOST || '0.0.0.0';
+const HOST = process.env.HOST || '::';
 
 if (process.env.HOST) {
   console.log(


### PR DESCRIPTION
The default `host` for Webpack's `devServer` is currently `0.0.0.0`. So we can reach our project on `http://localhost:3000`, but **only over IPv4**!

For browsers this isn't really a problem, as they fall back to IPv4 automatically. But other clients usually don't have such a fallback, and as more operating systems/frameworks will default to IPv6, this will cause problems.

By using `::` instead of `0.0.0.0`, the server will be available on both IPv4 and IPv6 by default.

I've tested this change locally, and the [Node.js docs](https://nodejs.org/docs/latest-v16.x/api/net.html#serverlistenoptions-callback) mention that dual-stack support is the default behaviour when using `::`. But more testing might be needed.

----

A little more context: I ran into this issue because I'm using `setupProxy` to access my GraphQL API through the `devServer`. So I ran `graphql-codegen` against `http://localhost:3000/graphql`, and it tries to connect using IPv6.
