### PR TITLE
Fix: Move dependencies to devDependencies in cra-template and cra-typescript-template

### DIFF
--- a/packages/cra-template-typescript/template.json
+++ b/packages/cra-template-typescript/template.json
@@ -1,6 +1,9 @@
 {
   "package": {
     "dependencies": {
+      "web-vitals": "^2.1.0"
+    },
+    "devDependencies": {
       "@testing-library/jest-dom": "^5.14.1",
       "@testing-library/react": "^13.0.0",
       "@testing-library/user-event": "^13.2.1",
@@ -8,8 +11,7 @@
       "@types/node": "^16.7.13",
       "@types/react": "^18.0.0",
       "@types/react-dom": "^18.0.0",
-      "typescript": "^4.4.2",
-      "web-vitals": "^2.1.0"
+      "typescript": "^4.4.2"
     },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]

--- a/packages/cra-template/template.json
+++ b/packages/cra-template/template.json
@@ -1,10 +1,12 @@
 {
   "package": {
     "dependencies": {
+      "web-vitals": "^2.1.0"
+    },
+    "devDependencies": {
       "@testing-library/jest-dom": "^5.14.1",
       "@testing-library/react": "^13.0.0",
-      "@testing-library/user-event": "^13.2.1",
-      "web-vitals": "^2.1.0"
+      "@testing-library/user-event": "^13.2.1"
     },
     "eslintConfig": {
       "extends": ["react-app", "react-app/jest"]


### PR DESCRIPTION
There was an issue in the cra-template and cra-typescript-template packages where some packages that did not need to be specified as dependencies were listed under dependencies in template.json. 
I have moved these packages to devDependencies.