### PR TITLE
fix: updated outdated packages in react-scripts to solve vulnerabilit…

### DIFF
--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -1,47 +1,107 @@
 {
-  "name": "create-react-app",
+  "name": "react-scripts",
   "version": "5.0.1",
-  "keywords": [
-    "react"
-  ],
-  "description": "Create React apps with no build configuration.",
+  "description": "Configuration and scripts for Create React App.",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/create-react-app.git",
-    "directory": "packages/create-react-app"
+    "directory": "packages/react-scripts"
   },
   "license": "MIT",
   "engines": {
-    "node": ">=14"
+    "node": ">=14.0.0"
   },
   "bugs": {
     "url": "https://github.com/facebook/create-react-app/issues"
   },
   "files": [
-    "index.js",
-    "createReactApp.js"
+    "bin",
+    "config",
+    "lib",
+    "scripts",
+    "template",
+    "template-typescript",
+    "utils"
   ],
   "bin": {
-    "create-react-app": "./index.js"
+    "react-scripts": "./bin/react-scripts.js"
   },
-  "scripts": {
-    "test": "cross-env FORCE_COLOR=true jest"
-  },
+  "types": "./lib/react-app.d.ts",
   "dependencies": {
-    "chalk": "^4.1.2",
-    "commander": "^4.1.1",
-    "cross-spawn": "^7.0.3",
-    "envinfo": "^7.8.1",
-    "fs-extra": "^10.0.0",
-    "hyperquest": "^2.1.3",
+    "@babel/core": "^7.22.10",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.10",
+    "@svgr/webpack": "^8.0.1",
+    "babel-jest": "^27.5.1",
+    "babel-loader": "^8.3.0",
+    "babel-plugin-named-asset-import": "^0.3.8",
+    "babel-preset-react-app": "^10.0.1",
+    "bfj": "^7.0.2",
+    "browserslist": "^4.21.10",
+    "camelcase": "^6.3.0",
+    "case-sensitive-paths-webpack-plugin": "^2.4.0",
+    "css-loader": "^6.8.1",
+    "css-minimizer-webpack-plugin": "^3.4.1",
+    "dotenv": "^10.0.0",
+    "dotenv-expand": "^5.1.0",
+    "eslint": "^8.46.0",
+    "eslint-config-react-app": "^7.0.1",
+    "eslint-webpack-plugin": "^3.2.0",
+    "file-loader": "^6.2.0",
+    "fs-extra": "^10.1.0",
+    "html-webpack-plugin": "^5.5.3",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^27.5.1",
+    "jest-resolve": "^27.5.1",
+    "jest-watch-typeahead": "^1.1.0",
+    "mini-css-extract-plugin": "^2.7.6",
+    "postcss": "^8.4.27",
+    "postcss-flexbugs-fixes": "^5.0.2",
+    "postcss-loader": "^6.2.1",
+    "postcss-normalize": "^10.0.1",
+    "postcss-preset-env": "^7.8.3",
     "prompts": "^2.4.2",
+    "react-app-polyfill": "^3.0.0",
+    "react-dev-utils": "^12.0.1",
+    "react-refresh": "^0.11.0",
+    "resolve": "^1.22.4",
+    "resolve-url-loader": "^4.0.0",
+    "sass-loader": "^12.6.0",
     "semver": "^7.3.5",
-    "tar-pack": "^3.4.1",
-    "tmp": "^0.2.1",
-    "validate-npm-package-name": "^3.0.0"
+    "source-map-loader": "^3.0.2",
+    "style-loader": "^3.3.3",
+    "tailwindcss": "^3.3.3",
+    "terser-webpack-plugin": "^5.3.9",
+    "webpack": "^5.88.2",
+    "webpack-dev-server": "^4.15.1",
+    "webpack-manifest-plugin": "^4.1.1",
+    "workbox-webpack-plugin": "^6.6.0"
   },
   "devDependencies": {
-    "cross-env": "^7.0.3",
-    "jest": "^27.4.3"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "optionalDependencies": {
+    "fsevents": "^2.3.2"
+  },
+  "peerDependencies": {
+    "react": ">= 16",
+    "typescript": "^3.2.1 || ^4"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }


### PR DESCRIPTION
In a project i have as dependency react-script when the command `npm audit` returns vulnerability warning due to outaded packages in react script

updated @svgr/webpack to 8.0.1. For testing i have run npm test and npm run test:integration and also created a new app with create-react-app and the app which was working