### PR TITLE
Fixed the image not being loaded in "Get started" part

### DIFF
--- a/docusaurus/website/src/pages/index.js
+++ b/docusaurus/website/src/pages/index.js
@@ -99,7 +99,7 @@ function Home() {
                 className={styles.featureImage}
                 alt="Easy to get started in seconds"
                 src={
-                  'https://camo.githubusercontent.com/29765c4a32f03bd01d44edef1cd674225e3c906b/68747470733a2f2f63646e2e7261776769742e636f6d2f66616365626f6f6b2f6372656174652d72656163742d6170702f323762343261632f73637265656e636173742e737667'
+                  'https://cdn.jsdelivr.net/gh/facebook/create-react-app@27b42ac7efa018f2541153ab30d63180f5fa39e0/screencast.svg'
                 }
               />
             </div>


### PR DESCRIPTION
In the "https://create-react-app.dev/" page, The image on the "Get Started in Seconds" is not loaded . 
It is maybe due to not finding the source. So i took the image, from react's main website documentation part and used it here. 

Have a look at the current problem by opening the first link on this message and merge if you want.
I have also attached a screenshot of the problem
![Screenshot 2024-05-01 at 9 02 20 AM](https://github.com/facebook/create-react-app/assets/144698632/81fdee18-ab99-4d02-8d96-f91b7ae2e4ea)
