### PR TITLE
Update proxy setup example for v3.0.0 in documentation

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -101,7 +101,7 @@ module.exports = function (app) {
   app.use(
     '/api',
     createProxyMiddleware({
-      target: 'http://localhost:5000',
+      target: 'http://localhost:5000/api',
       changeOrigin: true,
     })
   );
@@ -113,3 +113,5 @@ module.exports = function (app) {
 > **Note:** This file only supports Node's JavaScript syntax. Be sure to only use supported language features (i.e. no support for Flow, ES Modules, etc).
 
 > **Note:** Passing the path to the proxy function allows you to use globbing and/or pattern matching on the path, which is more flexible than the express route matching.
+
+> **Note** When proxy is mounted on a path, this path should be provided in the target.


### PR DESCRIPTION
followed by new [Version 3.0.0 breaking changes](https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION.md#v3-breaking-changes) change sample code and description
### Summary
This PR updates the proxy setup example in the Create React App documentation to align with the breaking changes introduced in `http-proxy-middleware` version 3.0.0. Specifically, it addresses the requirement that the proxy target path must explicitly include the path it is mounted on.

### Background
As of `http-proxy-middleware` v3.0.0, the library has removed the `req.url` patching feature. This change requires that when a proxy is mounted on a specific path, this path must be explicitly included in the target URL. This update ensures that developers who follow the CRA documentation will implement proxying correctly according to the latest version of `http-proxy-middleware`.

### Changes
- Updated the proxy setup example to include the mounted path in the `target` property.
- Added a note to emphasize the new requirement of including the mounted path in the `target` property for `http-proxy-middleware` v3.0.0 and above.

### Updated Example
```js
const { createProxyMiddleware } = require('http-proxy-middleware');

module.exports = function (app) {
  app.use(
    '/api',
    createProxyMiddleware({
      // Updated to include the path in the target URL
      target: 'http://localhost:5000/api',
      changeOrigin: true,
    })
  );
};
```

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
