### PR TITLE
Update deprecation link

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -79,7 +79,7 @@ function init() {
       'You can find a list of up-to-date React frameworks on react.dev'
     );
     console.log(
-      chalk.underline('https://react.dev/learn/start-a-new-react-project')
+      'For more info see:' + chalk.underline('https://react.dev/link/cra')
     );
     console.log('');
     console.log(


### PR DESCRIPTION
Updates to a shortlink that we can redirect as needed for old versions. Currently 404