### PR TITLE
Sass: dependency to dev-dependency

### DIFF
--- a/docusaurus/docs/adding-a-sass-stylesheet.md
+++ b/docusaurus/docs/adding-a-sass-stylesheet.md
@@ -13,9 +13,9 @@ Following this rule often makes CSS preprocessors less useful, as features like 
 To use Sass, first install `sass`:
 
 ```sh
-$ npm install sass
+$ npm install --save-dev sass
 # or
-$ yarn add sass
+$ yarn add sass --dev
 ```
 
 Now you can rename `src/App.css` to `src/App.scss` and update `src/App.js` to import `src/App.scss`.
@@ -61,8 +61,8 @@ To use imports relative to a path you specify, you can add a [`.env` file](https
 >
 > ```sh
 > $ npm uninstall node-sass
-> $ npm install sass
+> $ npm install sass --save-dev
 > # or
 > $ yarn remove node-sass
-> $ yarn add sass
+> $ yarn add --dev sass
 > ```

--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -88,7 +88,7 @@ function formatMessage(message) {
   if (lines[1] && lines[1].match(/Cannot find module.+sass/)) {
     lines[1] = 'To import Sass files, you first need to install sass.\n';
     lines[1] +=
-      'Run `npm install sass` or `yarn add sass` inside your workspace.';
+      'Run `npm install sass --save-dev` or `yarn add --dev sass` inside your workspace.';
   }
 
   message = lines.join('\n');


### PR DESCRIPTION
Saas should be installed as dev-dependency instead dependency.

Official Sass documentation:
`You can also add it to your project using npm install --save-dev sass.`
https://github.com/sass/dart-sass/blob/main/README.md

![image](https://github.com/facebook/create-react-app/assets/5566282/19142a5f-084d-4d0b-a52d-7369c3b5b070)
