### PR TITLE
Fixed the dead link to the image

### DIFF
--- a/docusaurus/website/src/pages/index.js
+++ b/docusaurus/website/src/pages/index.js
@@ -99,7 +99,7 @@ function Home() {
                 className={styles.featureImage}
                 alt="Easy to get started in seconds"
                 src={
-                  'https://camo.githubusercontent.com/29765c4a32f03bd01d44edef1cd674225e3c906b/68747470733a2f2f63646e2e7261776769742e636f6d2f66616365626f6f6b2f6372656174652d72656163742d6170702f323762343261632f73637265656e636173742e737667'
+                  'https://cdn.jsdelivr.net/gh/facebook/create-react-app@27b42ac7efa018f2541153ab30d63180f5fa39e0/screencast.svg'
                 }
               />
             </div>


### PR DESCRIPTION
In the "https://create-react-app.dev/" page, The image on the "Get Started in Seconds" is not loaded .
It is maybe due to dead link. So i updated the source to that image
Have a look at the current problem by opening the first link on this message and merge if you want.
I have also attached a screenshot of the problem
![Uploading Screenshot 2024-05-01 at 9.02.20 AM.png…]()
