### PR TITLE
Updated invalid React Bootstrap URL in CRA docs website

### DIFF
--- a/docusaurus/docs/adding-bootstrap.md
+++ b/docusaurus/docs/adding-bootstrap.md
@@ -3,7 +3,7 @@ id: adding-bootstrap
 title: Adding Bootstrap
 ---
 
-While you don’t have to use any specific library to integrate Bootstrap with React apps, it's often easier than trying to wrap the Bootstrap jQuery plugins. [React Bootstrap](https://react-bootstrap.netlify.com/) is the most popular option that strives for complete parity with Bootstrap. [reactstrap](https://reactstrap.github.io/) is also a good choice for projects looking for smaller builds at the expense of some features.
+While you don’t have to use any specific library to integrate Bootstrap with React apps, it's often easier than trying to wrap the Bootstrap jQuery plugins. [React Bootstrap](https://react-bootstrap.netlify.app/) is the most popular option that strives for complete parity with Bootstrap. [reactstrap](https://reactstrap.github.io/) is also a good choice for projects looking for smaller builds at the expense of some features.
 
 Each project's respective documentation site has detailed instructions for installing and using them. Both depend on the Bootstrap css file so install that as well:
 


### PR DESCRIPTION
**Fix:** Updated invalid React Bootstrap URL

The previous URL for React Bootstrap was outdated/invalid. I have updated it to the correct URL in the relevant documentation.

**Code File Changes:**
`docusaurus/docs/adding-bootstrap.md`

**Outdated or Invalid URL Screenshot:**
![image](https://github.com/user-attachments/assets/7d79a0e9-8801-477d-b2f8-5d8c2cb218d8)


**Correct URL Screenshot:**
![image](https://github.com/user-attachments/assets/fd1b360a-a983-42da-9d94-0307d77d7730)

