### PR TITLE
Proxy when there is no "accept"

### DIFF
--- a/packages/react-dev-utils/WebpackDevServerUtils.js
+++ b/packages/react-dev-utils/WebpackDevServerUtils.js
@@ -367,8 +367,11 @@ function prepareProxy(proxy, appPublicFolder, servedPathname) {
         return (
           req.method !== 'GET' ||
           (mayProxy(pathname) &&
-            req.headers.accept &&
-            req.headers.accept.indexOf('text/html') === -1)
+            (!req.headers.accept ||
+              (req.headers.accept &&
+               req.headers.accept.indexOf('text/html') === -1)
+            )
+          )
         );
       },
       onProxyReq: proxyReq => {


### PR DESCRIPTION
It seems chrome at the moment does not send request with "Accept" header when doing websocket GET request.

User-Agent: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36` 

<img width="1083" alt="image" src="https://github.com/facebook/create-react-app/assets/4948057/8c426850-99cb-4527-9133-dcc030562036">
