### PR TITLE
Pass WDS_SOCKET options to webpack webSocketServer

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -131,5 +131,13 @@ module.exports = function (proxy, allowedHost) {
       // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
       devServer.app.use(noopServiceWorkerMiddleware(paths.publicUrlOrPath));
     },
+    webSocketServer: {
+      type: "ws",
+      options: {
+        path: sockPath,
+        port: sockPort,
+        host: sockHost,
+      },
+    },
   };
 };


### PR DESCRIPTION
I've had trouble getting the `WDS_SOCKET_PATH` option to work with the react-scripts dev server - while the client was correctly attempting to connect to the path I specified, the backend was still just listening on `/ws` no matter what. Seems to be the same problem as #12092.

I've tracked it down to the configuration being provided to the webpack dev server. The websocket connection options were being provided only in the `client.webSocketURL` key, which tells the client where to connect but doesn't actually adjust where the dev server will be listening - that is specified in `webSocketServer.options` instead.

Making this change to `webpackDevServer.config.js` in my `node_modules` fixed the problem - after restarting the react dev server, the websocket was now listening at the correct path.