### PR TITLE
docs: Add instructions for bun/bunx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ You will need `npm@7` and `yarn@1` in order to bootstrap and test a local copy o
 
 2. Run `npm install` in the root `create-react-app` folder.
 
-Once it is done, you can modify any file locally and run `npm start`, `npm test` or `npm run build` like you can in a generated project. It will serve the application from the files located in `packages/cra-template/template`.
+Once it is done, you can modify any file locally and run `npm start`, `npm test` or `r` like you can in a generated project. It will serve the application from the files located in `packages/cra-template/template`.
 
 If you want to try out the end-to-end flow with the global CLI, you can do this too:
 
@@ -111,7 +111,7 @@ npx create-react-app my-app
 cd my-app
 ```
 
-and then run `npm start` or `npm run build`.
+and then run `npm start` or `r`.
 
 ## Contributing to E2E (end to end) tests
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ yarn create react-app my-app
 
 _[`yarn create <starter-kit-package>`](https://yarnpkg.com/lang/en/docs/cli/create/) is available in Yarn 0.25+_
 
+### Bun
+
+```sh
+bunx create-react-app my-app
+```
+
 It will create a directory called `my-app` inside the current folder.<br>
 Inside that directory, it will generate the initial project structure and install the transitive dependencies:
 

--- a/docusaurus/docs/adding-typescript.md
+++ b/docusaurus/docs/adding-typescript.md
@@ -21,6 +21,12 @@ or
 yarn create react-app my-app --template typescript
 ```
 
+or
+
+```sh
+bunx create-react-app my-app --template typescript
+```
+
 > If you've previously installed `create-react-app` globally via `npm install -g create-react-app`, we recommend you uninstall the package using `npm uninstall -g create-react-app` or `yarn global remove create-react-app` to ensure that `npx` always uses the latest version.
 >
 > Global installs of `create-react-app` are no longer supported.

--- a/docusaurus/docs/getting-started.md
+++ b/docusaurus/docs/getting-started.md
@@ -62,6 +62,12 @@ yarn create react-app my-app
 
 _`yarn create` is available in Yarn 0.25+_
 
+### Bun
+
+```sh
+bunx create-react-app my-app
+```
+
 ### Selecting a template
 
 You can now optionally start a new app from a template by appending `--template [template-name]` to the creation command.
@@ -90,13 +96,15 @@ If you already have a project and would like to add TypeScript, see our [Adding 
 
 ### Selecting a package manager
 
-When you create a new app, the CLI will use [npm](https://docs.npmjs.com) or [Yarn](https://yarnpkg.com/) to install dependencies, depending on which tool you use to run `create-react-app`. For example:
+When you create a new app, the CLI will use [npm](https://docs.npmjs.com), [Yarn](https://yarnpkg.com/), or [Bun](https://bun.sh/package-manager) to install dependencies, depending on which tool you use to run `create-react-app`. For example:
 
 ```sh
 # Run this to use npm
 npx create-react-app my-app
 # Or run this to use yarn
 yarn create react-app my-app
+# Or run this to use bun
+bunx create-react-app my-app
 ```
 
 ## Output

--- a/packages/cra-template-typescript/README.md
+++ b/packages/cra-template-typescript/README.md
@@ -8,10 +8,10 @@ For example:
 
 ```sh
 npx create-react-app my-app --template typescript
-
 # or
-
 yarn create react-app my-app --template typescript
+# or
+bunx create-react-app my-app --template typescript
 ```
 
 For more information, please refer to:

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -514,7 +514,7 @@ function run(
           },
           [root, appName, verbose, originalDirectory, templateName],
           `
-        const init = require('../../react-scripts/scripts/init.js');
+        const init = require('${packageName}/scripts/init.js');
         init.apply(null, JSON.parse(process.argv[1]));
       `
         );

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -49,8 +49,15 @@ const validateProjectName = require('validate-npm-package-name');
 
 const packageJson = require('./package.json');
 
-function isUsingYarn() {
-  return (process.env.npm_config_user_agent || '').indexOf('yarn') === 0;
+function getPackageManager() {
+  const pm_user_agent = process.env.npm_config_user_agent || '';
+  if (pm_user_agent.indexOf('yarn') === 0) {
+    return 'yarn';
+  }
+  if (pm_user_agent.indexOf('bun') === 0) {
+    return 'bun';
+  }
+  return 'npm';
 }
 
 let projectName;
@@ -219,20 +226,23 @@ function init() {
         );
         console.log();
       } else {
-        const useYarn = isUsingYarn();
+        let packageManager = getPackageManager();
+        if (packageManager === 'yarn' && program.usePnp) {
+          packageManager = 'yarn-pnp';
+        }
         createApp(
           projectName,
           program.verbose,
           program.scriptsVersion,
           program.template,
-          useYarn,
+          packageManager,
           program.usePnp
         );
       }
     });
 }
 
-function createApp(name, verbose, version, template, useYarn, usePnp) {
+function createApp(name, verbose, version, template, packageManager, usePnp) {
   const unsupportedNodeVersion = !semver.satisfies(
     // Coerce strings with metadata (i.e. `15.0.0-nightly`).
     semver.coerce(process.version),
@@ -275,11 +285,11 @@ function createApp(name, verbose, version, template, useYarn, usePnp) {
 
   const originalDirectory = process.cwd();
   process.chdir(root);
-  if (!useYarn && !checkThatNpmCanReadCwd()) {
+  if (packageManager === 'npm' && !checkThatNpmCanReadCwd()) {
     process.exit(1);
   }
 
-  if (!useYarn) {
+  if (packageManager === 'npm') {
     const npmInfo = checkNpmVersion();
     if (!npmInfo.hasMinNpm) {
       if (npmInfo.npmVersion) {
@@ -293,7 +303,7 @@ function createApp(name, verbose, version, template, useYarn, usePnp) {
       // Fall back to latest supported react-scripts for npm 3
       version = 'react-scripts@0.9.x';
     }
-  } else if (usePnp) {
+  } else if (packageManager.startsWith('yarn') && usePnp) {
     const yarnInfo = checkYarnVersion();
     if (yarnInfo.yarnVersion) {
       if (!yarnInfo.hasMinYarnPnp) {
@@ -304,7 +314,7 @@ function createApp(name, verbose, version, template, useYarn, usePnp) {
           )
         );
         // 1.11 had an issue with webpack-dev-middleware, so better not use PnP with it (never reached stable, but still)
-        usePnp = false;
+        packageManager = 'yarn';
       }
       if (!yarnInfo.hasMaxYarnPnp) {
         console.log(
@@ -313,7 +323,7 @@ function createApp(name, verbose, version, template, useYarn, usePnp) {
           )
         );
         // 2 supports PnP by default and breaks when trying to use the flag
-        usePnp = false;
+        packageManager = 'yarn';
       }
     }
   }
@@ -325,16 +335,23 @@ function createApp(name, verbose, version, template, useYarn, usePnp) {
     verbose,
     originalDirectory,
     template,
-    useYarn,
+    packageManager,
     usePnp
   );
 }
 
-function install(root, useYarn, usePnp, dependencies, verbose, isOnline) {
+function install(
+  root,
+  packageManager,
+  usePnp,
+  dependencies,
+  verbose,
+  isOnline
+) {
   return new Promise((resolve, reject) => {
     let command;
     let args;
-    if (useYarn) {
+    if (packageManager.startsWith('yarn')) {
       command = 'yarnpkg';
       args = ['add', '--exact'];
       if (!isOnline) {
@@ -356,6 +373,15 @@ function install(root, useYarn, usePnp, dependencies, verbose, isOnline) {
       if (!isOnline) {
         console.log(chalk.yellow('You appear to be offline.'));
         console.log(chalk.yellow('Falling back to the local Yarn cache.'));
+        console.log();
+      }
+    } else if (packageManager === 'bun') {
+      command = 'bun';
+      args = ['add', '--exact'].concat(dependencies);
+
+      if (usePnp) {
+        console.log(chalk.yellow("Bun doesn't support PnP."));
+        console.log(chalk.yellow('Falling back to the regular installs.'));
         console.log();
       }
     } else {
@@ -400,7 +426,7 @@ function run(
   verbose,
   originalDirectory,
   template,
-  useYarn,
+  packageManager,
   usePnp
 ) {
   Promise.all([
@@ -416,7 +442,7 @@ function run(
       getPackageInfo(templateToInstall),
     ])
       .then(([packageInfo, templateInfo]) =>
-        checkIfOnline(useYarn).then(isOnline => ({
+        checkIfOnline(packageManager).then(isOnline => ({
           isOnline,
           packageInfo,
           templateInfo,
@@ -460,7 +486,7 @@ function run(
 
         return install(
           root,
-          useYarn,
+          packageManager,
           usePnp,
           allDependencies,
           verbose,
@@ -488,7 +514,7 @@ function run(
           },
           [root, appName, verbose, originalDirectory, templateName],
           `
-        const init = require('${packageName}/scripts/init.js');
+        const init = require('../../react-scripts/scripts/init.js');
         init.apply(null, JSON.parse(process.argv[1]));
       `
         );
@@ -1051,8 +1077,8 @@ function checkThatNpmCanReadCwd() {
   return false;
 }
 
-function checkIfOnline(useYarn) {
-  if (!useYarn) {
+function checkIfOnline(packageManager) {
+  if (!packageManager.startsWith('yarn')) {
     // Don't ping the Yarn registry.
     // We'll just assume the best case.
     return Promise.resolve(true);


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Adds instructions for `bun` and `bunx` (Bun's `npx` equivalent). Bun can be used as a [runtime-agnostic package manager](https://bun.sh/package-manager). 

This PR also adds support for identifying when `bunx` is used to run `create-react-app` and uses it for dependency management if so. Here is a successful run showing `bun` being used to install the dependencies for both the `create-react-app` CLI and the template itself.

```sh
npm_config_user_agent=bun/1.0 bun run index.js myapp

Creating a new React app in /Users/colinmcd94/Documents/bun/fun/repos/create-react-app/packages/create-react-app/myapp.

Installing packages. This might take a couple of minutes.
Installing react, react-dom, and react-scripts with cra-template...

bun add v0.7.3 (a9b3d583)

 installed react@18.2.0
 installed react-dom@18.2.0
 installed react-scripts@5.0.1 with binaries:
  - react-scripts
 installed cra-template@1.2.0


 1179 packages installed [2.67s]
{ packageName: 'react-scripts', templateName: 'cra-template' }
[
  '/Users/colinmcd94/Documents/bun/fun/repos/create-react-app/packages/create-react-app/myapp',
  'myapp',
  undefined,
  '/Users/colinmcd94/Documents/bun/fun/repos/create-react-app/packages/create-react-app',
  'cra-template'
]
[]

Installing template dependencies using bun...
bun add v0.7.3 (a9b3d583)

 installed @testing-library/jest-dom@5.17.0
 installed @testing-library/react@13.4.0
 installed @testing-library/user-event@13.5.0
 installed web-vitals@2.1.4


 57 packages installed [476.00ms]
Removing template package using bun...

bun remove v0.7.3 (a9b3d583)
 - cra-template

 1 packages removed [36.00ms]

Success! Created myapp at /Users/colinmcd94/Documents/bun/fun/repos/create-react-app/packages/create-react-app/myapp
Inside that directory, you can run several commands:

  bun start
    Starts the development server.

  bun run build
    Bundles the app into static files for production.

  bun test
    Starts the test runner.

  bun run eject
    Removes this tool and copies build dependencies, configuration files
    and scripts into the app directory. If you do this, you can’t go back!

We suggest that you begin by typing:

  cd myapp
  bun start

Happy hacking!
```