### PR TITLE
Exit process on `devServer.startCallback` error. (Invalid `setupProxy.js` )

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -122,7 +122,16 @@ checkBrowsers(paths.appPath, isInteractive)
     };
     const devServer = new WebpackDevServer(serverConfig, compiler);
     // Launch WebpackDevServer.
-    devServer.startCallback(() => {
+    devServer.startCallback((err) => {
+      if(err) {
+        console.log(
+          chalk.red(
+            `Dev server failed to start.`
+          )
+          );
+          err.message && console.log(err.message);
+        process.exit();
+      }
       if (isInteractive) {
         clearConsole();
       }


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Fixes https://github.com/facebook/create-react-app/issues/13311

Our project was facing this issue for a long time due to some developer broke `setupProxy.js`. 
So it was easier to recreate the above mentioned scenario. 

So added a error catch to the code and tested with the above broken project. 

So now `react-scripts-start` will exit when `devServer.startCallback` returns an error. 

<img width="1016" alt="Screenshot 2023-08-27 at 12 50 22 PM" src="https://github.com/facebook/create-react-app/assets/11921692/414f5d34-c74a-4a8e-8f98-4552cc954552">

