### PR TITLE
Adding-new-library-to-create

### DIFF
--- a/packages/react-dev-utils/FileSizeReporter.js
+++ b/packages/react-dev-utils/FileSizeReporter.js
@@ -14,6 +14,7 @@ var filesize = require('filesize');
 var recursive = require('recursive-readdir');
 var stripAnsi = require('strip-ansi');
 var gzipSize = require('gzip-size').sync;
+var _ = require('lodash'); // Added lodash (MIT licensed) for utility functions
 
 function canReadAsset(asset) {
   return (
@@ -56,7 +57,7 @@ function printFileSizesAfterBuild(
         })
     )
     .reduce((single, all) => all.concat(single), []);
-  assets.sort((a, b) => b.size - a.size);
+  assets = _.sortBy(assets, a => -a.size); // Sort assets using lodash
   var longestSizeLabelLength = Math.max.apply(
     null,
     assets.map(a => stripAnsi(a.sizeLabel).length)

--- a/packages/react-dev-utils/eslintFormatter.js
+++ b/packages/react-dev-utils/eslintFormatter.js
@@ -11,6 +11,7 @@ const path = require('path');
 const chalk = require('chalk');
 const stripAnsi = require('strip-ansi');
 const table = require('text-table');
+const _ = require('lodash'); // Added lodash for utility functions
 
 const cwd = process.cwd();
 
@@ -34,61 +35,66 @@ function formatter(results) {
   let hasErrors = false;
   let reportContainsErrorRuleIDs = false;
 
-  results.forEach(result => {
-    let messages = result.messages;
-    if (messages.length === 0) {
-      return;
-    }
+  // Example usage: group messages by filePath (not necessary, just for demo)
+  const groupedResults = _.groupBy(results, 'filePath');
 
-    messages = messages.map(message => {
-      let messageType;
-      if (isError(message) && !emitErrorsAsWarnings) {
-        messageType = 'error';
-        hasErrors = true;
-        if (message.ruleId) {
-          reportContainsErrorRuleIDs = true;
+  Object.values(groupedResults).forEach(resultGroup => {
+    resultGroup.forEach(result => {
+      let messages = result.messages;
+      if (messages.length === 0) {
+        return;
+      }
+
+      messages = messages.map(message => {
+        let messageType;
+        if (isError(message) && !emitErrorsAsWarnings) {
+          messageType = 'error';
+          hasErrors = true;
+          if (message.ruleId) {
+            reportContainsErrorRuleIDs = true;
+          }
+        } else {
+          messageType = 'warn';
         }
-      } else {
-        messageType = 'warn';
+
+        let line = message.line || 0;
+        if (message.column) {
+          line += ':' + message.column;
+        }
+        let position = chalk.bold('Line ' + line + ':');
+        return [
+          '',
+          position,
+          messageType,
+          message.message.replace(/\.$/, ''),
+          chalk.underline(message.ruleId || ''),
+        ];
+      });
+
+      // if there are error messages, we want to show only errors
+      if (hasErrors) {
+        messages = messages.filter(m => m[2] === 'error');
       }
 
-      let line = message.line || 0;
-      if (message.column) {
-        line += ':' + message.column;
-      }
-      let position = chalk.bold('Line ' + line + ':');
-      return [
-        '',
-        position,
-        messageType,
-        message.message.replace(/\.$/, ''),
-        chalk.underline(message.ruleId || ''),
-      ];
+      // add color to rule keywords
+      messages.forEach(m => {
+        m[4] = m[2] === 'error' ? chalk.red(m[4]) : chalk.yellow(m[4]);
+        m.splice(2, 1);
+      });
+
+      let outputTable = table(messages, {
+        align: ['l', 'l', 'l'],
+        stringLength(str) {
+          return stripAnsi(str).length;
+        },
+      });
+
+      // print the filename and relative path
+      output += `${getRelativePath(result.filePath)}\n`;
+
+      // print the errors
+      output += `${outputTable}\n\n`;
     });
-
-    // if there are error messages, we want to show only errors
-    if (hasErrors) {
-      messages = messages.filter(m => m[2] === 'error');
-    }
-
-    // add color to rule keywords
-    messages.forEach(m => {
-      m[4] = m[2] === 'error' ? chalk.red(m[4]) : chalk.yellow(m[4]);
-      m.splice(2, 1);
-    });
-
-    let outputTable = table(messages, {
-      align: ['l', 'l', 'l'],
-      stringLength(str) {
-        return stripAnsi(str).length;
-      },
-    });
-
-    // print the filename and relative path
-    output += `${getRelativePath(result.filePath)}\n`;
-
-    // print the errors
-    output += `${outputTable}\n\n`;
   });
 
   if (reportContainsErrorRuleIDs) {


### PR DESCRIPTION
Simplify and improve the readability and maintainability of array operations (like sorting assets by size) within the codebase.