### PR TITLE
add "origin" to confusing-browser-globals

### DIFF
--- a/packages/confusing-browser-globals/index.js
+++ b/packages/confusing-browser-globals/index.js
@@ -40,6 +40,7 @@ module.exports = [
   'open',
   'opener',
   'opera',
+  'origin',
   'outerHeight',
   'outerWidth',
   'pageXOffset',


### PR DESCRIPTION
The short one-worded "origin" is likely to be used as variable. The page origin should be accessed via "window.origin" for clarity.
