### PR TITLE
Fixed dead links on the React Router page

### DIFF
--- a/docusaurus/docs/adding-a-router.md
+++ b/docusaurus/docs/adding-a-router.md
@@ -17,6 +17,6 @@ Alternatively you may use `yarn`:
 yarn add react-router-dom
 ```
 
-To try it, delete all the code in `src/App.js` and replace it with any of the examples on its website. The [Basic Example](https://reactrouter.com/docs/examples/basic) is a good place to get started. For more info on adding routes, check out [the React Router docs on adding routes](https://reactrouter.com/docs/getting-started/tutorial#add-some-routes).
+To try it, delete all the code in `src/App.js` and replace it with any of the examples on its website. The [Basic Example](https://github.com/remix-run/react-router/blob/dev/examples/basic/README.md) is a good place to get started. For more info on adding routes, check out [the React Router docs on adding routes](https://reactrouter.com/en/start/tutorial).
 
 Note that [you may need to configure your production server to support client-side routing](deployment.md#serving-apps-with-client-side-routing) before deploying your app.


### PR DESCRIPTION
Updated the old, dead links for the react router basic example and tutorial with the current ones

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
