### PR TITLE
Deprecate Create React App officially by changing the README, and adding a message on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# Create React App is Deprecated
-
-Create React App was one of the key tools for getting a React project up-and-running in 2017-2021, it is now in long-term stasis and we recommend that you migrate to one of React frameworks documented on ["Start a New React Project"](https://react.dev/learn/start-a-new-react-project).
-
-If you are following a tutorial to learn React, there is still value in continuing your tutorial, but we do not recommend starting production apps based on Create React App.
-
----
-
 ## Create React App [![Build & Test](https://github.com/facebook/create-react-app/actions/workflows/build-and-test.yml/badge.svg?branch=main)](https://github.com/facebook/create-react-app/actions/workflows/build-and-test.yml) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/facebook/create-react-app/blob/main/CONTRIBUTING.md)
+
+> [!CAUTION]
+> ## Deprecated
+> Create React App was one of the key tools for getting a React project up-and-running in 2017-2021, it is now in long-term stasis and we recommend that you migrate to one of React frameworks documented on [Start a New React Project](https://react.dev/learn/start-a-new-react-project).
+> 
+> If you are following a tutorial to learn React, there is still value in continuing your tutorial, but we do not recommend starting production apps based on Create React App.
 
 <img alt="Logo" align="right" src="https://create-react-app.dev/img/logo.svg" width="20%" />
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# Create React App [![Build & Test](https://github.com/facebook/create-react-app/actions/workflows/build-and-test.yml/badge.svg?branch=main)](https://github.com/facebook/create-react-app/actions/workflows/build-and-test.yml) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/facebook/create-react-app/blob/main/CONTRIBUTING.md)
+# Create React App is Deprecated
+
+Create React App was one of the key tools for getting a React project up-and-running in 2017-2021, it is now in long-term stasis and we recommend that you migrate to one of React frameworks documented on ["Start a New React Project"](https://react.dev/learn/start-a-new-react-project).
+
+If you are following a tutorial to learn React, there is still value in continuing your tutorial, but we do not recommend starting production apps based on Create React App.
+
+---
+
+## Create React App [![Build & Test](https://github.com/facebook/create-react-app/actions/workflows/build-and-test.yml/badge.svg?branch=main)](https://github.com/facebook/create-react-app/actions/workflows/build-and-test.yml) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/facebook/create-react-app/blob/main/CONTRIBUTING.md)
 
 <img alt="Logo" align="right" src="https://create-react-app.dev/img/logo.svg" width="20%" />
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 ## Create React App [![Build & Test](https://github.com/facebook/create-react-app/actions/workflows/build-and-test.yml/badge.svg?branch=main)](https://github.com/facebook/create-react-app/actions/workflows/build-and-test.yml) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/facebook/create-react-app/blob/main/CONTRIBUTING.md)
 
 > [!CAUTION]
+>
 > ## Deprecated
+>
 > Create React App was one of the key tools for getting a React project up-and-running in 2017-2021, it is now in long-term stasis and we recommend that you migrate to one of React frameworks documented on [Start a New React Project](https://react.dev/learn/start-a-new-react-project).
-> 
+>
 > If you are following a tutorial to learn React, there is still value in continuing your tutorial, but we do not recommend starting production apps based on Create React App.
 
 <img alt="Logo" align="right" src="https://create-react-app.dev/img/logo.svg" width="20%" />

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -54,21 +54,19 @@ function isUsingYarn() {
 }
 
 function hasGivenWarning() {
-  const ourPackageInNodeModules = path.join('node_modules', packageJson.name);
-  const warningFilePath = path.join(
-    ourPackageInNodeModules,
+  const localWarningFilePath = path.join(
+    __dirname,
     'given-deprecation-warning'
   );
-  return fs.existsSync(warningFilePath);
+  return fs.existsSync(localWarningFilePath);
 }
 
 function writeWarningFile() {
-  const ourPackageInNodeModules = path.join('node_modules', packageJson.name);
-  const warningFilePath = path.join(
-    ourPackageInNodeModules,
+  const localWarningFilePath = path.join(
+    __dirname,
     'given-deprecation-warning'
   );
-  fs.writeFileSync(warningFilePath, 'true');
+  fs.writeFileSync(localWarningFilePath, 'true');
 }
 
 let projectName;

--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -53,9 +53,43 @@ function isUsingYarn() {
   return (process.env.npm_config_user_agent || '').indexOf('yarn') === 0;
 }
 
+function hasGivenWarning() {
+  const ourPackageInNodeModules = path.join('node_modules', packageJson.name);
+  const warningFilePath = path.join(
+    ourPackageInNodeModules,
+    'given-deprecation-warning'
+  );
+  return fs.existsSync(warningFilePath);
+}
+
+function writeWarningFile() {
+  const ourPackageInNodeModules = path.join('node_modules', packageJson.name);
+  const warningFilePath = path.join(
+    ourPackageInNodeModules,
+    'given-deprecation-warning'
+  );
+  fs.writeFileSync(warningFilePath, 'true');
+}
+
 let projectName;
 
 function init() {
+  if (!hasGivenWarning()) {
+    console.log(chalk.yellow.bold('create-react-app is deprecated.'));
+    console.log('');
+    console.log(
+      'You can find a list of up-to-date React frameworks on react.dev'
+    );
+    console.log(
+      chalk.underline('https://react.dev/learn/start-a-new-react-project')
+    );
+    console.log('');
+    console.log(
+      chalk.grey('This error message will only be shown once per install.')
+    );
+    writeWarningFile();
+  }
+
   const program = new commander.Command(packageJson.name)
     .version(packageJson.version)
     .arguments('<project-directory>')

--- a/packages/create-react-app/package.json
+++ b/packages/create-react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-app",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "keywords": [
     "react"
   ],


### PR DESCRIPTION
It's probably time to make this project document its status as being deprecated and not recommended for production usage.

To change it:

 - I opted to add a header to the README saying its over and you should go look at https://react.dev/learn/start-a-new-react-project

 - I left a note saying that if you are following, it is maybe worth carrying on. While I hear react 19 doesn't work with CRA, I wouldn't be surprised that a good chunk of tutorials would still work. Open to being a bit more hard-lined there but there was a lot of great resources for learning react in that era and it seems like a waste to be making people stop early?

 - I added a message inside the CLI, it shows once and says "don't use this, use the stuff in https://react.dev/learn/start-a-new-react-project"
 