### PR TITLE
Shimondoodkin error filename

### DIFF
--- a/packages/react-dev-utils/formatWebpackMessages.js
+++ b/packages/react-dev-utils/formatWebpackMessages.js
@@ -13,18 +13,33 @@ function isLikelyASyntaxError(message) {
   return message.indexOf(friendlySyntaxErrorLabel) !== -1;
 }
 
+function cleanTerminalColors(input) {
+  // Regular expression to match ANSI escape codes
+  const ansiRegex = /\x1B\[[0-9;]*[a-zA-Z]/g;
+  // Remove ANSI escape codes from the input string
+  return input.replace(ansiRegex, '');
+}
+
 // Cleans up webpack error messages.
 function formatMessage(message) {
   let lines = [];
 
   if (typeof message === 'string') {
-    lines = message.split('\n');
+    lines = cleanTerminalColors(message).split('\n');
   } else if ('message' in message) {
-    lines = message['message'].split('\n');
+    lines = cleanTerminalColors(message['message']).split('\n');
+    // ensure message contains filename
+    if ('file' in message && !message['message'].includes(message.file)) {
+      lines.unshift("While building top file: " + message.file);
+    }  
   } else if (Array.isArray(message)) {
     message.forEach(message => {
       if ('message' in message) {
-        lines = message['message'].split('\n');
+        lines = cleanTerminalColors(message['message']).split('\n');
+        // ensure message contains filename
+        if ('file' in message && !message['message'].includes(message.file)) {
+          lines.unshift("While building top file: " + message.file);
+        }  
       }
     });
   }

--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -173,8 +173,12 @@ function build(previousFileSizes) {
       if (messages.errors.length) {
         // Only keep the first error. Others are often indicative
         // of the same problem, but confuse the reader with noise.
-        if (messages.errors.length > 1) {
-          messages.errors.length = 1;
+        const re = /\S+:\d+:\d+/;  // check if error message has filename with line number, to not print errors with no filename or line number
+        for(let i = 0; i < messages.errors.length; i++) {
+          if(re.test(messages.errors[i])) {
+            messages.errors.length = i+1; 
+            break;
+          }
         }
         return reject(new Error(messages.errors.join('\n\n')));
       }


### PR DESCRIPTION

it was not printing filenames for typescript errors,
in build.js turns out it was intentional truncation to 1 error, but accidently the first message was without filename.

I ensured there is at last a filename before truncating the errors to single error.

Result:

![image](https://github.com/user-attachments/assets/2d8c035c-8b5b-40da-b265-3c100007e0e6)
