### PR TITLE
Updates old link in App.tsx to correct link to React.dev

### DIFF
--- a/packages/cra-template-typescript/template/src/App.tsx
+++ b/packages/cra-template-typescript/template/src/App.tsx
@@ -12,7 +12,7 @@ function App() {
         </p>
         <a
           className="App-link"
-          href="https://reactjs.org"
+          href="https://react.dev/learn"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
When we create a TypeScript template-based project, the code in App.tsx still points to a legacy React website. This PR corrects the links to which it should be redirected after page generation.