### PR TITLE
Use FIPS Compliant sha256 algorithm for hashing

### DIFF
--- a/packages/react-dev-utils/getCSSModuleLocalIdent.js
+++ b/packages/react-dev-utils/getCSSModuleLocalIdent.js
@@ -25,7 +25,7 @@ module.exports = function getLocalIdent(
   // Create a hash based on a the file location and class name. Will be unique across a project, and close to globally unique.
   const hash = loaderUtils.getHashDigest(
     path.posix.relative(context.rootContext, context.resourcePath) + localName,
-    'md5',
+    'sha256',
     'base64',
     5
   );

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -238,6 +238,8 @@ module.exports = function (webpackEnv) {
               .replace(/\\/g, '/')
         : isEnvDevelopment &&
           (info => path.resolve(info.absoluteResourcePath).replace(/\\/g, '/')),
+      // Some environments disable insecure hash functions like md4,md5
+      hashFunction: 'sha256',
     },
     cache: {
       type: 'filesystem',

--- a/packages/react-scripts/config/webpack/persistentCache/createEnvironmentHash.js
+++ b/packages/react-scripts/config/webpack/persistentCache/createEnvironmentHash.js
@@ -2,7 +2,7 @@
 const { createHash } = require('crypto');
 
 module.exports = env => {
-  const hash = createHash('md5');
+  const hash = createHash('sha256');
   hash.update(JSON.stringify(env));
 
   return hash.digest('hex');


### PR DESCRIPTION
### Purpose

md5 and md4 (the webpack default) hashes are disabled on FIPS compliant systems.

Additionally sha256 is less prone to collisions.

See issue #11214

### Verification 
I verified these changes by:

1. Running `npm install`
2. Running `npm start`
3. Verifying that `http://localhost:3000` loads the react template app.
4. Modifying `./packages/cra-template/template/src/App.js` and observing the changes made are reflected on `http://localhost:3000`.

Additionally I ran `npm run build` before and after my changes were applied to see that the filenames under `./build/static/js` reflect the changed hash algorithm.

Output of `ls build/static/js` after `npm run build` on commit 4170341d5d7ff5533ba9f29543415f240fa9ca90
```
415.19472006.chunk.js  415.19472006.chunk.js.map  main.0b66650c.js  main.0b66650c.js.LICENSE.txt  main.0b66650c.js.map
```

Output of `ls build/static/js` after `npm run build` on commit 0a827f69ab0d2ee3871ba9b71350031d8a81b7ae
```
415.4a4b4c13.chunk.js  415.4a4b4c13.chunk.js.map  main.a5b8cfff.js  main.a5b8cfff.js.LICENSE.txt  main.a5b8cfff.js.map
```

Output of `ls build/static/js` after `npm run build` on commit 4170341d5d7ff5533ba9f29543415f240fa9ca90 (again)
```
415.19472006.chunk.js  415.19472006.chunk.js.map  main.0b66650c.js  main.0b66650c.js.LICENSE.txt  main.0b66650c.js.map
```

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
