### PR TITLE
fix: check Node.js version early (#5430)

### DIFF
--- a/packages/create-react-app/createReactApp.js
+++ b/packages/create-react-app/createReactApp.js
@@ -26,8 +26,26 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //   /!\ DO NOT MODIFY THIS FILE /!\
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const requiredNodeVersion = [18, 0, 0]; // Minimum: v18.0.0
 
-'use strict';
+const currentVersion = process.versions.node.split('.').map(Number);
+
+const isVersionCompatible =
+  currentVersion[0] > requiredNodeVersion[0] ||
+  (currentVersion[0] === requiredNodeVersion[0] &&
+    currentVersion[1] >= requiredNodeVersion[1]);
+
+if (!isVersionCompatible) {
+  console.error(
+    `\n❌ ERROR: Unsupported Node.js version ${process.version}.\n` +
+      `   Please upgrade to Node.js v${requiredNodeVersion.join(
+        '.'
+      )} or higher to use Create React App.\n`
+  );
+  process.exit(1);
+}
+
+('use strict');
 
 const https = require('https');
 const chalk = require('chalk');


### PR DESCRIPTION
This PR adds an early check to ensure that users are running a compatible version of Node.js when using create-react-app. If the Node version is below the required minimum, a clear error message is shown and the process exits.
