### PR TITLE
postinstall command put in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,60 +1,48 @@
 {
-  "private": true,
-  "workspaces": [
-    "packages/*",
-    "docusaurus/website"
+  "name": "create-react-app",
+  "version": "5.1.0",
+  "keywords": [
+    "react"
   ],
+  "description": "Create React apps with no build configuration.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/create-react-app.git",
+    "directory": "packages/create-react-app"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
+  "bugs": {
+    "url": "https://github.com/facebook/create-react-app/issues"
+  },
+  "files": [
+    "index.js",
+    "createReactApp.js"
+  ],
+  "bin": {
+    "create-react-app": "./index.js"
+  },
   "scripts": {
-    "build": "cd packages/react-scripts && node bin/react-scripts.js build",
-    "changelog": "lerna-changelog",
-    "create-react-app": "node tasks/cra.js",
-    "e2e": "tasks/e2e-simple.sh",
-    "e2e:docker": "tasks/local-test.sh",
-    "postinstall": "npm run build:prod -w react-error-overlay",
-    "publish": "tasks/publish.sh",
-    "start": "cd packages/react-scripts && node bin/react-scripts.js start",
-    "screencast": "node ./tasks/screencast.js",
-    "screencast:error": "svg-term --cast jyu19xGl88FQ3poMY8Hbmfw8y --out screencast-error.svg --window --at 12000 --no-cursor",
-    "alex": "alex .",
-    "test:integration": "jest test/integration",
-    "test": "cd packages/react-scripts && node bin/react-scripts.js test",
-    "eslint": "eslint .",
-    "prettier": "prettier .",
-    "format": "npm run prettier -- --write"
+   "postinstall": "sh scripts/preaudit.sh",  
+   "test": "cross-env FORCE_COLOR=true jest"
+  },
+  "dependencies": {
+    "chalk": "^4.1.2",
+    "commander": "^4.1.1",
+    "cross-spawn": "^7.0.3",
+    "envinfo": "^7.8.1",
+    "fs-extra": "^10.0.0",
+    "hyperquest": "^2.1.3",
+    "prompts": "^2.4.2",
+    "semver": "^7.3.5",
+    "tar-pack": "^3.4.1",
+    "tmp": "^0.2.1",
+    "validate-npm-package-name": "^3.0.0"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.15.1",
-    "@testing-library/react": "^12.1.2",
-    "@testing-library/user-event": "^13.5.0",
-    "alex": "^8.2.0",
-    "eslint": "^8.3.0",
-    "execa": "^5.1.1",
-    "fs-extra": "^10.0.0",
-    "get-port": "^5.1.1",
-    "globby": "^11.0.4",
-    "husky": "^4.3.8",
-    "jest": "^27.4.3",
-    "lerna": "^4.0.0",
-    "lerna-changelog": "^2.2.0",
-    "lint-staged": "^12.1.2",
-    "meow": "^9.0.0",
-    "multimatch": "^5.0.0",
-    "prettier": "^2.5.0",
-    "puppeteer": "^12.0.1",
-    "strip-ansi": "^6.0.1",
-    "svg-term-cli": "^2.1.1",
-    "tempy": "^1.0.1",
-    "wait-for-localhost": "^3.3.0",
-    "web-vitals": "^2.1.2"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "*.{js,json,yml,yaml,css,scss,ts,tsx,md}": [
-      "prettier --write"
-    ]
+    "cross-env": "^7.0.3",
+    "jest": "^27.4.3"
   }
 }

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,0 +1,11 @@
+#! /bin/sh
+echo 'backup of package.json is being kept  incase required as before running npm audir fix --force ( or yarn audit fix --force) as these commands may change package.json '  
+node -e "require('fs').copyFileSync('package.json','package.json.bak')"
+if [ $? -eq 0 ]; then 
+  echo " backup of package.json done to package,json.bak "
+else
+  echo "backup of package.json failed " >&2 
+  exit 1
+fi
+  
+    


### PR DESCRIPTION
postinstall command is added in package.json to excute scripts/postinstall.sh  , it executes shell script called postinstall.sh to do backup as original package.json as npm audit fix --force updates the user written package.json and there is no backup of package.json currently done , Thus original package.json gets lost , unless the Project is git maintained , and npm audit fix --force can be reversed by developer , and user may want to restore his original package.json . 
this creates a backup of original package.json  at the time of "npm install" itself , this is tested with same modification to create-react-app new sample project, however react team can review the need to echo and take backup of package.json file postinstall.sh needs to be put in scripts folder in the project

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
