### PR TITLE
[template] Bump `@testing-library/react` to 15.0.6

### DIFF
--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -2,7 +2,7 @@
   "package": {
     "dependencies": {
       "@testing-library/jest-dom": "^5.14.1",
-      "@testing-library/react": "^13.0.0",
+      "@testing-library/react": "^15.0.6",
       "@testing-library/user-event": "^13.2.1",
       "@types/jest": "^27.0.1",
       "@types/node": "^16.7.13",

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -2,7 +2,7 @@
   "package": {
     "dependencies": {
       "@testing-library/jest-dom": "^5.14.1",
-      "@testing-library/react": "^13.0.0",
+      "@testing-library/react": "^15.0.6",
       "@testing-library/user-event": "^13.2.1",
       "web-vitals": "^2.1.0"
     },


### PR DESCRIPTION
This version does not produce deprecation warnings in React 18.3