### PR TITLE
chore(deps): 16 dependencies identified as outdated. 8 safe minor/patch upgrades sugg

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,29 +23,29 @@
     "format": "npm run prettier -- --write"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.15.1",
-    "@testing-library/react": "^12.1.2",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^13.5.0",
     "alex": "^8.2.0",
-    "eslint": "^8.3.0",
+    "eslint": "^8.57.0",
     "execa": "^5.1.1",
-    "fs-extra": "^10.0.0",
+    "fs-extra": "^10.1.0",
     "get-port": "^5.1.1",
-    "globby": "^11.0.4",
+    "globby": "^11.1.0",
     "husky": "^4.3.8",
-    "jest": "^27.4.3",
+    "jest": "^27.5.0",
     "lerna": "^4.0.0",
     "lerna-changelog": "^2.2.0",
     "lint-staged": "^12.1.2",
     "meow": "^9.0.0",
     "multimatch": "^5.0.0",
-    "prettier": "^2.5.0",
+    "prettier": "^2.8.8",
     "puppeteer": "^12.0.1",
     "strip-ansi": "^6.0.1",
     "svg-term-cli": "^2.1.1",
     "tempy": "^1.0.1",
     "wait-for-localhost": "^3.3.0",
-    "web-vitals": "^2.1.2"
+    "web-vitals": "^2.1.4"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## 🔧 依赖维护更新 — facebook/create-react-app

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

16 dependencies identified as outdated. 8 safe minor/patch upgrades suggested: jest→27.5.0, eslint→8.57.0, prettier→2.8.8, testing-library/react→12.1.5, testing-library/jest-dom→5.17.0, globby→11.1.0, web-vitals→2.1.4, fs-extra→10.1.0. Remaining 8 have major version gaps with breaking changes and should be upgraded separately with testing.

### 📦 变更清单

🔴 **jest**: `^27.4.3` → `^27.5.0`
  _27.4.3 is a 2019 release, latest 27.x is 27.5.1 with bug fixes. Major bump to 29.x is available but carries breaking changes._

🔴 **eslint**: `^8.3.0` → `^8.57.0`
  _8.3.0 is from early 2022, latest 8.x is 8.57.0 with many bug fixes and eslint-plugin fixes. Safe minor upgrade within major version._

🔴 **prettier**: `^2.5.0` → `^2.8.8`
  _2.5.0 is from 2022, latest 2.x is 2.8.8 with bug fixes. Major upgrade to 3.x is available but has breaking changes (API, plugin system)._

🟢 **lerna**: `^4.0.0` → `^4.0.0`
  _Lerna 4.x is end-of-life. 5.x and 6.x are available but major breaking changes (Nx integration, etc.). Skip for safety._

🟢 **execa**: `^5.1.1` → `^5.1.1`
  _5.x is a 2021 release. Latest is 9.x with breaking API changes. Not safe to upgrade blindly._

🟢 **husky**: `^4.3.8` → `^4.3.8`
  _4.x uses old hook format. v7+ has breaking config changes (different .husky directory structure). Major migration effort._

🔴 **@testing-library/react**: `^12.1.2` → `^12.1.5`
  _12.1.2 is from 2021, latest 12.x is 12.1.5. Major upgrade to 14.x available but requires React 18 and has breaking changes._

🔴 **@testing-library/jest-dom**: `^5.15.1` → `^5.17.0`
  _5.15.1 from 2021, latest 5.x is 5.17.0. Major 6.x available but has some breaking changes._

🟢 **@testing-library/user-event**: `^13.5.0` → `^13.5.0`
  _13.5.0 is from 2021. Latest 14.x has breaking changes to async APIs. Not safe to blindly upgrade._

🟢 **puppeteer**: `^12.0.1` → `^12.0.1`
  _v12 is from 2020, latest is 23.x. Major version bumps require Node.js version updates and API changes. Skipping._

🟡 **fs-extra**: `^10.0.0` → `^10.1.0`
  _10.0.0 from 2021, latest 10.x is 10.1.0. Major 11.x available but drops Node 12 support and has some breaking changes._

🔴 **globby**: `^11.0.4` → `^11.1.0`
  _11.0.4 from 2021, latest 11.x is 11.1.0 with minor fixes. Major 13.x+ available but has breaking changes._

🔴 **web-vitals**: `^2.1.2` → `^2.1.4`
  _2.1.2 from 2021, latest 2.x is 2.1.4. Major 4.x available but has significant API changes._

🟢 **tempy**: `^1.0.1` → `^1.0.1`
  _1.0.1 from 2021, latest 3.x has breaking API changes. Skipping._

🟢 **lerna-changelog**: `^2.2.0` → `^2.2.0`
  _2.2.0 is from 2021, latest is around 6.x with breaking changes. Skipping._

🟢 **meow**: `^9.0.0` → `^9.0.0`
  _9.0.0 from 2021, latest 14.x has breaking changes to ESM and API. Skipping._

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_