### PR TITLE
fix: upgrade workbox-webpack-plugin from v6 to v7

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -74,7 +74,7 @@
     "webpack": "^5.64.4",
     "webpack-dev-server": "^4.6.0",
     "webpack-manifest-plugin": "^4.0.2",
-    "workbox-webpack-plugin": "^6.4.1"
+    "workbox-webpack-plugin": "^7.4.0"
   },
   "devDependencies": {
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
Upgrades workbox-webpack-plugin from v6.4.1 to v7.4.0 to resolve deprecation warnings.

## Motivation
- Resolves deprecation warning for `rollup-plugin-terser` (v7 uses @rollup/plugin-terser)
- Resolves deprecation warnings for `workbox-cacheable-response` and `workbox-background-sync`
- `workbox-google-analytics` updated to v7 (still present but maintained version)

## Changes
- Updated workbox-webpack-plugin from ^6.4.1 to ^7.4.0 in react-scripts package.json

## Testing
- ✅ Build succeeds
- ✅ Service worker generation works
- ✅ No breaking changes in API usage

## Resolves
- Addresses rollup-plugin-terser deprecation (#7)
- Addresses workbox package deprecations (#20)