### PR TITLE
docs(proxy): clarify setupProxy.js usage to fix 404 error in CRA v5

### DIFF
--- a/docusaurus/docs/proxying-api-requests-in-development.md
+++ b/docusaurus/docs/proxying-api-requests-in-development.md
@@ -99,10 +99,10 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 
 module.exports = function (app) {
   app.use(
-    '/api',
     createProxyMiddleware({
       target: 'http://localhost:5000',
       changeOrigin: true,
+      pathFilter: '/api/',
     })
   );
 };


### PR DESCRIPTION
**What**
Fixed a proxy issue in setupProxy.js where API requests were not forwarded to the target server (localhost:5000), resulting in a 404 error.

**Changes**
Replaced the app.use('/api', ...) pattern with pathFilter: '/api' in the proxy middleware configuration

**Test**
Confirmed that /api/... requests are correctly proxied to localhost:5000 using the following environment:
- react-scripts@5.0.1
- http-proxy-middleware@3.0.5

**Reference**
[http-proxy-middleware official docs – Basic Usage](https://www.npmjs.com/package/http-proxy-middleware?activeTab=readme#basic-usage)