### PR TITLE
Fixing incorrect docs link for Service Worker in making a PWA docs.

### DIFF
--- a/docusaurus/docs/making-a-progressive-web-app.md
+++ b/docusaurus/docs/making-a-progressive-web-app.md
@@ -45,7 +45,7 @@ file:
 ```js
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
-// Learn more about service workers: https://cra.link/PWA
+// Learn more about service workers: https://web.dev/learn/pwa/service-workers
 serviceWorkerRegistration.unregister();
 ```
 


### PR DESCRIPTION
Updated the documentation redirect of `Service Workers` in `/making-a-progressive-web-app.md` from `https://cra.link/PWA` to `https://web.dev/learn/pwa/service-workers`.